### PR TITLE
Fix: chokidar ESM crash on startup (+ error logger)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -162,6 +162,11 @@ The renderer's `window.api.pty.onData/onEnd` register listeners and return unsub
 The watcher's catch-up query for the renderer (live push lands with the observability UI):
 - `observability:eventsForSession(sessionId, sinceEventId?, limit?)` → `EventRow[]` — rows from the `events` table for the given session, ordered by `id` ascending, restricted to `id > sinceEventId`. Caller polls with the highest `id` it has seen to get incremental updates. Returns up to `limit` rows (default 500).
 
+### Error log
+Both main and renderer hook the standard "uncaught" channels and forward each crash through a single sink to `<userData>/error.log`. Main installs `process.on('uncaughtException')` + `process.on('unhandledRejection')` directly. The renderer wires `window.addEventListener('error', …)` + `window.addEventListener('unhandledrejection', …)` in `src/renderer/src/main.tsx` *before* mounting React, so a crash during App's initial render still lands. Each row is one JSON object: `{ ts, source: 'main' | 'renderer', type, message, stack?, extra? }`. No rotation; users can delete the file at will.
+- `app:logError({ type, message, stack?, extra? })` → `void` — renderer → main bridge. The renderer never writes the log directly (sandbox / cross-process consistency).
+- `app:errorLogPath()` → `string` — absolute path of the log, exposed for a future "Open error log" affordance.
+
 ### Clipboard + context menu
 The renderer cannot use `navigator.clipboard` reliably (focus/permission gotchas in Electron, and the renderer is contextIsolated). All clipboard access goes through main:
 - `clipboard:write(text)` → `void` — `electron.clipboard.writeText` (no-op on empty).

--- a/src/main/errorLog.ts
+++ b/src/main/errorLog.ts
@@ -1,0 +1,79 @@
+// Global error logger.
+//
+// Captures uncaught exceptions and unhandled rejections from BOTH the main
+// process and the renderer (via an IPC bridge), writing each one to
+// `<userData>/error.log` as a single line of JSON. Users hit a popup they
+// can't copy from? Have them cat the log and paste here.
+//
+// Intentionally a no-frills append-only log. No rotation, no level
+// filtering, no remote sink. The file is small in practice (one line per
+// crash) and the user can delete it whenever.
+
+import { app } from 'electron';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+type Source = 'main' | 'renderer';
+
+interface LogPayload {
+  source: Source;
+  type: string;    // 'uncaughtException', 'unhandledRejection', 'window.onerror', …
+  message: string;
+  stack?: string;
+  extra?: Record<string, unknown>;
+}
+
+let logPath: string | null = null;
+
+function ensureLogPath(): string {
+  if (logPath) return logPath;
+  const p = join(app.getPath('userData'), 'error.log');
+  mkdirSync(dirname(p), { recursive: true });
+  logPath = p;
+  return p;
+}
+
+/** Append one JSON line to the log. Best-effort — never throws. */
+export function logError(payload: LogPayload): void {
+  try {
+    const row = {
+      ts: new Date().toISOString(),
+      ...payload,
+    };
+    appendFileSync(ensureLogPath(), JSON.stringify(row) + '\n', 'utf8');
+  } catch {
+    // If writing the log itself errors, there's nothing useful we can do —
+    // any throw here would cascade into the very error-handling path the
+    // user invoked. Drop it.
+  }
+}
+
+/**
+ * Hook the main-process uncaughtException + unhandledRejection signals so
+ * any crash in main lands in the log. Call once, after `app.whenReady` is
+ * resolved (so `app.getPath('userData')` is valid).
+ */
+export function installMainProcessHandlers(): void {
+  process.on('uncaughtException', (err) => {
+    logError({
+      source: 'main',
+      type: 'uncaughtException',
+      message: err?.message ?? String(err),
+      stack: err?.stack,
+    });
+  });
+  process.on('unhandledRejection', (reason) => {
+    const err = reason instanceof Error ? reason : null;
+    logError({
+      source: 'main',
+      type: 'unhandledRejection',
+      message: err?.message ?? String(reason),
+      stack: err?.stack,
+    });
+  });
+}
+
+/** Path to the log file. Useful for the user to find it. */
+export function getLogPath(): string {
+  return ensureLogPath();
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { registerIpc } from './ipc.js';
 import { openDb, closeDb } from './db.js';
 import { JsonlWatcher } from './jsonlWatcher.js';
 import { listWorkspaceManifests } from './workspaces.js';
+import { installMainProcessHandlers, logError, getLogPath } from './errorLog.js';
 
 // Mock mode is for UI iteration without Docker; no real JSONLs exist, so the
 // watcher and DB stay dormant.
@@ -43,6 +44,13 @@ function createWindow(): BrowserWindow {
 }
 
 app.whenReady().then(async () => {
+  // First thing after whenReady: register error logging. From here on,
+  // any thrown error or rejected promise on main lands in error.log
+  // before potentially propagating into a crash.
+  installMainProcessHandlers();
+  // Surface the log location so users (and Playwright tests) can find it.
+  console.log(`[claude-fleet] error log: ${getLogPath()}`);
+
   if (jsonlWatcher) {
     openDb(app.getPath('userData'));
     const manifests = await listWorkspaceManifests();

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,6 +17,7 @@ import {
 import type { PtyHandle, RemoveWorkspaceOpts, CreateWorkspaceInput } from './docker.js';
 import type { JsonlWatcher } from './jsonlWatcher.js';
 import { eventsForSession } from './db.js';
+import { logError, getLogPath } from './errorLog.js';
 
 export const MOCK_MODE = process.env.CLAUDE_FLEET_MOCK === '1';
 const backend = MOCK_MODE ? mockDocker : realDocker;
@@ -251,4 +252,19 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     (_e, sessionId: string, sinceEventId = 0, limit = 500) =>
       eventsForSession(sessionId, sinceEventId, limit)
   );
+
+  // Renderer-side error reporting bridge. The renderer's onerror /
+  // onunhandledrejection handlers forward into here so all crashes
+  // (main + renderer) land in a single `<userData>/error.log` users
+  // can cat for diagnostic info.
+  ipcMain.handle(
+    'app:logError',
+    (
+      _e,
+      payload: { type: string; message: string; stack?: string; extra?: Record<string, unknown> }
+    ) => {
+      logError({ source: 'renderer', ...payload });
+    }
+  );
+  ipcMain.handle('app:errorLogPath', () => getLogPath());
 }

--- a/src/main/jsonlWatcher.ts
+++ b/src/main/jsonlWatcher.ts
@@ -16,7 +16,10 @@
 
 import { promises as fsp, type Stats } from 'node:fs';
 import { join, basename, extname, sep as pathSep } from 'node:path';
-import chokidar, { type FSWatcher } from 'chokidar';
+// chokidar v5 is ESM-only. Our main bundle is CommonJS (per
+// electron.vite.config.ts), so `require('chokidar')` would throw
+// ERR_REQUIRE_ESM. Load it via dynamic import inside `start()`.
+import type { FSWatcher } from 'chokidar';
 import { workspaceClaudeDir } from './paths.js';
 import { ingestLine } from './db.js';
 
@@ -40,6 +43,7 @@ export class JsonlWatcher {
 
   async start(workspaceNames: string[]): Promise<void> {
     if (this.watcher) return;
+    const chokidar = await import('chokidar');
     this.watcher = chokidar.watch([], {
       depth: 0,
       ignoreInitial: false,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,7 +41,21 @@ export interface ObservabilityEventRow {
 
 const api = {
   app: {
-    mockMode: (): Promise<boolean> => ipcRenderer.invoke('app:mockMode')
+    mockMode: (): Promise<boolean> => ipcRenderer.invoke('app:mockMode'),
+    /**
+     * Forward a renderer-side error into the main process's error.log.
+     * Called automatically by the global onerror/onunhandledrejection
+     * handlers wired in src/renderer/src/main.tsx; callers can also use
+     * it manually around a known-risky operation.
+     */
+    logError: (payload: {
+      type: string;
+      message: string;
+      stack?: string;
+      extra?: Record<string, unknown>;
+    }): Promise<void> => ipcRenderer.invoke('app:logError', payload),
+    /** Absolute path of the error.log file (so we can surface it in the UI later). */
+    errorLogPath: (): Promise<string> => ipcRenderer.invoke('app:errorLogPath')
   },
   workspace: {
     backendReady: (): Promise<boolean> => ipcRenderer.invoke('workspace:ping'),

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,5 +3,37 @@ import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles.css';
 
+// Forward renderer-side crashes into <userData>/error.log via the main
+// process. Wired before React mounts so a crash during App's initial
+// render still lands in the log.
+//
+// We pre-bind to a local reference of window.api so a future
+// monkeypatch can't break the bridge. The handlers swallow their own
+// failures (the log itself is best-effort).
+const api = window.api;
+function forward(payload: { type: string; message: string; stack?: string; extra?: Record<string, unknown> }) {
+  try {
+    api?.app.logError(payload);
+  } catch {
+    // intentional — never let logging itself crash the page.
+  }
+}
+window.addEventListener('error', (e: ErrorEvent) => {
+  forward({
+    type: 'window.onerror',
+    message: e.message ?? String(e.error ?? 'unknown'),
+    stack: e.error instanceof Error ? e.error.stack : undefined,
+    extra: { filename: e.filename, lineno: e.lineno, colno: e.colno }
+  });
+});
+window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent) => {
+  const reason = e.reason;
+  forward({
+    type: 'window.onunhandledrejection',
+    message: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined
+  });
+});
+
 const root = document.getElementById('root');
 if (root) createRoot(root).render(<React.StrictMode><App /></React.StrictMode>);


### PR DESCRIPTION
**Urgent fix.** The merged observability foundation (#35) statically imports `chokidar` v5, which is ESM-only. The main process is bundled as CommonJS, so every Electron launch since the merge crashes in main with:

\`\`\`
Error [ERR_REQUIRE_ESM]: require() of ES Module
.../chokidar/index.js from out/main/index.cjs not supported.
\`\`\`

Electron surfaces this as the uncopyable \"A JavaScript error occurred in the main process\" dialog — the popup the user couldn't copy from. **All 26 Playwright tests timed out at 30s** because Electron never reached the renderer.

## Fix

Dynamic `await import('chokidar')` inside \`JsonlWatcher.start()\`. The bundle stays CJS; chokidar loads as ESM at runtime; no require shim or downgrade needed.

After the fix, the same Playwright run prints \`26 passed (21.6s)\`.

## Bonus: global error logger

While we're here, ship insurance for the next opaque main-process crash:

- **\`src/main/errorLog.ts\`** — append-only JSON-lines log at \`<userData>/error.log\`. Each entry: \`{ ts, source, type, message, stack?, extra? }\`. Best-effort writer that never throws back into the crash handler.
- **\`src/main/index.ts\`** — installs \`process.on('uncaughtException')\` + \`process.on('unhandledRejection')\` first thing after \`app.whenReady\`. Logs the path to stdout: \`[claude-fleet] error log: /home/.../error.log\`.
- **\`src/main/ipc.ts\`** — \`app:logError\` (renderer → main) and \`app:errorLogPath\`.
- **\`src/preload/index.ts\`** — \`window.api.app.logError\` / \`window.api.app.errorLogPath\`.
- **\`src/renderer/src/main.tsx\`** — \`window.addEventListener('error', …)\` + \`'unhandledrejection'\` *before* React mounts so a crash during \`<App>\`'s initial render still lands.
- **\`docs/SPEC.md\`** — new §6 \"Error log\" subsection.

When a future crash hits, the user can \`cat ~/.config/claude-fleet/error.log\` and paste the JSON lines here.

## Test plan

- [x] \`npm run typecheck\` — clean.
- [x] \`npm run build\` — clean.
- [x] Launch electron directly: prints log path, no crash dialog.
- [x] Full Playwright run: **26 passed / 0 failed** (was 0 / 26 before fix).
- [ ] Verify the error log captures a thrown error from renderer (sanity-check the bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)