### PR TITLE
Recover ObservabilityPane v1 (orphan from PR #36)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -112,7 +112,7 @@ The renderer layout is a 3-row × 3-col shell:
 - **Body row** (3 columns):
   - **Sessions pane** (left, ~280px): placeholder until #3 lands the JSONL-backed sessions table.
   - **Main pane** (center, fluid): header with selected workspace's name/status and `Close…` button, plus the xterm `TerminalPane` (or empty/first-run/disconnected states).
-  - **Observability pane** (right, ~320px): placeholder until #2 lands the cost/token/event watcher.
+  - **Observability pane** (right, ~320px): live view of the most-recently-active Claude session in the selected workspace, polled every 2s. Shows session title (from `ai-title` event or first-user-message head), latest model, last-activity relative time, event count, token totals (input / cache-create / cache-read / output) and top tools by call count. Empty state when the workspace has no transcript events yet. Cost rollup (USD) lands with step 2 of #2. Per-terminal-tab precision is deferred (renderer drives off active workspace, not active tab — the latest-active session is the right answer ≥95% of the time).
 - **Bottom row** (`BottomBar`): static hint bar with key bindings and degraded-vault notice when applicable.
 
 Modals (`CreateWorkspaceModal`, `CloseWorkspaceModal`, `ProfilesDialog`) are owned by `App` and rendered above the shell.
@@ -161,8 +161,8 @@ Per-session events from main to renderer:
 The renderer's `window.api.pty.onData/onEnd` register listeners and return unsubscribe functions.
 
 ### Observability
-The watcher's catch-up query for the renderer (live push lands with the observability UI):
 - `observability:eventsForSession(sessionId, sinceEventId?, limit?)` → `EventRow[]` — rows from the `events` table for the given session, ordered by `id` ascending, restricted to `id > sinceEventId`. Caller polls with the highest `id` it has seen to get incremental updates. Returns up to `limit` rows (default 500).
+- `observability:summaryForWorkspace(workspaceName)` → `WorkspaceSummary | null` — picks the most-recently-active Claude session in the workspace and returns `{ sessionId, title, model, startedAt, lastActiveAt, eventCount, inputTokens, outputTokens, cacheReadInputTokens, cacheCreationInputTokens, topTools[] }`. Returns null when no events have been ingested for the workspace yet. The right-rail observability pane polls this every 2s. Live push (`observability:event:${sessionId}`) is a planned follow-up that lets the pane subscribe instead of polling.
 
 ### Error log
 Both main and renderer hook the standard "uncaught" channels and forward each crash through a single sink to `<userData>/error.log`. Main installs `process.on('uncaughtException')` + `process.on('unhandledRejection')` directly. The renderer wires `window.addEventListener('error', …)` + `window.addEventListener('unhandledrejection', …)` in `src/renderer/src/main.tsx` *before* mounting React, so a crash during App's initial render still lands. Each row is one JSON object: `{ ts, source: 'main' | 'renderer', type, message, stack?, extra? }`. No rotation; users can delete the file at will.
@@ -490,8 +490,9 @@ Per-session cost and token counts derived from Claude transcript JSONL events. *
 
 **Outstanding:**
 - **Cost rollup.** Derive a `cost` view (or materialized table) from the existing `events` rows: per session, sum input / output / cache-read / cache-creation tokens, multiply by a pricing table (hardcoded constants per `service_tier` × `model`, refreshed manually). New IPCs: `observability:getCost(sessionId)`, `observability:getCostForWorkspace(workspaceName)`. See #32.
-- **Live event push.** Today the renderer polls `observability:eventsForSession` for catch-up. A live `observability:event:${sessionId}` push (sent from the watcher's ingest path) replaces polling for streaming UIs. Land alongside the ObservabilityPane in #33.
-- **UI surface.** ObservabilityPane v1: cost + token totals + per-tool counts + session metadata for the active session (#33). Slot consumers — chip secondary line (#20), tab status (#24), context-bar fill (#25) — wire to live data once available (#34).
+- **Live event push.** Today the ObservabilityPane polls `observability:summaryForWorkspace` every 2s. A live `observability:event:${sessionId}` push (sent from the watcher's ingest path) replaces polling for streaming UIs.
+- **Precise per-tab mapping.** v1 of the ObservabilityPane keys off the workspace's most-recently-active Claude session, not the focused terminal tab. The "right" mapping bridges broker session id ↔ claude session UUID, e.g., by associating each broker session with the next new JSONL that appears after its attach event. Land as a follow-up sub-issue.
+- **Slot consumers.** Chip secondary line (#20), tab status (#24), context-bar fill (#25) — wire to live data once available (#34).
 - **Subagent JSONLs.** Today `depth: 0` skips them. Decide whether to surface them in the events stream as a separate `parent_session_id` field, or treat them as opaque tool runs.
 
 ### Sessions table

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -332,6 +332,115 @@ export function getSession(id: string): SessionRow | null {
   };
 }
 
+// ── Workspace summary ─────────────────────────────────────────────────────
+
+export interface ToolCallCount {
+  name: string;
+  count: number;
+}
+
+export interface WorkspaceSummary {
+  /** Latest active Claude session UUID in the workspace, or null if none. */
+  sessionId: string | null;
+  /** Display title — from `ai-title.aiTitle` if present, else the session's first user message head. */
+  title: string | null;
+  /** Latest assistant.message.model seen in this session. */
+  model: string | null;
+  startedAt: number | null;
+  lastActiveAt: number | null;
+  /** Row count for this session in `events`. */
+  eventCount: number;
+  /** Per-session token sums (assistant events only). */
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  /** Top tools called in this session, descending count. */
+  topTools: ToolCallCount[];
+}
+
+/**
+ * Single-shot query for the renderer's right-rail pane: pick the
+ * most-recently-active session in this workspace, then assemble its
+ * token totals + top tools + metadata. Returns null when the workspace
+ * has no JSONL events at all yet.
+ */
+export function summaryForWorkspace(workspaceName: string, topToolsLimit = 5): WorkspaceSummary | null {
+  const d = openDbOrThrow();
+  const session = d
+    .prepare(`
+      SELECT id, ai_title, first_user_message, started_at, last_active_at
+      FROM sessions
+      WHERE workspace_name = ?
+      ORDER BY COALESCE(last_active_at, 0) DESC
+      LIMIT 1
+    `)
+    .get(workspaceName) as
+    | {
+        id: string;
+        ai_title: string | null;
+        first_user_message: string | null;
+        started_at: number | null;
+        last_active_at: number | null;
+      }
+    | undefined;
+  if (!session) return null;
+
+  const aggregates = d
+    .prepare(`
+      SELECT
+        COUNT(*)                                                   AS event_count,
+        COALESCE(SUM(input_tokens), 0)                             AS input_tokens,
+        COALESCE(SUM(output_tokens), 0)                            AS output_tokens,
+        COALESCE(SUM(cache_read_input_tokens), 0)                  AS cache_read_input_tokens,
+        COALESCE(SUM(cache_creation_input_tokens), 0)              AS cache_creation_input_tokens
+      FROM events
+      WHERE session_id = ?
+    `)
+    .get(session.id) as {
+    event_count: number;
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+  };
+
+  const latestModel = d
+    .prepare(`
+      SELECT model FROM events
+      WHERE session_id = ? AND type = 'assistant' AND model IS NOT NULL
+      ORDER BY id DESC LIMIT 1
+    `)
+    .get(session.id) as { model: string } | undefined;
+
+  const topTools = d
+    .prepare(`
+      SELECT tool_name AS name, COUNT(*) AS count
+      FROM events
+      WHERE session_id = ? AND tool_name IS NOT NULL
+      GROUP BY tool_name
+      ORDER BY count DESC
+      LIMIT ?
+    `)
+    .all(session.id, topToolsLimit) as ToolCallCount[];
+
+  return {
+    sessionId: session.id,
+    title:
+      session.ai_title ??
+      (session.first_user_message ? session.first_user_message.slice(0, 80) : null),
+    model: latestModel?.model ?? null,
+    startedAt: session.started_at,
+    lastActiveAt: session.last_active_at,
+    eventCount: aggregates.event_count,
+    inputTokens: aggregates.input_tokens,
+    outputTokens: aggregates.output_tokens,
+    cacheReadInputTokens: aggregates.cache_read_input_tokens,
+    cacheCreationInputTokens: aggregates.cache_creation_input_tokens,
+    topTools,
+  };
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────
 
 function openDbOrThrow(): Database.Database {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -16,7 +16,7 @@ import {
 } from './workspaces.js';
 import type { PtyHandle, RemoveWorkspaceOpts, CreateWorkspaceInput } from './docker.js';
 import type { JsonlWatcher } from './jsonlWatcher.js';
-import { eventsForSession } from './db.js';
+import { eventsForSession, summaryForWorkspace } from './db.js';
 import { logError, getLogPath } from './errorLog.js';
 
 export const MOCK_MODE = process.env.CLAUDE_FLEET_MOCK === '1';
@@ -251,6 +251,16 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     'observability:eventsForSession',
     (_e, sessionId: string, sinceEventId = 0, limit = 500) =>
       eventsForSession(sessionId, sinceEventId, limit)
+  );
+
+  /**
+   * Pragmatic v1: picks the most-recently-active Claude session in the
+   * workspace. Precise per-tab mapping (broker session ↔ claude session
+   * UUID) is a deferred follow-up; in practice the latest-active heuristic
+   * matches the focused tab nearly always.
+   */
+  ipcMain.handle('observability:summaryForWorkspace', (_e, workspaceName: string) =>
+    summaryForWorkspace(workspaceName)
   );
 
   // Renderer-side error reporting bridge. The renderer's onerror /

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,25 @@ export interface SessionInventory {
  * subset the renderer needs. `rawJsonl` holds the original line so the
  * renderer can pull fields the extract columns don't cover yet.
  */
+/**
+ * Per-workspace summary for the right-rail observability pane. Reflects
+ * the most-recently-active Claude session in the workspace; null when
+ * no events have been ingested for that workspace yet.
+ */
+export interface WorkspaceObservabilitySummary {
+  sessionId: string | null;
+  title: string | null;
+  model: string | null;
+  startedAt: number | null;
+  lastActiveAt: number | null;
+  eventCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  topTools: Array<{ name: string; count: number }>;
+}
+
 export interface ObservabilityEventRow {
   id: number;
   sessionId: string;
@@ -152,7 +171,11 @@ const api = {
       sinceEventId = 0,
       limit = 500
     ): Promise<ObservabilityEventRow[]> =>
-      ipcRenderer.invoke('observability:eventsForSession', sessionId, sinceEventId, limit)
+      ipcRenderer.invoke('observability:eventsForSession', sessionId, sinceEventId, limit),
+    summaryForWorkspace: (
+      workspaceName: string
+    ): Promise<WorkspaceObservabilitySummary | null> =>
+      ipcRenderer.invoke('observability:summaryForWorkspace', workspaceName)
   }
 };
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -245,7 +245,7 @@ export function App() {
           </div>
         </main>
 
-        <ObservabilityPane />
+        <ObservabilityPane workspaceName={selected?.name ?? null} />
       </div>
 
       <BottomBar vaultAvailable={vaultAvailable} />

--- a/src/renderer/src/components/ObservabilityPane.tsx
+++ b/src/renderer/src/components/ObservabilityPane.tsx
@@ -1,17 +1,159 @@
-export function ObservabilityPane() {
+import { useEffect, useState } from 'react';
+import type { WorkspaceObservabilitySummary } from '../../../preload';
+
+interface Props {
+  /** Active workspace name, or null when nothing is selected. */
+  workspaceName: string | null;
+}
+
+const POLL_MS = 2000;
+
+export function ObservabilityPane({ workspaceName }: Props) {
+  const [summary, setSummary] = useState<WorkspaceObservabilitySummary | null>(null);
+  // Distinct from `summary == null`: until the first fetch returns, we don't
+  // know whether the workspace has data. Avoids flashing the empty state.
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!workspaceName) {
+      setSummary(null);
+      setLoaded(true);
+      return;
+    }
+    let cancelled = false;
+    setLoaded(false);
+    const fetchSummary = async () => {
+      try {
+        const next = await window.api.observability.summaryForWorkspace(workspaceName);
+        if (cancelled) return;
+        setSummary(next);
+        setLoaded(true);
+      } catch {
+        // Observability is best-effort; a transient failure shouldn't
+        // disrupt the rest of the app. Keep the previous summary.
+      }
+    };
+    fetchSummary();
+    const id = setInterval(fetchSummary, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [workspaceName]);
+
   return (
     <aside className="pane sidebar-right">
       <div className="pane-header">
         <span>Observability</span>
+        {summary?.model && <span className="obs-model">{summary.model}</span>}
       </div>
       <div className="pane-body">
-        <div className="pane-placeholder">
-          <strong>Coming with #2</strong>
-          Per-session cost, token counts, context usage, and recent tool calls
-          sourced from each workspace's Claude transcript JSONL. See
-          <code> docs/SPEC.md</code> §11 “Observability layer”.
-        </div>
+        {!workspaceName ? (
+          <EmptyState message="No workspace selected." />
+        ) : !loaded ? (
+          <EmptyState message="Loading…" />
+        ) : !summary || summary.sessionId === null ? (
+          <EmptyState message="No transcript events yet." subdued />
+        ) : (
+          <SummaryView summary={summary} />
+        )}
       </div>
     </aside>
   );
+}
+
+function SummaryView({ summary }: { summary: WorkspaceObservabilitySummary }) {
+  return (
+    <div className="obs-stack">
+      <section className="obs-title-block">
+        {summary.title && <div className="obs-title">{summary.title}</div>}
+        <div className="obs-meta-row">
+          {summary.lastActiveAt && <span>active {relativeTime(summary.lastActiveAt)}</span>}
+          <span>·</span>
+          <span>
+            {summary.eventCount} event{summary.eventCount === 1 ? '' : 's'}
+          </span>
+        </div>
+      </section>
+
+      <section className="obs-section">
+        <div className="obs-section-title">Tokens</div>
+        <TokenRow label="input" value={summary.inputTokens} />
+        <TokenRow label="cache create" value={summary.cacheCreationInputTokens} />
+        <TokenRow label="cache read" value={summary.cacheReadInputTokens} subdued />
+        <TokenRow label="output" value={summary.outputTokens} accent />
+      </section>
+
+      {summary.topTools.length > 0 && (
+        <section className="obs-section">
+          <div className="obs-section-title">Top tools</div>
+          {summary.topTools.map((t) => (
+            <div key={t.name} className="obs-row">
+              <span className="obs-row-label">{t.name}</span>
+              <span className="obs-row-value">{t.count}</span>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <section className="obs-section obs-section-quiet">
+        <div className="obs-row">
+          <span className="obs-row-label">started</span>
+          <span className="obs-row-value mono">
+            {summary.startedAt ? new Date(summary.startedAt).toLocaleString() : '—'}
+          </span>
+        </div>
+        {summary.sessionId && (
+          <div className="obs-row">
+            <span className="obs-row-label">session</span>
+            <span className="obs-row-value mono" title={summary.sessionId}>
+              {summary.sessionId.slice(0, 8)}…
+            </span>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function TokenRow({
+  label,
+  value,
+  subdued,
+  accent,
+}: {
+  label: string;
+  value: number;
+  subdued?: boolean;
+  accent?: boolean;
+}) {
+  return (
+    <div className={`obs-row ${subdued ? 'subdued' : ''} ${accent ? 'accent' : ''}`}>
+      <span className="obs-row-label">{label}</span>
+      <span className="obs-row-value mono">{formatTokens(value)}</span>
+    </div>
+  );
+}
+
+function EmptyState({ message, subdued }: { message: string; subdued?: boolean }) {
+  return (
+    <div className={`pane-placeholder ${subdued ? 'subdued' : ''}`}>
+      <p style={{ margin: 0, color: 'var(--text-muted)' }}>{message}</p>
+    </div>
+  );
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 2 : 1)}K`;
+  return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 2 : 1)}M`;
+}
+
+function relativeTime(ms: number): string {
+  const delta = Date.now() - ms;
+  if (delta < 5_000) return 'just now';
+  if (delta < 60_000) return `${Math.round(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `${Math.round(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.round(delta / 3_600_000)}h ago`;
+  return `${Math.round(delta / 86_400_000)}d ago`;
 }

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -241,6 +241,64 @@ body {
   line-height: 1.5;
 }
 .pane-placeholder strong { color: var(--text-secondary); display: block; margin-bottom: 4px; font-size: 13px; }
+.pane-placeholder.subdued { border-style: solid; border-color: var(--border-subtle); background: var(--bg-base); }
+
+/* ----- observability pane --------------------------------------------- */
+.obs-model {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+.obs-stack { display: flex; flex-direction: column; gap: 14px; }
+.obs-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.obs-title {
+  font-size: 13px;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+.obs-meta-row {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-muted);
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.obs-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.obs-section-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.obs-section-quiet { padding-top: 8px; border-top: 1px solid var(--border-subtle); }
+.obs-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+  padding: 2px 0;
+}
+.obs-row-label { color: var(--text-secondary); }
+.obs-row-value { color: var(--text-primary); }
+.obs-row-value.mono { font-family: var(--font-mono); font-size: 11.5px; }
+.obs-row.subdued .obs-row-value { color: var(--text-muted); }
+.obs-row.accent .obs-row-value { color: var(--accent); font-weight: 500; }
 
 /* ----- terminal pane --------------------------------------------------- */
 .main-pane {


### PR DESCRIPTION
## Why

PR #36 (ObservabilityPane v1) shows MERGED on GitHub, but its squash commit (`4db0638`) is reachable only from `origin/obs/step-1-watcher` — not `main`. Cause: stacked-PR mishap. PR #36 targeted `obs/step-1-watcher` (PR #35's branch). When PR #35 was squash-merged to `main` first, PR #36 didn't auto-retarget, and its eventual squash-merge landed back into `obs/step-1-watcher`, which itself never made it to `main` afterwards. End result: the runtime pane is still the "Coming with #2" placeholder.

This PR cherry-picks `4db0638` onto current `main`, with two trivial conflict resolutions in `src/main/ipc.ts` (additive — keeps both the `summaryForWorkspace` import + handler from #36 and the `app:logError` / `app:errorLogPath` wiring from #39).

## What this restores

- `src/main/db.ts` — `summaryForWorkspace(workspaceName)` (session pick + token aggregation + top-tools).
- `src/main/ipc.ts` — `observability:summaryForWorkspace` handler.
- `src/preload/index.ts` — `window.api.observability.summaryForWorkspace` + `WorkspaceObservabilitySummary` type.
- `src/renderer/src/components/ObservabilityPane.tsx` — full rewrite: title/last-activity/event-count header, tokens block, top-tools block, session-metadata block, empty states.
- `styles.css` — observability-pane styles.
- `docs/SPEC.md` — §5 pane description + §6 new IPC + §11 *Observability — Outstanding* refreshed.

## Out of scope

- USD cost calc → #32 (cost rollup) — landing next on top of this.
- Live `observability:event:${sessionId}` push (still polls 2s) — follow-up.
- Precise per-tab mapping (broker session ↔ claude session UUID) — follow-up.
- Slot consumers (chip/tab/context-bar) — #34 / #37 also need re-rebase.

Closes #33 (again — first close was illusory).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — all 26 Playwright smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)