### PR TITLE
Observability foundation: JSONL watcher + SQLite cache (step 1 of #2)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -48,7 +48,8 @@ It is a local-only operator console — not a remote orchestrator, not a multi-u
 | Terminal | `@xterm/xterm` + `@xterm/addon-fit` | The de facto web terminal. Handles ANSI, resize, scrollback, paste, copy-on-select. |
 | Docker client | `dockerode` | Promise-based wrapper over the Docker Engine API with first-class streaming `exec` attach (needed for live PTY). Avoids shelling out to the `docker` CLI. |
 | Credentials | `keytar` | OS keychain integration (Keychain on macOS, Credential Vault on Windows, libsecret on Linux). API keys never hit disk in plaintext. |
-| Local DB | `better-sqlite3` | Synchronous SQLite for the history/cost layer. Single-file, embedded, no daemon. *(Planned — see §11 Open decisions.)* |
+| Local DB | `better-sqlite3` | Synchronous SQLite for the history/cost layer. Single-file, embedded, no daemon. The JSONL→SQLite cache ships in step 1 of #2; cost rollup + UI follow in subsequent steps. |
+| File watcher | `chokidar` | Tails JSONL transcripts as Claude Code appends to them. Battle-tested cross-platform layer above `fs.watch` (atomic-rename handling, polling fallback on WSL). |
 
 The runner image is `claude-fleet/runner:latest`, built from `docker/Dockerfile`. Base: `node:22-bookworm-slim`. Installs `git`, `ca-certificates`, `curl`, `ripgrep`, `jq`, `less`, `tini`, and globally installs `@anthropic-ai/claude-code`. Runs as non-root user `fleet` (UID/GID 1000 by default). Entrypoint is `tini`; default `CMD` is `sleep infinity` so the container stays alive and is `exec`'d into for each terminal session.
 
@@ -64,8 +65,8 @@ Three processes, per Electron convention:
 │  - clipboard       │   via preload script    │   ├──┬───────┬──┤  │
 │  - native Menu     │                         │   │S │ term  │ O│  │
 │  - broker client   │                         │   ├──┴───────┴──┤  │
-│  - better-sqlite3* │                         │   └─ bottom bar ┘  │
-│  - JSONL watcher*  │                         └────────────────────┘
+│  - better-sqlite3  │                         │   └─ bottom bar ┘  │
+│  - JSONL watcher   │                         └────────────────────┘
 └─────────┬──────────┘
           │
           │  Docker socket + Unix sockets to each container's broker
@@ -91,7 +92,6 @@ binds (per container):
   state/<name>/broker      → /run/broker   (broker socket directory)
 ```
 
-\* planned, see §11.
 
 The **broker** is a small Go daemon (//broker) shipped inside the runner image. It owns every claude PTY in the container and exposes them via a Unix-socket protocol. The host's Electron main process attaches via the bind-mounted socket directory rather than running `docker exec claude` directly. This is the foundation of "expert workspaces" (issue #18): PTYs outlive any individual host disconnect (app quit, app crash), so when the user pauses + closes the app + reopens + unpauses, every session reattaches to the same live `claude` process with its in-memory context (analyses, file watches, MCP server state) intact.
 
@@ -99,7 +99,7 @@ The **broker** is a small Go daemon (//broker) shipped inside the runner image. 
 - Docker daemon access via `dockerode` (default socket).
 - OS keychain access via `keytar`.
 - PTY session lifecycle: holds the duplex stream handle for each active `docker exec`, forwards data to the renderer over per-session IPC channels, forwards renderer input back to the stream, forwards resize events to Docker.
-- (Planned) JSONL transcript watching + SQLite persistence.
+- JSONL transcript watching (`chokidar`) + SQLite persistence (`better-sqlite3`). The watcher tails every workspace's `<state>/<name>/.claude/projects/-workspace/*.jsonl` non-recursively and ingests new lines into the SQLite cache (see §7 *JSONL→SQLite cache*). Cost rollup, observability UI, and slot consumers (chip/tab/context-bar) land in later steps of #2.
 
 **Preload** is a tightly scoped bridge. It uses `contextBridge.exposeInMainWorld('api', …)` to expose a typed `window.api` to the renderer. Window options: `contextIsolation: true`, `nodeIntegration: false`, `sandbox: false` (sandbox is off because the preload needs `ipcRenderer`).
 
@@ -157,6 +157,10 @@ Per-session events from main to renderer:
 - `pty:error:${sessionId}` — stream error (stringified).
 
 The renderer's `window.api.pty.onData/onEnd` register listeners and return unsubscribe functions.
+
+### Observability
+The watcher's catch-up query for the renderer (live push lands with the observability UI):
+- `observability:eventsForSession(sessionId, sinceEventId?, limit?)` → `EventRow[]` — rows from the `events` table for the given session, ordered by `id` ascending, restricted to `id > sinceEventId`. Caller polls with the highest `id` it has seen to get incremental updates. Returns up to `limit` rows (default 500).
 
 ### Clipboard + context menu
 The renderer cannot use `navigator.clipboard` reliably (focus/permission gotchas in Electron, and the renderer is contextIsolated). All clipboard access goes through main:
@@ -258,6 +262,62 @@ Today the only workspace backend is a Docker container. Each managed container c
 - `User: <hostUid>:<hostGid>` so bind-mounted files are owned by the host user.
 - Optional resource limits: `cpus` (→ `NanoCpus`), `memoryMb` (→ `Memory`).
 - `AutoRemove: false` — containers persist across restarts unless explicitly removed.
+
+### JSONL→SQLite cache
+Each workspace's Claude transcripts (`<userData>/state/<name>/.claude/projects/-workspace/<session-uuid>.jsonl`) are tailed by a single SQLite cache at `<userData>/state.db` (WAL mode). JSONL stays authoritative — the DB can be dropped at any time and the watcher rebuilds it from the JSONLs on next start.
+
+**Schema (v1):**
+
+```sql
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  workspace_name TEXT NOT NULL,
+  ts INTEGER,                          -- ms since epoch; null for light events
+  type TEXT NOT NULL,                  -- assistant / user / system / etc.
+  subtype TEXT,                        -- system subtype (turn_duration, compact_boundary, …)
+  uuid TEXT,                           -- event UUID (heavy events only)
+  parent_uuid TEXT,
+  -- fast-access extracts (NULL when n/a):
+  model TEXT,                          -- assistant.message.model
+  input_tokens INTEGER,
+  output_tokens INTEGER,
+  cache_read_input_tokens INTEGER,
+  cache_creation_input_tokens INTEGER,
+  service_tier TEXT,
+  tool_name TEXT,                      -- first tool_use.name in the event's content[]
+  raw_jsonl TEXT NOT NULL,             -- original line, preserves fidelity
+  dedup_key TEXT NOT NULL,             -- uuid when present, else sha256(raw_jsonl)
+  UNIQUE(session_id, dedup_key)
+);
+CREATE INDEX idx_events_session_ts ON events(session_id, ts);
+CREATE INDEX idx_events_workspace ON events(workspace_name);
+CREATE INDEX idx_events_type ON events(type);
+
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,                 -- session UUID (= JSONL filename stem)
+  workspace_name TEXT NOT NULL,
+  cwd TEXT,                            -- from first `system` event carrying it
+  started_at INTEGER,                  -- first event ts
+  last_active_at INTEGER,              -- max(event ts)
+  ai_title TEXT,                       -- latest `ai-title.aiTitle`
+  first_user_message TEXT,             -- last-prompt or first user.content
+  user_set_name TEXT                   -- manual override (for the sessions table; see §11)
+);
+CREATE INDEX idx_sessions_workspace ON sessions(workspace_name);
+```
+
+**Why these design choices:**
+- **Unique `(session_id, dedup_key)`** makes ingestion idempotent. Re-tailing a JSONL from byte 0 (after crash, after losing in-memory offsets) produces no duplicates: heavy events use their `uuid` as the key; light events without a `uuid` use a SHA-256 hash of the raw line. Insert uses `INSERT OR IGNORE`.
+- **`raw_jsonl` stored verbatim** so the DB is rebuildable and so new extract columns can be backfilled from existing rows without re-tailing.
+- **Subagent JSONLs** (`<session-id>/subagents/agent-*.jsonl`) are deliberately *not* ingested today — the watcher uses `depth: 0` to skip them. Surface them later if needed.
+
+**Watcher behavior:**
+- One `JsonlWatcher` instance per main process. Started on `app.whenReady` (after `listWorkspaceManifests`), stopped on `before-quit`.
+- Each workspace is registered with `registerWorkspace(name)`, which adds `<state>/<name>/.claude/projects/-workspace` to the watch set (chokidar tolerates missing paths and picks them up when claude creates them).
+- Per-file byte offsets are kept in memory only. On add/change: read from offset to EOF, find the last `\n`, ingest complete lines, advance offset past the newline. Trailing partial line waits for the next event.
+- Compaction (file shrinks below the stored offset) resets the offset to 0; `dedup_key` ensures already-ingested rows aren't duplicated.
+- Mock mode (`CLAUDE_FLEET_MOCK=1`) skips watcher + DB entirely — no real JSONLs to read.
 
 ### Vault layout
 `keytar` stores per-profile credentials under:
@@ -417,11 +477,15 @@ Each container gets its own host-side state dir, bind-mounted into the container
 - **Settings reset.** `.claude/` will eventually also hold `settings.json`, custom commands, file checkpoints, tasks state. All of it survives container recreate by default. If we later want a "reset settings without losing project history" affordance, decide what's keepable vs. wipeable.
 
 ### Observability layer: cost, tokens, tool calls
-Per-session cost and token counts derived from Claude transcript JSONL events. Outstanding:
-- **Watcher.** Main process watches each container's bind-mounted `.claude/projects/` (see above), tails new events into SQLite as they arrive.
-- **Schema.** `events(session_id, ts, type, payload_json)` and `cost(session_id, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, usd)`. Cost is rolled up from per-event token usage; pricing table refreshed periodically.
-- **IPC surface.** `observability:getCost(sessionId)`, `observability:streamEvents(sessionId)` for live tailing.
-- **UI surface.** Probably a status row inside the sessions table plus a per-session detail pane. To be sketched.
+Per-session cost and token counts derived from Claude transcript JSONL events. **Status: foundation shipped (step 1 of #2); cost rollup, UI, and slot consumers are outstanding.**
+
+**Shipped (foundation):** the JSONL→SQLite cache + watcher described in §7 *JSONL→SQLite cache*, the `observability:eventsForSession` catch-up IPC in §6, and the `chokidar`+`better-sqlite3` runtime pieces in §4. The watcher tails every workspace's transcripts, ingests new lines idempotently into the `events` table, and updates the `sessions` table with derived metadata (`cwd`, `ai_title`, `first_user_message`, `started_at`, `last_active_at`).
+
+**Outstanding:**
+- **Cost rollup.** Derive a `cost` view (or materialized table) from the existing `events` rows: per session, sum input / output / cache-read / cache-creation tokens, multiply by a pricing table (hardcoded constants per `service_tier` × `model`, refreshed manually). New IPCs: `observability:getCost(sessionId)`, `observability:getCostForWorkspace(workspaceName)`. See #32.
+- **Live event push.** Today the renderer polls `observability:eventsForSession` for catch-up. A live `observability:event:${sessionId}` push (sent from the watcher's ingest path) replaces polling for streaming UIs. Land alongside the ObservabilityPane in #33.
+- **UI surface.** ObservabilityPane v1: cost + token totals + per-tool counts + session metadata for the active session (#33). Slot consumers — chip secondary line (#20), tab status (#24), context-bar fill (#25) — wire to live data once available (#34).
+- **Subagent JSONLs.** Today `depth: 0` skips them. Decide whether to surface them in the events stream as a separate `parent_session_id` field, or treat them as opaque tool runs.
 
 ### Sessions table
 Global, container-filterable table of past Claude Code sessions, each resumable via `claude --resume <session-id>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@xterm/addon-unicode11": "^0.8.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
+        "better-sqlite3": "^12.10.0",
+        "chokidar": "^5.0.0",
         "dockerode": "^4.0.2",
         "keytar": "^7.9.0",
         "react": "^18.3.1",
@@ -20,6 +22,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/dockerode": "^3.3.29",
         "@types/node": "^20.14.0",
         "@types/react": "^18.3.3",
@@ -1876,6 +1879,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -2504,6 +2517,29 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2814,6 +2850,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -3897,6 +3948,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -5470,6 +5527,19 @@
       "peer": true,
       "dependencies": {
         "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@xterm/addon-unicode11": "^0.8.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "better-sqlite3": "^12.10.0",
+    "chokidar": "^5.0.0",
     "dockerode": "^4.0.2",
     "keytar": "^7.9.0",
     "react": "^18.3.1",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/dockerode": "^3.3.29",
     "@types/node": "^20.14.0",
     "@types/react": "^18.3.3",

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -1,0 +1,366 @@
+// SQLite cache for JSONL transcript events.
+//
+// JSONL is the source of truth; this DB is rebuildable from the JSONLs at any
+// time. `events` mirrors raw lines with fast-access extract columns;
+// `sessions` carries derived per-session metadata. The watcher ingests every
+// JSONL line through `ingestEvent`; duplicate ingestions (re-tail after
+// restart) are silently dropped via the UNIQUE(session_id, dedup_key)
+// constraint — `dedup_key` is the event's uuid when present, otherwise a
+// hash of the raw line so light events without uuids also dedupe cleanly.
+
+import { createHash } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import Database from 'better-sqlite3';
+
+let db: Database.Database | null = null;
+
+export function openDb(userDataDir: string): Database.Database {
+  if (db) return db;
+  const path = join(userDataDir, 'state.db');
+  mkdirSync(dirname(path), { recursive: true });
+  db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  migrate(db);
+  return db;
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function migrate(d: Database.Database): void {
+  const current = (d.pragma('user_version', { simple: true }) as number) ?? 0;
+  if (current < 1) {
+    d.exec(`
+      CREATE TABLE events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        workspace_name TEXT NOT NULL,
+        ts INTEGER,
+        type TEXT NOT NULL,
+        subtype TEXT,
+        uuid TEXT,
+        parent_uuid TEXT,
+        model TEXT,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        cache_read_input_tokens INTEGER,
+        cache_creation_input_tokens INTEGER,
+        service_tier TEXT,
+        tool_name TEXT,
+        raw_jsonl TEXT NOT NULL,
+        dedup_key TEXT NOT NULL,
+        UNIQUE(session_id, dedup_key)
+      );
+      CREATE INDEX idx_events_session_ts ON events(session_id, ts);
+      CREATE INDEX idx_events_workspace ON events(workspace_name);
+      CREATE INDEX idx_events_type ON events(type);
+
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        workspace_name TEXT NOT NULL,
+        cwd TEXT,
+        started_at INTEGER,
+        last_active_at INTEGER,
+        ai_title TEXT,
+        first_user_message TEXT,
+        user_set_name TEXT
+      );
+      CREATE INDEX idx_sessions_workspace ON sessions(workspace_name);
+    `);
+    d.pragma('user_version = 1');
+  }
+}
+
+// ── Ingest ────────────────────────────────────────────────────────────────
+
+export interface IngestResult {
+  inserted: boolean;       // false when the event was a duplicate
+  sessionId: string;
+  type: string;
+}
+
+const insertEvent = (d: Database.Database) =>
+  d.prepare(`
+    INSERT OR IGNORE INTO events (
+      session_id, workspace_name, ts, type, subtype, uuid, parent_uuid,
+      model, input_tokens, output_tokens,
+      cache_read_input_tokens, cache_creation_input_tokens,
+      service_tier, tool_name, raw_jsonl, dedup_key
+    ) VALUES (
+      @session_id, @workspace_name, @ts, @type, @subtype, @uuid, @parent_uuid,
+      @model, @input_tokens, @output_tokens,
+      @cache_read_input_tokens, @cache_creation_input_tokens,
+      @service_tier, @tool_name, @raw_jsonl, @dedup_key
+    )
+  `);
+
+const upsertSession = (d: Database.Database) =>
+  d.prepare(`
+    INSERT INTO sessions (id, workspace_name, started_at, last_active_at)
+    VALUES (@id, @workspace_name, @ts, @ts)
+    ON CONFLICT(id) DO UPDATE SET
+      last_active_at = MAX(COALESCE(last_active_at, 0), excluded.last_active_at),
+      started_at = COALESCE(started_at, excluded.started_at)
+  `);
+
+const updateSessionCwd = (d: Database.Database) =>
+  d.prepare(`UPDATE sessions SET cwd = ? WHERE id = ? AND cwd IS NULL`);
+const updateSessionAiTitle = (d: Database.Database) =>
+  d.prepare(`UPDATE sessions SET ai_title = ? WHERE id = ?`);
+const updateSessionLastPrompt = (d: Database.Database) =>
+  d.prepare(`UPDATE sessions SET first_user_message = COALESCE(first_user_message, ?) WHERE id = ?`);
+
+interface Cache {
+  insertEvent: ReturnType<typeof insertEvent>;
+  upsertSession: ReturnType<typeof upsertSession>;
+  updateSessionCwd: ReturnType<typeof updateSessionCwd>;
+  updateSessionAiTitle: ReturnType<typeof updateSessionAiTitle>;
+  updateSessionLastPrompt: ReturnType<typeof updateSessionLastPrompt>;
+}
+let stmts: Cache | null = null;
+function getStmts(d: Database.Database): Cache {
+  if (!stmts) {
+    stmts = {
+      insertEvent: insertEvent(d),
+      upsertSession: upsertSession(d),
+      updateSessionCwd: updateSessionCwd(d),
+      updateSessionAiTitle: updateSessionAiTitle(d),
+      updateSessionLastPrompt: updateSessionLastPrompt(d),
+    };
+  }
+  return stmts;
+}
+
+/**
+ * Ingest a single JSONL line. Caller passes `workspaceName` and `sessionId`
+ * (both derived from the file path on disk — JSONL light events sometimes
+ * omit sessionId, so the path is authoritative). The line is parsed,
+ * extracts pulled out for fast access, the raw line stored verbatim, and the
+ * sessions table updated with any derived metadata.
+ *
+ * Returns whether the row was inserted (false = duplicate, already present).
+ */
+export function ingestLine(
+  workspaceName: string,
+  sessionId: string,
+  rawLine: string,
+): IngestResult {
+  const d = openDbOrThrow();
+  const s = getStmts(d);
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(rawLine) as Record<string, unknown>;
+  } catch {
+    // Malformed line — skip silently. JSONL writers occasionally produce
+    // partial lines mid-write; the watcher will re-read on the next change.
+    return { inserted: false, sessionId, type: 'malformed' };
+  }
+
+  const type = String(parsed.type ?? 'unknown');
+  const subtype = typeof parsed.subtype === 'string' ? parsed.subtype : null;
+  const uuid = typeof parsed.uuid === 'string' ? parsed.uuid : null;
+  const parentUuid = typeof parsed.parentUuid === 'string' ? parsed.parentUuid : null;
+  const ts = parseTimestamp(parsed.timestamp);
+  const dedupKey = uuid ?? hashLine(rawLine);
+
+  // Token usage + model (assistant events only).
+  const message = (parsed.message ?? null) as Record<string, unknown> | null;
+  const usage = (message?.usage ?? null) as Record<string, unknown> | null;
+  const model = typeof message?.model === 'string' ? message.model : null;
+  const inputTokens = numOrNull(usage?.input_tokens);
+  const outputTokens = numOrNull(usage?.output_tokens);
+  const cacheReadInputTokens = numOrNull(usage?.cache_read_input_tokens);
+  const cacheCreationInputTokens = numOrNull(usage?.cache_creation_input_tokens);
+  const serviceTier = typeof usage?.service_tier === 'string' ? usage.service_tier : null;
+
+  // First tool name in the event's content[] (assistant or user/tool_result events).
+  const toolName = extractFirstToolName(message);
+
+  const info = s.insertEvent.run({
+    session_id: sessionId,
+    workspace_name: workspaceName,
+    ts,
+    type,
+    subtype,
+    uuid,
+    parent_uuid: parentUuid,
+    model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_read_input_tokens: cacheReadInputTokens,
+    cache_creation_input_tokens: cacheCreationInputTokens,
+    service_tier: serviceTier,
+    tool_name: toolName,
+    raw_jsonl: rawLine,
+    dedup_key: dedupKey,
+  });
+
+  // Touch the sessions row for every event with a known ts so last_active_at
+  // tracks reality; events without ts (light events) get the upsert too but
+  // contribute NULL.
+  s.upsertSession.run({ id: sessionId, workspace_name: workspaceName, ts });
+
+  // Derive per-event metadata into the sessions row.
+  if (type === 'system' && typeof parsed.cwd === 'string') {
+    s.updateSessionCwd.run(parsed.cwd, sessionId);
+  } else if (type === 'ai-title' && typeof parsed.aiTitle === 'string') {
+    s.updateSessionAiTitle.run(parsed.aiTitle, sessionId);
+  } else if (type === 'last-prompt' && typeof parsed.lastPrompt === 'string') {
+    s.updateSessionLastPrompt.run(parsed.lastPrompt, sessionId);
+  } else if (type === 'user' && typeof message?.content === 'string') {
+    s.updateSessionLastPrompt.run(message.content, sessionId);
+  }
+
+  return { inserted: info.changes > 0, sessionId, type };
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────
+
+export interface EventRow {
+  id: number;
+  sessionId: string;
+  workspaceName: string;
+  ts: number | null;
+  type: string;
+  subtype: string | null;
+  uuid: string | null;
+  parentUuid: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadInputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  serviceTier: string | null;
+  toolName: string | null;
+  rawJsonl: string;
+}
+
+interface EventRowSql {
+  id: number;
+  session_id: string;
+  workspace_name: string;
+  ts: number | null;
+  type: string;
+  subtype: string | null;
+  uuid: string | null;
+  parent_uuid: string | null;
+  model: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  service_tier: string | null;
+  tool_name: string | null;
+  raw_jsonl: string;
+}
+
+function rowFromSql(r: EventRowSql): EventRow {
+  return {
+    id: r.id,
+    sessionId: r.session_id,
+    workspaceName: r.workspace_name,
+    ts: r.ts,
+    type: r.type,
+    subtype: r.subtype,
+    uuid: r.uuid,
+    parentUuid: r.parent_uuid,
+    model: r.model,
+    inputTokens: r.input_tokens,
+    outputTokens: r.output_tokens,
+    cacheReadInputTokens: r.cache_read_input_tokens,
+    cacheCreationInputTokens: r.cache_creation_input_tokens,
+    serviceTier: r.service_tier,
+    toolName: r.tool_name,
+    rawJsonl: r.raw_jsonl,
+  };
+}
+
+export function eventsForSession(sessionId: string, sinceEventId = 0, limit = 500): EventRow[] {
+  const d = openDbOrThrow();
+  const rows = d
+    .prepare(`
+      SELECT * FROM events
+      WHERE session_id = ? AND id > ?
+      ORDER BY id ASC
+      LIMIT ?
+    `)
+    .all(sessionId, sinceEventId, limit) as EventRowSql[];
+  return rows.map(rowFromSql);
+}
+
+export interface SessionRow {
+  id: string;
+  workspaceName: string;
+  cwd: string | null;
+  startedAt: number | null;
+  lastActiveAt: number | null;
+  aiTitle: string | null;
+  firstUserMessage: string | null;
+  userSetName: string | null;
+}
+
+interface SessionRowSql {
+  id: string;
+  workspace_name: string;
+  cwd: string | null;
+  started_at: number | null;
+  last_active_at: number | null;
+  ai_title: string | null;
+  first_user_message: string | null;
+  user_set_name: string | null;
+}
+
+export function getSession(id: string): SessionRow | null {
+  const d = openDbOrThrow();
+  const row = d.prepare(`SELECT * FROM sessions WHERE id = ?`).get(id) as SessionRowSql | undefined;
+  if (!row) return null;
+  return {
+    id: row.id,
+    workspaceName: row.workspace_name,
+    cwd: row.cwd,
+    startedAt: row.started_at,
+    lastActiveAt: row.last_active_at,
+    aiTitle: row.ai_title,
+    firstUserMessage: row.first_user_message,
+    userSetName: row.user_set_name,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function openDbOrThrow(): Database.Database {
+  if (!db) throw new Error('db not opened — call openDb(userDataDir) first');
+  return db;
+}
+
+function parseTimestamp(v: unknown): number | null {
+  if (typeof v !== 'string') return null;
+  const ms = Date.parse(v);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function numOrNull(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function hashLine(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+function extractFirstToolName(message: Record<string, unknown> | null): string | null {
+  if (!message) return null;
+  const content = message.content;
+  if (!Array.isArray(content)) return null;
+  for (const block of content as Array<Record<string, unknown>>) {
+    if (block && block.type === 'tool_use' && typeof block.name === 'string') {
+      return block.name;
+    }
+  }
+  return null;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,14 @@
 import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'node:path';
 import { registerIpc } from './ipc.js';
+import { openDb, closeDb } from './db.js';
+import { JsonlWatcher } from './jsonlWatcher.js';
+import { listWorkspaceManifests } from './workspaces.js';
+
+// Mock mode is for UI iteration without Docker; no real JSONLs exist, so the
+// watcher and DB stay dormant.
+const isMock = process.env.CLAUDE_FLEET_MOCK === '1';
+const jsonlWatcher = isMock ? null : new JsonlWatcher();
 
 const isDev = process.env.NODE_ENV === 'development' || !!process.env.ELECTRON_RENDERER_URL;
 
@@ -34,13 +42,23 @@ function createWindow(): BrowserWindow {
   return win;
 }
 
-app.whenReady().then(() => {
-  registerIpc();
+app.whenReady().then(async () => {
+  if (jsonlWatcher) {
+    openDb(app.getPath('userData'));
+    const manifests = await listWorkspaceManifests();
+    await jsonlWatcher.start(manifests.map((m) => m.name));
+  }
+  registerIpc({ jsonlWatcher });
   createWindow();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+});
+
+app.on('before-quit', async () => {
+  await jsonlWatcher?.stop();
+  closeDb();
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -15,11 +15,17 @@ import {
   type WorkspaceSpec
 } from './workspaces.js';
 import type { PtyHandle, RemoveWorkspaceOpts, CreateWorkspaceInput } from './docker.js';
+import type { JsonlWatcher } from './jsonlWatcher.js';
+import { eventsForSession } from './db.js';
 
 export const MOCK_MODE = process.env.CLAUDE_FLEET_MOCK === '1';
 const backend = MOCK_MODE ? mockDocker : realDocker;
 
 const ptySessions = new Map<string, PtyHandle>();
+
+interface RegisterIpcOpts {
+  jsonlWatcher: JsonlWatcher | null;
+}
 
 /**
  * Merge the live-workspace list (from the backend) with on-disk manifests
@@ -56,7 +62,8 @@ async function listAllWorkspaces(): Promise<Workspace[]> {
   return result;
 }
 
-export function registerIpc(): void {
+export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): void {
+  const { jsonlWatcher } = opts;
   ipcMain.handle('workspace:ping', () => backend.ping());
   ipcMain.handle('workspace:ensureImage', async (event, channelId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
@@ -87,6 +94,7 @@ export function registerIpc(): void {
         lastUsedAt: ws.lastUsedAt
       };
       await writeWorkspaceManifest(spec);
+      jsonlWatcher?.registerWorkspace(ws.name);
 
       // Auto-record the image into the library so the next create's
       // picker shows it (and any labels it was built with). Best-effort:
@@ -233,4 +241,14 @@ export function registerIpc(): void {
     ptySessions.get(sessionId)?.detach();
     ptySessions.delete(sessionId);
   });
+
+  // Observability — minimal step-1 surface. Renderer polls
+  // eventsForSession with the latest id it has; the DB returns rows
+  // ingested since. Live push + cost rollup + per-workspace queries
+  // ship with steps 2-3 of #2.
+  ipcMain.handle(
+    'observability:eventsForSession',
+    (_e, sessionId: string, sinceEventId = 0, limit = 500) =>
+      eventsForSession(sessionId, sinceEventId, limit)
+  );
 }

--- a/src/main/jsonlWatcher.ts
+++ b/src/main/jsonlWatcher.ts
@@ -1,0 +1,183 @@
+// Tails Claude transcript JSONLs and ingests new lines into the SQLite cache.
+//
+// Each workspace's claude binary writes its transcript to:
+//   <userData>/state/<name>/.claude/projects/-workspace/<session-uuid>.jsonl
+//
+// We watch that directory non-recursively (so subagent JSONLs nested under
+// <session-uuid>/subagents/* are deliberately skipped — out of scope for
+// step 1). For every change we read from the file's last-known byte offset
+// to the current EOF, split on newlines, ingest complete lines, and stash
+// the offset of any trailing partial line for the next change event.
+//
+// Re-ingestion is idempotent: db.ingestLine uses uuid (or a content hash for
+// light events) as a dedup key. The byte offset is an in-memory optimization
+// only — if we lose it (process restart, watch dropped), re-reading from
+// offset 0 produces the same end state.
+
+import { promises as fsp, type Stats } from 'node:fs';
+import { join, basename, extname, sep as pathSep } from 'node:path';
+import chokidar, { type FSWatcher } from 'chokidar';
+import { workspaceClaudeDir } from './paths.js';
+import { ingestLine } from './db.js';
+
+const PROJECTS_SUBDIR = join('projects', '-workspace');
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface FileState {
+  workspaceName: string;
+  sessionId: string;
+  offset: number;
+}
+
+export class JsonlWatcher {
+  private watcher: FSWatcher | null = null;
+  private readonly files = new Map<string, FileState>();
+  private readonly watchedDirs = new Set<string>();
+  // Per-file mutex (sequenced via a chained promise) so concurrent
+  // add/change events on the same file don't race the byte offset.
+  private readonly chains = new Map<string, Promise<void>>();
+
+  async start(workspaceNames: string[]): Promise<void> {
+    if (this.watcher) return;
+    this.watcher = chokidar.watch([], {
+      depth: 0,
+      ignoreInitial: false,
+      persistent: true,
+      // No awaitWriteFinish: we tolerate partial-line reads by tracking the
+      // last newline byte and rolling the offset forward only past complete
+      // lines. Lower latency this way.
+    });
+    this.watcher
+      .on('add', (p) => this.enqueue(p))
+      .on('change', (p) => this.enqueue(p))
+      .on('unlink', (p) => {
+        this.files.delete(p);
+        this.chains.delete(p);
+      })
+      .on('error', (err) => console.error('[jsonlWatcher] error:', err));
+    for (const name of workspaceNames) {
+      this.registerWorkspace(name);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.watcher) return;
+    await this.watcher.close();
+    this.watcher = null;
+    this.files.clear();
+    this.chains.clear();
+    this.watchedDirs.clear();
+  }
+
+  registerWorkspace(name: string): void {
+    if (!this.watcher) return;
+    const dir = join(workspaceClaudeDir(name), PROJECTS_SUBDIR);
+    if (this.watchedDirs.has(dir)) return;
+    this.watchedDirs.add(dir);
+    // chokidar tolerates non-existent paths; when the dir is created later
+    // (first time claude runs in the workspace) `add` events fire.
+    this.watcher.add(dir);
+  }
+
+  unregisterWorkspace(name: string): void {
+    if (!this.watcher) return;
+    const dir = join(workspaceClaudeDir(name), PROJECTS_SUBDIR);
+    if (!this.watchedDirs.delete(dir)) return;
+    this.watcher.unwatch(dir);
+    const prefix = dir + pathSep;
+    for (const path of [...this.files.keys()]) {
+      if (path === dir || path.startsWith(prefix)) {
+        this.files.delete(path);
+        this.chains.delete(path);
+      }
+    }
+  }
+
+  private enqueue(path: string): void {
+    if (extname(path) !== '.jsonl') return;
+    const prev = this.chains.get(path) ?? Promise.resolve();
+    const next = prev.then(() => this.process(path)).catch((err) => {
+      console.error(`[jsonlWatcher] process failed for ${path}:`, err);
+    });
+    this.chains.set(path, next);
+  }
+
+  private async process(path: string): Promise<void> {
+    const state = this.files.get(path) ?? this.initState(path);
+    if (!state) return;
+
+    let stats: Stats;
+    try {
+      stats = await fsp.stat(path);
+    } catch {
+      this.files.delete(path);
+      return;
+    }
+    // Compaction: file shrank below our offset — reset and re-ingest.
+    // dedup_key keeps existing rows; only genuinely new lines insert.
+    if (stats.size < state.offset) state.offset = 0;
+    if (stats.size === state.offset) return;
+
+    const newOffset = await readAndIngest(path, state);
+    state.offset = newOffset;
+    this.files.set(path, state);
+  }
+
+  private initState(path: string): FileState | null {
+    const workspaceName = workspaceNameFromPath(path);
+    const sessionId = basename(path, '.jsonl');
+    if (!workspaceName || !UUID_RE.test(sessionId)) return null;
+    const state: FileState = { workspaceName, sessionId, offset: 0 };
+    this.files.set(path, state);
+    return state;
+  }
+}
+
+/**
+ * Read from `state.offset` to EOF, ingest complete lines, return new offset.
+ * Trailing partial line (no terminating `\n`) is left for the next call.
+ */
+async function readAndIngest(path: string, state: FileState): Promise<number> {
+  const fh = await fsp.open(path, 'r');
+  try {
+    const stats = await fh.stat();
+    if (stats.size <= state.offset) return state.offset;
+
+    const bytesToRead = stats.size - state.offset;
+    const buf = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await fh.read(buf, 0, bytesToRead, state.offset);
+
+    // Find the last newline (0x0a). Everything up to and including it is
+    // complete lines; anything after is partial and we revisit next change.
+    let lastNl = -1;
+    for (let i = bytesRead - 1; i >= 0; i--) {
+      if (buf[i] === 0x0a) {
+        lastNl = i;
+        break;
+      }
+    }
+    if (lastNl === -1) return state.offset;
+
+    const text = buf.slice(0, lastNl + 1).toString('utf8');
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      ingestLine(state.workspaceName, state.sessionId, trimmed);
+    }
+
+    return state.offset + lastNl + 1;
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * .../state/<workspace>/.claude/projects/-workspace/<session>.jsonl
+ *                       ^ marker — the segment before .claude is the workspace.
+ */
+function workspaceNameFromPath(filePath: string): string | null {
+  const segments = filePath.split(/[\\/]/);
+  const idx = segments.lastIndexOf('.claude');
+  return idx > 0 ? (segments[idx - 1] ?? null) : null;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,30 @@ export interface SessionInventory {
   activeId?: string;
 }
 
+/**
+ * Row shape from the JSONL → SQLite cache. Mirrors db.EventRow with the
+ * subset the renderer needs. `rawJsonl` holds the original line so the
+ * renderer can pull fields the extract columns don't cover yet.
+ */
+export interface ObservabilityEventRow {
+  id: number;
+  sessionId: string;
+  workspaceName: string;
+  ts: number | null;
+  type: string;
+  subtype: string | null;
+  uuid: string | null;
+  parentUuid: string | null;
+  model: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadInputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  serviceTier: string | null;
+  toolName: string | null;
+  rawJsonl: string;
+}
+
 const api = {
   app: {
     mockMode: (): Promise<boolean> => ipcRenderer.invoke('app:mockMode')
@@ -101,6 +125,20 @@ const api = {
       ipcRenderer.on(channel, handler);
       return () => ipcRenderer.removeListener(channel, handler);
     }
+  },
+  observability: {
+    /**
+     * Pull rows from the JSONL→SQLite cache for one session, in id order,
+     * after `sinceEventId`. Renderer polls this for catch-up; a live-push
+     * channel arrives with the cost-rollup work in step 2 / observability
+     * UI in step 3.
+     */
+    eventsForSession: (
+      sessionId: string,
+      sinceEventId = 0,
+      limit = 500
+    ): Promise<ObservabilityEventRow[]> =>
+      ipcRenderer.invoke('observability:eventsForSession', sessionId, sinceEventId, limit)
   }
 };
 


### PR DESCRIPTION
Closes #31. Step 1 of umbrella #2.

## Summary

Foundation for the observability layer. Tails every workspace's Claude transcripts and ingests new lines into a SQLite cache. No UI yet, no cost calc — those land in #32 / #33 / #34.

## What's in this PR

- **`src/main/db.ts`** (244 LOC) — `better-sqlite3` wrapper. Schema v1 (events + sessions tables). `INSERT OR IGNORE` + `UNIQUE(session_id, dedup_key)` makes ingestion idempotent. `dedup_key` is the event's `uuid` when present, else `sha256(raw_jsonl)` so light events without uuids also dedupe cleanly. Token usage (input/output/cache-read/cache-creation), model id, service tier, and first tool name extracted into indexed columns. `raw_jsonl` stored verbatim so new extract columns can be backfilled without re-tailing.
- **`src/main/jsonlWatcher.ts`** (140 LOC) — `chokidar` v5 with `depth: 0`. Per-file byte offset in memory; reads new bytes, splits on `\n`, ingests complete lines, leaves trailing partial line for the next change event. Compaction detection (file shrank below offset → reset to 0). Per-file mutex via promise-chain to avoid offset races.
- **`src/main/index.ts`** — opens the DB and starts the watcher on `app.whenReady`, stops on `before-quit`. Mock mode (`CLAUDE_FLEET_MOCK=1`) skips both.
- **`src/main/ipc.ts`** — `workspace:create` registers the new workspace with the watcher. `observability:eventsForSession(sessionId, sinceEventId?, limit?)` catch-up query.
- **`src/preload/index.ts`** — exposes `window.api.observability.eventsForSession` + `ObservabilityEventRow` type.
- **`docs/SPEC.md`** — §4 stack table no longer "planned" for `better-sqlite3`; adds `chokidar`. New §7 "JSONL→SQLite cache" subsection documents schema + dedup strategy + watcher behavior + `depth: 0` choice. §11 *Observability layer* split into "Shipped (foundation)" and "Outstanding".

## Out of scope (deferred to other sub-issues)

- Cost rollup + pricing table → **#32**
- ObservabilityPane v1 UI → **#33**
- Wiring chip secondary line / tab status / context bar fill → **#34**
- Live `observability:event:${sessionId}` push channel — renderer polls today; live push ships alongside the UI in #33.
- Subagent JSONLs (`<session-id>/subagents/agent-*.jsonl`) — `depth: 0` skips them; surface decision deferred (noted in spec).

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] Smoke-tested ingest pipeline against two real Claude transcripts:
  - 13-event session: all rows inserted, 0 duplicates on re-ingest.
  - 3565-event session: all rows inserted, 0 duplicates on re-ingest. ~135µs per ingestLine call. Session metadata (cwd, ai_title, first_user_message) accumulated correctly.
- [ ] Launch dev app on real workspaces (`kind-llama`, etc.), confirm `state.db` populates within seconds and grows as `claude` runs.
- [ ] Restart app, confirm no duplicate rows.

## Note on spec-maintenance rule

This PR is on a branch off `origin/main`, so it carries the OLD spec text plus the step-1 updates. PR #19 (the target-state spec rewrite) is in flight on a separate branch. When both merge, the §11 *Observability layer* section will need a touch-up to merge the "Shipped (foundation)" framing from this PR with the target-state framing from #19. Flagging for whoever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)