### PR TITLE
Fix: rebuild native modules for Electron via postinstall

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -49,7 +49,9 @@ It is a local-only operator console — not a remote orchestrator, not a multi-u
 | Docker client | `dockerode` | Promise-based wrapper over the Docker Engine API with first-class streaming `exec` attach (needed for live PTY). Avoids shelling out to the `docker` CLI. |
 | Credentials | `keytar` | OS keychain integration (Keychain on macOS, Credential Vault on Windows, libsecret on Linux). API keys never hit disk in plaintext. |
 | Local DB | `better-sqlite3` | Synchronous SQLite for the history/cost layer. Single-file, embedded, no daemon. The JSONL→SQLite cache ships in step 1 of #2; cost rollup + UI follow in subsequent steps. |
-| File watcher | `chokidar` | Tails JSONL transcripts as Claude Code appends to them. Battle-tested cross-platform layer above `fs.watch` (atomic-rename handling, polling fallback on WSL). |
+| File watcher | `chokidar` | Tails JSONL transcripts as Claude Code appends to them. Battle-tested cross-platform layer above `fs.watch` (atomic-rename handling, polling fallback on WSL). Imported via dynamic `await import('chokidar')` because v5 is ESM-only and the main bundle is CommonJS. |
+
+**Native modules.** `better-sqlite3` and `keytar` ship as N-API native bindings — they must match Electron's bundled Node ABI, not the system Node. The repo's `postinstall` script runs `electron-builder install-app-deps` to pull prebuilt binaries (or rebuild) for the current Electron version. Without this hook, `npm install` builds the bindings against the system Node and Electron fails to load them at runtime with a `NODE_MODULE_VERSION` mismatch.
 
 The runner image is `claude-fleet/runner:latest`, built from `docker/Dockerfile`. Base: `node:22-bookworm-slim`. Installs `git`, `ca-certificates`, `curl`, `ripgrep`, `jq`, `less`, `tini`, and globally installs `@anthropic-ai/claude-code`. Runs as non-root user `fleet` (UID/GID 1000 by default). Entrypoint is `tini`; default `CMD` is `sleep infinity` so the container stays alive and is `exec`'d into for each terminal session.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "claude-fleet",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "electron-builder install-app-deps",
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "start": "electron-vite preview",


### PR DESCRIPTION
**Urgent fix.** Real-mode launch (`npm run dev` without `CLAUDE_FLEET_MOCK=1`) was crashing in main with:

\`\`\`
NODE_MODULE_VERSION 141 (better-sqlite3 built for system Node v25)
                vs 125 (Electron 31 ships Node 20)
\`\`\`

\`better-sqlite3\` and \`keytar\` are N-API native bindings — they need to match Electron's bundled Node ABI, not the system Node. A bare \`npm install\` builds against the system Node, so when main does \`new Database(...)\` Electron fails to dlopen the binding.

Mock mode wasn't hit because \`openDb()\` never runs there. The crash only fires on real-mode startup, which matches the user-reported symptom (\"the app doesn't come up when I run \`npm run dev\`\").

Caught immediately by the error logger from #39 — first JSON line in \`~/.config/claude-fleet/error.log\` had the full stack trace.

## Fix

Adds a \`postinstall\` script to package.json:

\`\`\`json
"postinstall": "electron-builder install-app-deps"
\`\`\`

\`electron-builder\` is already a devDependency, and its \`install-app-deps\` subcommand fetches prebuilt binaries (or rebuilds from source) for the active Electron version. Every subsequent \`npm install\` keeps the bindings aligned.

## Test plan

- [x] Deliberately rebuild better-sqlite3 against system Node (\`cd node_modules/better-sqlite3 && npm rebuild\`).
- [x] Run \`npm install\`; postinstall hook fires and re-fetches the Electron prebuild.
- [x] Run \`./node_modules/.bin/electron .\` (real mode, no mock) — boots cleanly, error log records nothing new.
- [x] Spec §4 stack: documents both the chokidar dynamic-import shape and the native-module postinstall hook.

## Note

If anyone has a stale checkout, one manual run of \`npm install\` after pulling this PR will fix the bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)