### PR TITLE
Workspace actions: Clone, Delete, chip ⋮ Edit/Clone/Delete, restart banner (Phase 2 PR 2/3)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -119,7 +119,12 @@ The renderer layout is a 3-row × 3-col shell:
   - **Observability pane** (right, ~320px): live view of the **active terminal tab**'s Claude session in the selected workspace. Shows session title (from `ai-title` event or first-user-message head), latest model, last-activity relative time, event count, prominent USD total, token totals (input / cache-create / cache-read / output), and top tools by call count. Empty state when the focused tab has no per-tab data yet. Per-tab resolution comes from the `broker_sessions` mapping table (§11 *Per-tab mapping*). `TerminalPane` bubbles its active tab id up via `onActiveTabChange`; App.tsx fetches `summaryForBrokerSession(workspaceId, activeTabId)` for the selected workspace and re-fetches on every push for that workspace. **No workspace fallback** — when the per-tab fetch returns null the pane shows its empty state directly, regardless of how the tab was added. The fallback was tried (loaded-from-inventory tabs → workspace summary, fresh tabs → empty) but produced two user-visible bugs: clicking `+` showed the previous tab's data via the fallback, and switching between two unmapped tabs showed the same workspace-summary content on both ("doesn't update"). Per-tab semantics are now honest: each tab shows its own data or empty, never inherits from a sibling tab.
 - **Bottom row** (`BottomBar`): static hint bar with key bindings and degraded-vault notice when applicable.
 
-Modals (`WorkspaceModal`, `CloseWorkspaceModal`) are owned by `App` and rendered above the shell. `WorkspaceModal` is a tabbed shell with Saved + New tabs (underlined-tab style). The body of each tab uses `WorkspaceForm` — the field-level form component owns its own state, validation, and footer; New tab renders it in `mode='create'`, expanded Saved-tab rows render it in `mode='edit'` with the workspace's persisted spec pre-filled. The legacy `ProfilesDialog` is gone — per-workspace env-var management lives inside `WorkspaceForm`.
+Modals owned by `App`:
+- `WorkspaceModal` — tabbed shell with Saved + New tabs (underlined-tab style). Body of each tab uses `WorkspaceForm` — the field-level form component owns state, validation, and footer; New tab renders it in `mode='create'`, expanded Saved-tab rows render it in `mode='edit'`. Saved-row expanded footer is `Delete · Cancel · Clone · Resume`; New-tab footer is `Cancel · Create & start`.
+- `EditWorkspaceModal` — single-purpose modal for editing a *live* workspace. Opened from the chip ⋮ menu Edit entry. Wraps `WorkspaceForm` in `mode='edit'`. On Save, calls `workspace:writeManifest` + diffs pre/post specs; container-level changes flip the restart-to-apply banner in the workspace's TerminalPane.
+- `CloseWorkspaceModal` — Stop / Pause / Stop & remove (keeps state dir).
+- `DeleteWorkspaceModal` — Permanent purge confirmation: stop + `workspace:remove(containerId, { deleteState: true })` + `vault:deleteAllForWorkspace(id)`.
+- The legacy `ProfilesDialog` is gone — per-workspace env-var management lives inside `WorkspaceForm`.
 
 ## 6. IPC surface
 
@@ -381,12 +386,14 @@ Values are read from the renderer only on explicit `vault:getSecret`; during nor
 ### Create a workspace
 1. User clicks **+ New workspace** in the top strip.
 2. `<WorkspaceModal>` opens. Two tabs at top: **Saved** (count badge) + **New**, underlined-tab style. Default tab is Saved when at least one non-running workspace exists, else New.
-3. The Saved tab lists every stopped / paused / deleted workspace — sorted with a Variant-B label-filter search at the top: text input matches name + description (substring, case-insensitive), and a **Labels** dropdown opens a checkbox list of fleet-wide labels with usage counts. Selected labels filter the list as OR (any-match); active filters surface as removable pills above the list with an `N of M` count on the right. Each row shows a color identity bar, name, description, state badge, and last-used relative time. Clicking a row's header animates it open (CSS `grid-template-rows: 0fr → 1fr`, 320ms cubic-bezier; chevron rotates 180°; form contents fade-and-slide in over 220ms with 80ms delay) and renders `WorkspaceForm` inline in `mode='edit'` with the persisted spec pre-filled.
+3. The Saved tab lists every stopped / paused / deleted workspace — sorted with a Variant-B label-filter search at the top: text input matches name + description (substring, case-insensitive), and a **Labels** dropdown opens a checkbox list of fleet-wide labels with usage counts. Selected labels filter the list as OR (any-match); active filters surface as removable pills above the list with an `N of M` count on the right. Each row shows a color identity bar, name, description, state badge, and last-used relative time. Clicking a row's header animates it open (CSS `grid-template-rows: 0fr → 1fr`, 320ms cubic-bezier; chevron rotates 180°; form contents fade-and-slide in over 220ms with 80ms delay) and renders `WorkspaceForm` inline in `mode='edit'` with the persisted spec pre-filled. The expanded row's footer is **Delete (danger)** on the far left, then `Cancel · Clone · Resume` on the right.
 4. **Resume** (primary in the expanded form) — `App.handleResume`:
    - Writes any newly-typed secret env values via `vault:setSecret(id, key, value)`. Pre-existing secrets the user didn't touch are left alone.
    - Calls `workspace:writeManifest(spec)` so renderer-visible edits (description, labels, color, name) take effect immediately even if the container needs a restart for env/image changes.
    - Calls `workspace:start(id)`. If a container exists (state was stopped/paused/running with no label match), it's started. If null (state was deleted, container gone), the renderer falls through to the create flow with the **same id reused** so state-dir + vault history stay attached.
-5. **Cancel** in the expanded form collapses the row without applying changes.
+5. **Clone** in the expanded form opens the modal in Clone mode — `App.openCloneFrom` strips the source's id, auto-suggests `<source>-N` (incrementing N from 2 until unused), clears the color so a fresh hue is picked, and the modal's New tab takes the foreground pre-filled with the source's spec. The user can edit before clicking **Create & start**. Source workspace is unchanged.
+6. **Delete** in the expanded form (or chip ⋮ menu) opens `DeleteWorkspaceModal` — a confirm modal with explicit warning text. On confirm: `workspace:stop` (if live) → `workspace:remove(containerId, { deleteState: true })` (wipes state dir + manifest) → `vault:deleteAllForWorkspace(id)` (purges every secret).
+7. **Cancel** in the expanded form collapses the row without applying changes.
 6. The **New** tab is the Create form. The user fills:
    - **Type** radio: Container (default — isolated Docker runner) or Local ("coming soon" — submit throws).
    - For Container, an **Image** input appears with the inline image-library picker beneath it (default = most-recently-used library entry, or the bundled runner).
@@ -424,7 +431,24 @@ Each `pty:attach` runs `claude` fresh inside the container via `docker exec` —
 **Clickable links**: `term.registerLinkProvider` walks back to the first non-wrapped row, forward through `isWrapped` continuations, concatenates the rows, and matches URLs against the joined text — so a URL that soft-wraps across multiple rows is registered as a single link spanning all of them. Activation calls `window.open`, which `setWindowOpenHandler` routes through `shell.openExternal`.
 
 ### Manage per-workspace env vars
-The global Profiles modal is gone. Per-workspace env vars (both plain and secret) live in the Env-vars disclosure inside `WorkspaceForm` — the same component renders for new workspaces in the New tab and for existing workspaces in the Saved tab's inline expand-edit form. Underneath, the renderer calls `vault:setSecret(workspaceId, key, value)` / `vault:deleteSecret(workspaceId, key)` to mutate keychain values, and the manifest's `env.secretKeys` array tracks which keys exist for that workspace so the editor can surface them without ever reading a value.
+The global Profiles modal is gone. Per-workspace env vars (both plain and secret) live in the Env-vars disclosure inside `WorkspaceForm` — the same component renders for new workspaces in the New tab, for non-running workspaces in the Saved tab's inline expand-edit form, and for **running** workspaces in `EditWorkspaceModal` (opened via the chip ⋮ menu). Underneath, the renderer calls `vault:setSecret(workspaceId, key, value)` / `vault:deleteSecret(workspaceId, key)` to mutate keychain values, and the manifest's `env.secretKeys` array tracks which keys exist for that workspace so the editor can surface them without ever reading a value.
+
+### Chip ⋮ menu (live workspaces)
+Each chip in the workspace strip has a `⋮` trigger that opens a contextual menu. The menu's contents depend on the workspace's state:
+- **Pause / Stop** (running), **Resume** (paused), or **Start** (stopped) — single-action lifecycle controls.
+- **Edit…** — opens `EditWorkspaceModal`, a single-purpose modal wrapping `WorkspaceForm` in edit mode with the workspace's spec pre-filled. On Save, `App.handleEditSave` persists secrets + calls `workspace:writeManifest`, then compares pre-edit vs post-edit specs (`containerLevelChanged` in `EditWorkspaceModal.tsx`). Render-only changes (`name`, `description`, `labels`, `color`) take effect immediately. Container-level changes (`env`, `image`, `authMode`, `resources`) flip the **restart-to-apply banner** in the workspace's `TerminalPane` (see below).
+- **Clone…** — opens the workspace modal in Clone mode pre-filled from this workspace (same `App.openCloneFrom` flow as the Saved-tab Clone footer button).
+- **Close…** — opens `CloseWorkspaceModal` (preserves state dir).
+- **Delete…** — opens `DeleteWorkspaceModal` (purges state dir + every keychain entry under the workspace's id). Distinct from Close — Close keeps the workspace in the Saved list; Delete makes it disappear.
+
+### Restart-to-apply banner
+`TerminalPane` renders a dismissable banner above the session tab strip when `EditWorkspaceModal` saves changes to any container-level field on a running or paused workspace:
+
+> Changes apply on next start. **[Restart now]** ×
+
+- **Restart now**: `workspace:stop(containerId)` → `workspace:start(id)`. Banner clears.
+- **×** (dismiss): banner clears without restart.
+- The banner is keyed by workspace id in App.tsx's `restartBannerIds` Set; the corresponding TerminalPane reads `restartBanner` as a prop and renders accordingly. The Set survives chip switches — selecting another workspace and coming back still shows the banner until dismissed.
 
 ### Close a workspace
 1. User selects a workspace, then clicks **Close…** in the main-pane header.
@@ -509,6 +533,8 @@ claude-fleet/
                 ├── BottomBar.tsx          # footer hint bar
                 ├── WorkspaceModal.tsx     # tabbed shell: Saved (variant-B search + inline expand-edit) + New
                 ├── WorkspaceForm.tsx      # reusable form (color, description, labels, env, resources); mode-aware
+                ├── EditWorkspaceModal.tsx # single-purpose edit modal for live workspaces (chip ⋮ Edit)
+                ├── DeleteWorkspaceModal.tsx # confirm modal: stop + remove + purge keytar
                 └── CloseWorkspaceModal.tsx
 ```
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,9 +4,11 @@ import { SessionsPane } from './components/SessionsPane';
 import { ObservabilityPane } from './components/ObservabilityPane';
 import { TerminalPane } from './components/TerminalPane';
 import { BottomBar } from './components/BottomBar';
-import { WorkspaceModal } from './components/WorkspaceModal';
+import { WorkspaceModal, suggestCloneName } from './components/WorkspaceModal';
 import type { WorkspaceFormSubmit } from './components/WorkspaceForm';
 import { CloseWorkspaceModal } from './components/CloseWorkspaceModal';
+import { DeleteWorkspaceModal } from './components/DeleteWorkspaceModal';
+import { EditWorkspaceModal, containerLevelChanged } from './components/EditWorkspaceModal';
 import type { WorkspaceObservabilitySummary } from '../../preload';
 
 export type WorkspaceState = 'running' | 'paused' | 'stopped' | 'deleted';
@@ -77,6 +79,17 @@ export function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [closeTargetId, setCloseTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [editTargetId, setEditTargetId] = useState<string | null>(null);
+  // When the user clicks Clone (Saved-row footer, chip menu, or
+  // EditWorkspaceModal), the source spec lands here and the modal
+  // reopens on the New tab pre-filled. Cleared when modal closes.
+  const [cloneSource, setCloneSource] =
+    useState<Partial<WorkspaceFormSubmit & { id: string }> | null>(null);
+  // Workspaces whose container-level fields were just edited while
+  // running. TerminalPane reads this map to render the
+  // restart-to-apply banner; clearing happens on Restart or Dismiss.
+  const [restartBannerIds, setRestartBannerIds] = useState<Set<string>>(new Set());
   const [summaries, setSummaries] = useState<
     Record<string, WorkspaceObservabilitySummary | null>
   >({});
@@ -341,6 +354,112 @@ export function App() {
     refresh();
   };
 
+  /**
+   * Apply edits to a live workspace's manifest. Returns true when any
+   * container-level field changed (caller flips the restart-to-apply
+   * banner in TerminalPane).
+   */
+  const handleEditSave = async (submit: WorkspaceFormSubmit): Promise<boolean> => {
+    const id = submit.id;
+    if (!id) throw new Error('handleEditSave requires submit.id');
+    const before = workspaces.find((w) => w.id === id);
+    if (!before) throw new Error(`Workspace ${id} not found`);
+
+    await persistSecrets(id, submit);
+    await window.api.workspace.writeManifest({
+      id,
+      name: submit.name,
+      description: submit.description,
+      labels: submit.labels,
+      color: submit.color,
+      workspaceRoot: submit.workspaceRoot,
+      workspaceSubdir: submit.workspaceSubdir,
+      kind: submit.kind,
+      image: submit.image,
+      authMode: submit.authMode,
+      env: { plain: submit.plainEnv, secretKeys: submit.secretKeys },
+      resources: submit.resources,
+      createdAt: before.createdAt,
+      lastUsedAt: Date.now()
+    });
+
+    const containerEdit = containerLevelChanged(before, submit);
+    if (containerEdit && (before.state === 'running' || before.state === 'paused')) {
+      setRestartBannerIds((prev) => {
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+    }
+    refresh();
+    return containerEdit;
+  };
+
+  /**
+   * Open the modal in Clone mode pre-filled with the source's spec.
+   * Strips the source's id, suggests `<source>-N` for the name, and
+   * clears the color so a fresh hue is picked.
+   */
+  const openCloneFrom = (source: WorkspaceFormSubmit | WorkspaceSummary): void => {
+    const isSummary = 'state' in source;
+    const baseName = source.name;
+    const plain = isSummary ? source.env.plain : source.plainEnv;
+    const secretKeys = isSummary ? source.env.secretKeys : source.secretKeys;
+    const clone: Partial<WorkspaceFormSubmit & { id: string }> = {
+      // No id — WorkspaceModal.handleCreate mints a fresh ULID on submit.
+      name: suggestCloneName(baseName, workspaces),
+      description: source.description,
+      labels: source.labels,
+      color: undefined, // fresh hue
+      workspaceRoot: source.workspaceRoot,
+      workspaceSubdir: source.workspaceSubdir,
+      kind: source.kind,
+      image: source.image,
+      authMode: source.authMode,
+      plainEnv: { ...plain },
+      // Don't carry secret *values* across — they live in the source's
+      // vault entry, not in the clone's. The user re-enters them in the
+      // env editor before submitting. (Showing pre-existing secret keys
+      // would be misleading: those keys exist for the *source* id.)
+      secretKeys: [...secretKeys],
+      secrets: {},
+      resources: source.resources
+    };
+    setCloneSource(clone);
+    setEditTargetId(null); // close edit modal if open
+    setCreateOpen(true);
+  };
+
+  const restartFromBanner = async (workspaceId: string, containerId: string): Promise<void> => {
+    try {
+      await window.api.workspace.stop(containerId);
+    } catch (err) {
+      console.warn('workspace.stop during restart-banner failed:', err);
+    }
+    try {
+      await window.api.workspace.start(workspaceId);
+    } catch (err) {
+      console.warn('workspace.start during restart-banner failed:', err);
+    }
+    setRestartBannerIds((prev) => {
+      if (!prev.has(workspaceId)) return prev;
+      const next = new Set(prev);
+      next.delete(workspaceId);
+      return next;
+    });
+    refresh();
+  };
+
+  const dismissBanner = (workspaceId: string): void => {
+    setRestartBannerIds((prev) => {
+      if (!prev.has(workspaceId)) return prev;
+      const next = new Set(prev);
+      next.delete(workspaceId);
+      return next;
+    });
+  };
+
   return (
     <div className="app">
       <WorkspaceTabStrip
@@ -352,6 +471,9 @@ export function App() {
         onSelect={setSelectedId}
         onNewWorkspace={() => setCreateOpen(true)}
         onCloseWorkspace={(w) => setCloseTargetId(w.id)}
+        onEditWorkspace={(w) => setEditTargetId(w.id)}
+        onCloneWorkspace={(w) => openCloneFrom(w)}
+        onDeleteWorkspace={(w) => setDeleteTargetId(w.id)}
         onRefresh={refresh}
       />
 
@@ -382,6 +504,9 @@ export function App() {
                   containerId={w.containerId!}
                   paused={w.state === 'paused'}
                   summary={summaries[w.id] ?? null}
+                  restartBanner={restartBannerIds.has(w.id)}
+                  onRestartFromBanner={() => restartFromBanner(w.id, w.containerId!)}
+                  onDismissBanner={() => dismissBanner(w.id)}
                   onResume={async () => {
                     await window.api.workspace.start(w.id);
                     refresh();
@@ -410,10 +535,53 @@ export function App() {
         open={createOpen}
         workspaces={workspaces}
         vaultAvailable={vaultAvailable}
-        onClose={() => setCreateOpen(false)}
-        onCreate={handleCreate}
+        onClose={() => {
+          setCreateOpen(false);
+          setCloneSource(null);
+        }}
+        onCreate={async (submit, setStatus) => {
+          await handleCreate(submit, setStatus);
+          setCloneSource(null);
+        }}
         onResume={handleResume}
+        onClone={async (submit) => openCloneFrom(submit)}
+        onDelete={(w) => setDeleteTargetId(w.id)}
+        initialNewTabValues={cloneSource}
       />
+      {(() => {
+        if (!editTargetId) return null;
+        const target = workspaces.find((w) => w.id === editTargetId);
+        if (!target) return null;
+        return (
+          <EditWorkspaceModal
+            workspace={target}
+            workspaces={workspaces}
+            vaultAvailable={vaultAvailable}
+            onClose={() => setEditTargetId(null)}
+            onSave={handleEditSave}
+            onClone={async (submit) => openCloneFrom(submit)}
+            onDeleted={() => {
+              if (selectedId === target.id) setSelectedId(null);
+              refresh();
+            }}
+          />
+        );
+      })()}
+      {(() => {
+        if (!deleteTargetId) return null;
+        const target = workspaces.find((w) => w.id === deleteTargetId);
+        if (!target) return null;
+        return (
+          <DeleteWorkspaceModal
+            workspace={target}
+            onClose={() => setDeleteTargetId(null)}
+            onDeleted={() => {
+              if (selectedId === target.id) setSelectedId(null);
+              refresh();
+            }}
+          />
+        );
+      })()}
       {(() => {
         if (!closeTargetId) return null;
         const target = workspaces.find((w) => w.id === closeTargetId);

--- a/src/renderer/src/components/DeleteWorkspaceModal.tsx
+++ b/src/renderer/src/components/DeleteWorkspaceModal.tsx
@@ -1,0 +1,83 @@
+// Permanent-delete confirmation. Distinct from `CloseWorkspaceModal`:
+// Close keeps the state dir + manifest so the workspace stays in the
+// Saved list (recoverable); Delete purges everything — state dir,
+// manifest, every keytar secret under the workspace's id.
+
+import { useState } from 'react';
+import type { WorkspaceSummary } from '../App';
+
+interface Props {
+  workspace: WorkspaceSummary;
+  onClose: () => void;
+  onDeleted: () => void;
+}
+
+export function DeleteWorkspaceModal({ workspace, onClose, onDeleted }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const confirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      // Stop the container first if it's live — `workspace:remove` with
+      // `force: true` would also work, but a graceful stop gives any
+      // in-flight Claude work a chance to flush its JSONL.
+      if (workspace.containerId && (workspace.state === 'running' || workspace.state === 'paused')) {
+        setStatus('Stopping…');
+        try {
+          await window.api.workspace.stop(workspace.containerId);
+        } catch (err) {
+          // Best-effort — if stop fails, fall through to force-remove.
+          console.warn('workspace.stop during delete failed:', err);
+        }
+      }
+      if (workspace.containerId) {
+        setStatus('Removing container + state dir…');
+        await window.api.workspace.remove(workspace.containerId, { deleteState: true });
+      }
+      setStatus('Purging vault entries…');
+      try {
+        await window.api.vault.deleteAllForWorkspace(workspace.id);
+      } catch (err) {
+        // Best-effort — manifest is gone either way; orphan keytar
+        // entries get caught on next migration run.
+        console.warn('vault.deleteAllForWorkspace failed:', err);
+      }
+      onDeleted();
+      onClose();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+      setStatus(null);
+    }
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={busy ? undefined : onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2>Delete workspace</h2>
+        <p className="modal-eyebrow">{workspace.name}</p>
+        <p style={{ margin: '8px 0 16px', lineHeight: 1.5 }}>
+          Permanently delete <strong>{workspace.name}</strong>? This removes the workspace
+          state directory and every secret env value stored for it in the OS keychain.
+          <br />
+          <strong style={{ color: 'var(--state-error, #ef4d4d)' }}>This cannot be undone.</strong>
+        </p>
+        {status && <div className="form-status">{status}</div>}
+        {error && <div className="form-hint error-text">{error}</div>}
+        <div className="modal-footer">
+          <span className="modal-footer-spacer" />
+          <button className="btn" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button className="btn danger" onClick={confirm} disabled={busy}>
+            {busy ? '…' : 'Delete permanently'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/EditWorkspaceModal.tsx
+++ b/src/renderer/src/components/EditWorkspaceModal.tsx
@@ -1,0 +1,156 @@
+// Single-purpose edit modal for a live workspace. Opened from the chip
+// ⋮ menu (running / paused / stopped — anywhere the workspace isn't in
+// the Saved tab). Wraps `WorkspaceForm` in edit mode.
+//
+// Why a separate component rather than reusing `WorkspaceModal`: the
+// Saved tab lists *non-running* workspaces by design (state 8 of the
+// design doc). Editing a running workspace shouldn't require it to
+// also appear in Saved — that would confuse the tab's mental model.
+// A focused single-modal makes the chip-menu Edit interaction direct
+// and lets the Save action know to surface the restart-to-apply banner
+// when container-level fields changed.
+//
+// The "container-level changed" check is what triggers the banner in
+// `TerminalPane` (see the `bannerByWorkspaceId` map in App.tsx). Plain
+// labels / description / color / name edits land in the manifest
+// immediately and don't trigger the banner.
+
+import { useState } from 'react';
+import { WorkspaceForm, type WorkspaceFormSubmit } from './WorkspaceForm';
+import { DeleteWorkspaceModal } from './DeleteWorkspaceModal';
+import type { WorkspaceSummary } from '../App';
+
+interface Props {
+  workspace: WorkspaceSummary;
+  workspaces: WorkspaceSummary[];
+  vaultAvailable: boolean | null;
+  onClose: () => void;
+  /** Apply edits to the manifest. Returns true if container-level fields changed (triggers the restart banner). */
+  onSave: (submit: WorkspaceFormSubmit) => Promise<boolean>;
+  /** Clone the source into a new workspace. */
+  onClone: (submit: WorkspaceFormSubmit) => Promise<void>;
+  /** Workspace was deleted — caller refreshes + closes. */
+  onDeleted: () => void;
+}
+
+export function EditWorkspaceModal({
+  workspace,
+  workspaces,
+  vaultAvailable,
+  onClose,
+  onSave,
+  onClone,
+  onDeleted
+}: Props) {
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+  const handleSave = async (
+    submit: WorkspaceFormSubmit,
+    _setStatus: (m: string | null) => void
+  ): Promise<void> => {
+    await onSave(submit);
+    onClose();
+  };
+
+  const handleClone = async (submit: WorkspaceFormSubmit): Promise<void> => {
+    await onClone(submit);
+    onClose();
+  };
+
+  const handleDeleteRequest = async (): Promise<void> => {
+    setDeleteConfirmOpen(true);
+  };
+
+  if (deleteConfirmOpen) {
+    return (
+      <DeleteWorkspaceModal
+        workspace={workspace}
+        onClose={() => setDeleteConfirmOpen(false)}
+        onDeleted={() => {
+          setDeleteConfirmOpen(false);
+          onDeleted();
+          onClose();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-tabs" role="tablist">
+          <div className="modal-tab active" aria-current="page">
+            Edit {workspace.name}
+          </div>
+        </div>
+        <div className="new-tab" role="tabpanel">
+          <WorkspaceForm
+            mode="edit"
+            initial={{
+              id: workspace.id,
+              name: workspace.name,
+              description: workspace.description,
+              labels: workspace.labels,
+              color: workspace.color,
+              workspaceRoot: workspace.workspaceRoot,
+              workspaceSubdir: workspace.workspaceSubdir,
+              kind: workspace.kind,
+              image: workspace.image,
+              authMode: workspace.authMode,
+              plainEnv: workspace.env.plain,
+              // secretKeys is read by WorkspaceForm via a separate cast
+              // (the initial reader looks for it on the partial object).
+              secretKeys: workspace.env.secretKeys,
+              resources: workspace.resources
+            }}
+            workspaces={workspaces}
+            vaultAvailable={vaultAvailable}
+            primaryLabel="Save"
+            onSubmit={handleSave}
+            onCancel={onClose}
+            onClone={handleClone}
+            onDelete={handleDeleteRequest}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compare two workspace specs and report whether any container-level
+ * field changed. Container-level = the fields the runner container
+ * itself materializes (env, image, authMode, resources). Render-only
+ * fields (name, description, labels, color, workspaceRoot,
+ * workspaceSubdir) don't trigger the restart-to-apply banner — though
+ * note that workspaceRoot + workspaceSubdir technically affect the
+ * bind-mount; in practice changing those is rare and the user has to
+ * recreate the container manually anyway.
+ */
+export function containerLevelChanged(
+  before: WorkspaceSummary,
+  after: WorkspaceFormSubmit
+): boolean {
+  if (before.authMode !== after.authMode) return true;
+  if ((before.image ?? '') !== (after.image ?? '')) return true;
+  // env.plain values
+  const beforePlain = before.env.plain;
+  const afterPlain = after.plainEnv;
+  const allPlainKeys = new Set([...Object.keys(beforePlain), ...Object.keys(afterPlain)]);
+  for (const k of allPlainKeys) {
+    if ((beforePlain[k] ?? '') !== (afterPlain[k] ?? '')) return true;
+  }
+  // secretKeys add/remove
+  const beforeSecrets = new Set(before.env.secretKeys);
+  const afterSecrets = new Set(after.secretKeys);
+  if (beforeSecrets.size !== afterSecrets.size) return true;
+  for (const k of beforeSecrets) if (!afterSecrets.has(k)) return true;
+  // Any newly-typed secret value
+  if (Object.keys(after.secrets).length > 0) return true;
+  // resources
+  const beforeRes = before.resources;
+  const afterRes = after.resources;
+  if ((beforeRes?.cpus ?? null) !== (afterRes?.cpus ?? null)) return true;
+  if ((beforeRes?.memoryMb ?? null) !== (afterRes?.memoryMb ?? null)) return true;
+  return false;
+}

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -38,6 +38,16 @@ interface Props {
    * still reads visually correct.
    */
   summary: WorkspaceObservabilitySummary | null;
+  /**
+   * When true, render the restart-to-apply banner above the session-tab
+   * strip. Set by App.tsx after an EditWorkspaceModal save changes any
+   * container-level field (env, image, authMode, resources) on a running
+   * workspace. Render-only edits (name, description, labels, color)
+   * never trigger the banner.
+   */
+  restartBanner?: boolean;
+  onRestartFromBanner?: () => void;
+  onDismissBanner?: () => void;
   onResume: () => void;
   /**
    * Reports the active tab's broker session id whenever it changes
@@ -94,6 +104,9 @@ export function TerminalPane({
   paused,
   visible,
   summary,
+  restartBanner,
+  onRestartFromBanner,
+  onDismissBanner,
   onResume,
   onActiveTabChange
 }: Props) {
@@ -254,6 +267,29 @@ export function TerminalPane({
       }}
       aria-hidden={!visible}
     >
+      {restartBanner && (
+        <div className="restart-banner" role="status" aria-live="polite">
+          <span className="restart-banner-text">
+            Changes apply on next start.
+          </span>
+          <button
+            type="button"
+            className="btn primary restart-banner-btn"
+            onClick={onRestartFromBanner}
+          >
+            Restart now
+          </button>
+          <button
+            type="button"
+            className="restart-banner-dismiss"
+            onClick={onDismissBanner}
+            aria-label="Dismiss"
+            title="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      )}
       <div className="session-tab-strip" role="tablist" aria-label="Terminal sessions">
         {sessions.map((s) => {
           const ended = endedIds.has(s.id);

--- a/src/renderer/src/components/WorkspaceForm.tsx
+++ b/src/renderer/src/components/WorkspaceForm.tsx
@@ -111,7 +111,22 @@ interface Props {
   vaultAvailable: boolean | null;
   onSubmit: (values: WorkspaceFormSubmit, setStatus: (s: string | null) => void) => Promise<void>;
   onCancel: () => void;
-  /** Optional slot for extra footer buttons (Clone / Delete in PR-B edit mode). */
+  /**
+   * Optional Clone action — only meaningful in `mode='edit'`. When set,
+   * a Clone button appears between Cancel and Resume in the footer; on
+   * click the form validates + bubbles the current values via this
+   * callback (the parent re-opens the modal in clone-prefilled state).
+   */
+  onClone?: (values: WorkspaceFormSubmit) => Promise<void>;
+  /**
+   * Optional Delete action — only meaningful in `mode='edit'`. When set,
+   * a Delete button appears on the far left of the footer. The parent
+   * is responsible for confirming + purging state.
+   */
+  onDelete?: (id: string) => Promise<void>;
+  /** Override the primary button label (e.g. "Save" instead of "Resume"). */
+  primaryLabel?: string;
+  /** Optional slot for extra footer buttons. */
   extraFooterLeft?: ReactNode;
 }
 
@@ -122,6 +137,9 @@ export function WorkspaceForm({
   vaultAvailable,
   onSubmit,
   onCancel,
+  onClone,
+  onDelete,
+  primaryLabel: primaryLabelOverride,
   extraFooterLeft
 }: Props) {
   const [name, setName] = useState(initial?.name ?? '');
@@ -167,11 +185,14 @@ export function WorkspaceForm({
   const [error, setError] = useState<string | null>(null);
   const [namePlaceholder] = useState<string>(petName);
 
-  // Fetch image library + default the image input on mount.
+  // Fetch image library on mount. Auto-default the image input only in
+  // create mode — edit mode preserves whatever the manifest had, including
+  // an empty value, so containerLevelChanged doesn't see a spurious
+  // diff when the user opens-and-saves an edit with no image change.
   useEffect(() => {
     window.api.images.list().then((entries: ImageEntry[]) => {
       setLibraryImages(entries);
-      if (!image) {
+      if (mode === 'create' && !image) {
         const recent = [...entries].sort((a, b) => b.lastUsedAt - a.lastUsedAt)[0];
         setImage(recent?.ref ?? DEFAULT_RUNNER_IMAGE);
       }
@@ -225,30 +246,40 @@ export function WorkspaceForm({
   const removeEnvRow = (i: number) =>
     setEnvRows((prev) => prev.filter((_, idx) => idx !== i));
 
-  const submit = async () => {
-    if (busy) return;
+  /**
+   * Validate the form and assemble a `WorkspaceFormSubmit`. Returns null
+   * when validation failed (the error state is set in that case).
+   * Shared by `submit` (primary action) and `clone` (Clone button).
+   * `skipNameClash` lets the Clone path defer the name-uniqueness check
+   * to the parent's auto-increment of `<source>-2`.
+   */
+  const buildPayload = (
+    opts: { skipNameClash?: boolean } = {}
+  ): WorkspaceFormSubmit | null => {
     if (kind === 'local') {
       setError("Local workspaces aren't implemented yet. Pick 'Container' for now.");
-      return;
+      return null;
     }
     if (!nameOk) {
       setError('Workspace name must be 1–80 chars with no control characters.');
-      return;
+      return null;
     }
-    const nameClash = workspaces.some(
-      (w) => w.name === effectiveName && w.state !== 'deleted' && w.id !== initial?.id
-    );
-    if (nameClash) {
-      setError(`A workspace named "${effectiveName}" already exists.`);
-      return;
+    if (!opts.skipNameClash) {
+      const nameClash = workspaces.some(
+        (w) => w.name === effectiveName && w.state !== 'deleted' && w.id !== initial?.id
+      );
+      if (nameClash) {
+        setError(`A workspace named "${effectiveName}" already exists.`);
+        return null;
+      }
     }
     if (!workspaceRoot.trim()) {
       setError('Workspace root is required.');
-      return;
+      return null;
     }
     if (kind === 'container' && !image.trim()) {
       setError('Image reference is required for a container workspace.');
-      return;
+      return null;
     }
 
     const seen = new Set<string>();
@@ -260,11 +291,11 @@ export function WorkspaceForm({
       if (!k) continue;
       if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
         setError(`Invalid env var name "${k}" — must match [A-Z_][A-Z0-9_]+ (POSIX style).`);
-        return;
+        return null;
       }
       if (seen.has(k)) {
         setError(`Duplicate env var "${k}".`);
-        return;
+        return null;
       }
       seen.add(k);
       if (row.secret) {
@@ -273,7 +304,7 @@ export function WorkspaceForm({
             `Secret env "${k}" requires the OS keychain, which isn't reachable. ` +
               `Switch the row to plain or install libsecret.`
           );
-          return;
+          return null;
         }
         secretKeys.push(k);
         // preExisting + empty value = user didn't change it; leave the
@@ -294,12 +325,34 @@ export function WorkspaceForm({
     if (Number.isFinite(cpusNum) && cpusNum > 0) resources = { ...(resources ?? {}), cpus: cpusNum };
     if (Number.isFinite(memNum) && memNum > 0) resources = { ...(resources ?? {}), memoryMb: memNum };
 
+    return {
+      id: initial?.id,
+      name: effectiveName,
+      description: description.trim() || undefined,
+      labels,
+      color: hue !== null ? { hue } : undefined,
+      workspaceRoot: workspaceRoot.trim(),
+      workspaceSubdir: workspaceSubdir.trim(),
+      kind,
+      image: kind === 'container' ? image.trim() : undefined,
+      authMode,
+      plainEnv,
+      secretKeys,
+      secrets,
+      resources
+    };
+  };
+
+  const submit = async () => {
+    if (busy) return;
+    const payload = buildPayload();
+    if (!payload) return;
     setBusy(true);
     setStatus(null);
     setError(null);
     try {
       if (mode === 'create') {
-        const ws = workspaceRoot.trim();
+        const ws = payload.workspaceRoot;
         const exists = await window.api.fs.isDirectory(ws);
         if (!exists) {
           const ok = window.confirm(`Workspace folder "${ws}" does not exist. Create it?`);
@@ -309,26 +362,42 @@ export function WorkspaceForm({
         }
         saveLastWorkspaceRoot(ws);
       }
+      await onSubmit(payload, setStatus);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+      setStatus(null);
+    }
+  };
 
-      await onSubmit(
-        {
-          id: initial?.id,
-          name: effectiveName,
-          description: description.trim() || undefined,
-          labels,
-          color: hue !== null ? { hue } : undefined,
-          workspaceRoot: workspaceRoot.trim(),
-          workspaceSubdir: workspaceSubdir.trim(),
-          kind,
-          image: kind === 'container' ? image.trim() : undefined,
-          authMode,
-          plainEnv,
-          secretKeys,
-          secrets,
-          resources
-        },
-        setStatus
-      );
+  const clone = async () => {
+    if (busy || !onClone) return;
+    // Clone defers the name-clash check to the parent's auto-incrementor
+    // (`<source>-2`, `-3`, …) — the user's current name will collide
+    // with the source workspace until the suffix lands.
+    const payload = buildPayload({ skipNameClash: true });
+    if (!payload) return;
+    setBusy(true);
+    setStatus(null);
+    setError(null);
+    try {
+      await onClone(payload);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(false);
+      setStatus(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (busy || !onDelete || !initial?.id) return;
+    setBusy(true);
+    setStatus(null);
+    setError(null);
+    try {
+      await onDelete(initial.id);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -338,7 +407,7 @@ export function WorkspaceForm({
   };
 
   const swatchStyle = hue !== null ? { background: `oklch(72% 0.14 ${hue})` } : undefined;
-  const primaryLabel = mode === 'create' ? 'Create & start' : 'Resume';
+  const primaryLabel = primaryLabelOverride ?? (mode === 'create' ? 'Create & start' : 'Resume');
 
   return (
     <div className="workspace-form">
@@ -665,9 +734,32 @@ export function WorkspaceForm({
       {error && <div className="form-hint error-text">{error}</div>}
       <div className="modal-footer">
         {extraFooterLeft}
+        {mode === 'edit' && onDelete && initial?.id && (
+          <button
+            type="button"
+            className="btn danger"
+            onClick={handleDelete}
+            disabled={busy}
+            title="Permanently delete this workspace"
+          >
+            <IconTrash /> Delete
+          </button>
+        )}
+        <span className="modal-footer-spacer" />
         <button className="btn" onClick={onCancel} disabled={busy}>
           Cancel
         </button>
+        {mode === 'edit' && onClone && (
+          <button
+            type="button"
+            className="btn"
+            onClick={clone}
+            disabled={busy}
+            title="Clone this workspace into a new one"
+          >
+            <IconCopy /> Clone
+          </button>
+        )}
         <button className="btn primary" onClick={submit} disabled={busy}>
           {busy ? 'Working…' : primaryLabel}
         </button>
@@ -793,5 +885,22 @@ function ImagePicker({ library, filter, onPick, busy }: ImagePickerProps) {
         </ul>
       )}
     </div>
+  );
+}
+
+function IconTrash(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M4 1 H8 V2 H11 V3 H1 V2 H4 Z M2 4 H10 L9 11 H3 Z" />
+    </svg>
+  );
+}
+
+function IconCopy(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <rect x="3" y="3" width="7" height="8" rx="0.8" />
+      <path d="M2 8 V2 a1 1 0 0 1 1 -1 H8" />
+    </svg>
   );
 }

--- a/src/renderer/src/components/WorkspaceModal.tsx
+++ b/src/renderer/src/components/WorkspaceModal.tsx
@@ -27,6 +27,37 @@ interface Props {
   onClose: () => void;
   onCreate: (submit: WorkspaceFormSubmit, setStatus: (msg: string | null) => void) => Promise<void>;
   onResume: (submit: WorkspaceFormSubmit, setStatus: (msg: string | null) => void) => Promise<void>;
+  /** Clone action from an expanded Saved row — opens the modal again with the New tab pre-filled. */
+  onClone: (source: WorkspaceFormSubmit) => Promise<void>;
+  /** Delete action from an expanded Saved row — caller shows a confirmation modal. */
+  onDelete: (workspace: WorkspaceSummary) => void;
+  /**
+   * Pre-fill the New tab with these values (used for Clone). Forces the
+   * default tab to 'new' and rebuilds the form's state from the values
+   * each time the modal opens with a non-null source.
+   */
+  initialNewTabValues?: Partial<WorkspaceFormSubmit & { id: string }> | null;
+}
+
+/**
+ * Auto-increment a base name to the first unused `<base>-N` (N ≥ 2)
+ * against the current workspace list. Stops at N = 999 to keep the
+ * loop bounded — in practice no fleet hits that.
+ */
+export function suggestCloneName(base: string, workspaces: WorkspaceSummary[]): string {
+  const taken = new Set(
+    workspaces
+      .filter((w) => w.state !== 'deleted')
+      .map((w) => w.name)
+  );
+  // Strip any existing `-N` suffix so cloning `foo-2` suggests `foo-3`
+  // (rather than `foo-2-2`).
+  const trimmed = base.replace(/-\d+$/, '');
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${trimmed}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${trimmed}-${Date.now()}`;
 }
 
 type TabKey = 'saved' | 'new';
@@ -50,7 +81,10 @@ export function WorkspaceModal({
   vaultAvailable,
   onClose,
   onCreate,
-  onResume
+  onResume,
+  onClone,
+  onDelete,
+  initialNewTabValues
 }: Props) {
   // Saved tab shows non-running workspaces (stopped + paused + deleted).
   // Running workspaces are edited from the chip ⋮ menu in PR-B.
@@ -59,17 +93,21 @@ export function WorkspaceModal({
     [workspaces]
   );
 
-  // Default tab: Saved when there are saved workspaces, else New.
-  // Re-pick the default each time the modal opens so an emptied-out Saved
-  // tab doesn't keep showing as the default after every row was started.
-  const [tab, setTab] = useState<TabKey>(saved.length > 0 ? 'saved' : 'new');
+  // Default tab: New when a clone source is provided, Saved when there
+  // are saved workspaces, else New. Re-pick each time the modal opens so
+  // an emptied-out Saved tab doesn't stick as the default after every
+  // row was started.
+  const defaultTab = (): TabKey =>
+    initialNewTabValues ? 'new' : saved.length > 0 ? 'saved' : 'new';
+  const [tab, setTab] = useState<TabKey>(defaultTab());
   const lastOpen = useRef(open);
   useEffect(() => {
     if (open && !lastOpen.current) {
-      setTab(saved.length > 0 ? 'saved' : 'new');
+      setTab(defaultTab());
     }
     lastOpen.current = open;
-  }, [open, saved.length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, saved.length, initialNewTabValues]);
 
   // Search state — Saved tab only.
   const [searchText, setSearchText] = useState('');
@@ -308,6 +346,22 @@ export function WorkspaceModal({
                                 vaultAvailable={vaultAvailable}
                                 onSubmit={handleResume}
                                 onCancel={() => setExpandedId(null)}
+                                onClone={async (submit) => {
+                                  // Parent updates `initialNewTabValues`;
+                                  // we collapse the row and switch tabs so
+                                  // the user lands on the pre-filled form.
+                                  // Form re-keys via the `key` prop in the
+                                  // New-tab render below.
+                                  await onClone(submit);
+                                  setExpandedId(null);
+                                  setTab('new');
+                                }}
+                                onDelete={async () => {
+                                  onDelete(w);
+                                  // Close modal so the confirmation modal
+                                  // takes the foreground.
+                                  onClose();
+                                }}
                               />
                             )}
                           </div>
@@ -322,7 +376,11 @@ export function WorkspaceModal({
         ) : (
           <div className="new-tab" role="tabpanel">
             <WorkspaceForm
+              // Re-key the form when a new clone source lands so the
+              // form's internal state resets to the new initial values.
+              key={initialNewTabValues ? `clone-${initialNewTabValues.id ?? initialNewTabValues.name}` : 'fresh'}
               mode="create"
+              initial={initialNewTabValues ?? undefined}
               workspaces={workspaces}
               vaultAvailable={vaultAvailable}
               onSubmit={handleCreate}

--- a/src/renderer/src/components/WorkspaceTabStrip.tsx
+++ b/src/renderer/src/components/WorkspaceTabStrip.tsx
@@ -19,6 +19,12 @@ interface Props {
   onNewWorkspace: () => void;
   /** Open the CloseWorkspaceModal for the given workspace (full close UX). */
   onCloseWorkspace: (workspace: WorkspaceSummary) => void;
+  /** Open the EditWorkspaceModal for the given workspace. */
+  onEditWorkspace: (workspace: WorkspaceSummary) => void;
+  /** Open the WorkspaceModal in Clone mode with this workspace as the source. */
+  onCloneWorkspace: (workspace: WorkspaceSummary) => void;
+  /** Open the DeleteWorkspaceModal (purge) — distinct from Close (keep state dir). */
+  onDeleteWorkspace: (workspace: WorkspaceSummary) => void;
   /** Re-pull workspace:list — called after a chip-menu action mutates state. */
   onRefresh: () => void;
 }
@@ -76,6 +82,28 @@ function IconEject(): JSX.Element {
     </svg>
   );
 }
+function IconEdit(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
+    </svg>
+  );
+}
+function IconCopy(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <rect x="3" y="3" width="7" height="8" rx="0.8" />
+      <path d="M2 8 V2 a1 1 0 0 1 1 -1 H8" />
+    </svg>
+  );
+}
+function IconTrash(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M4 1 H8 V2 H11 V3 H1 V2 H4 Z M2 4 H10 L9 11 H3 Z" />
+    </svg>
+  );
+}
 
 /**
  * Compute the screen-coordinate position of the menu, anchored to the
@@ -104,6 +132,9 @@ export function WorkspaceTabStrip({
   onSelect,
   onNewWorkspace,
   onCloseWorkspace,
+  onEditWorkspace,
+  onCloneWorkspace,
+  onDeleteWorkspace,
   onRefresh
 }: Props) {
   // Single open menu at a time. `for` = workspace id; top/right are
@@ -280,6 +311,27 @@ export function WorkspaceTabStrip({
             <div className="ws-chip-menu-divider" />
             <button
               role="menuitem"
+              onClick={() => {
+                setMenu(null);
+                onEditWorkspace(menuWorkspace);
+              }}
+            >
+              <IconEdit />
+              <span>Edit…</span>
+            </button>
+            <button
+              role="menuitem"
+              onClick={() => {
+                setMenu(null);
+                onCloneWorkspace(menuWorkspace);
+              }}
+            >
+              <IconCopy />
+              <span>Clone…</span>
+            </button>
+            <div className="ws-chip-menu-divider" />
+            <button
+              role="menuitem"
               className="danger"
               onClick={() => {
                 setMenu(null);
@@ -288,6 +340,18 @@ export function WorkspaceTabStrip({
             >
               <IconEject />
               <span>Close…</span>
+            </button>
+            <button
+              role="menuitem"
+              className="danger"
+              onClick={() => {
+                setMenu(null);
+                onDeleteWorkspace(menuWorkspace);
+              }}
+              title="Permanently delete (purges state dir + keychain entries)"
+            >
+              <IconTrash />
+              <span>Delete…</span>
             </button>
           </div>,
           document.body

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1629,3 +1629,39 @@ body {
   transform: translateY(0);
   padding: 4px 14px 14px;
 }
+
+/* ── PR-B: Clone/Delete footer, restart-banner ───────────────────────── */
+
+.modal-footer-spacer { flex: 1; }
+
+.btn.danger {
+  color: var(--state-error, #ef4d4d);
+  border-color: color-mix(in oklab, var(--state-error, #ef4d4d) 35%, var(--border, #2a2f38));
+}
+.btn.danger:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--state-error, #ef4d4d) 14%, transparent);
+}
+.btn.danger svg { color: var(--state-error, #ef4d4d); }
+
+.restart-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: color-mix(in oklab, var(--accent, #5fa1de) 14%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--accent, #5fa1de) 30%, transparent);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.restart-banner-text { flex: 1; }
+.restart-banner-btn { padding: 4px 12px; font-size: 12px; }
+.restart-banner-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.restart-banner-dismiss:hover { color: var(--text-primary); }

--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -151,9 +151,14 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       create: [],
       list: [],
       start: [],
+      stop: [],
+      pause: [],
+      remove: [],
       writeManifest: [],
       isDirectory: [],
-      mkdirp: []
+      mkdirp: [],
+      vaultSetSecret: [],
+      vaultDeleteAllForWorkspace: []
     };
 
     const channels = [
@@ -161,12 +166,21 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       'workspace:create',
       'workspace:list',
       'workspace:start',
+      'workspace:stop',
+      'workspace:pause',
+      'workspace:remove',
       'workspace:ping',
       'workspace:writeManifest',
       'images:list',
       'images:remove',
       'fs:isDirectory',
       'fs:mkdirp',
+      'vault:available',
+      'vault:listKeys',
+      'vault:getSecret',
+      'vault:setSecret',
+      'vault:deleteSecret',
+      'vault:deleteAllForWorkspace',
       'observability:summaryForWorkspace',
       'observability:summaryForBrokerSession',
       'observability:getCost',
@@ -241,6 +255,33 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
     ipcMain.handle('workspace:writeManifest', async (_e, spec: Record<string, unknown>) => {
       g.__calls.writeManifest.push(spec);
     });
+    ipcMain.handle('workspace:stop', async (_e, containerId: string) => {
+      g.__calls.stop.push(containerId);
+    });
+    ipcMain.handle('workspace:pause', async (_e, containerId: string) => {
+      g.__calls.pause.push(containerId);
+    });
+    ipcMain.handle(
+      'workspace:remove',
+      async (_e, containerId: string, removeOpts: { deleteState?: boolean } | undefined) => {
+        g.__calls.remove.push({ containerId, ...(removeOpts ?? {}) });
+      }
+    );
+    // Vault mocks — record but no persistence. Tests assert against the
+    // call list to verify Delete and secret-write flows.
+    ipcMain.handle('vault:available', () => true);
+    ipcMain.handle('vault:listKeys', (_e, _id: string) => []);
+    ipcMain.handle('vault:getSecret', (_e, _id: string, _key: string) => null);
+    ipcMain.handle('vault:setSecret', async (_e, id: string, key: string, value: string) => {
+      g.__calls.vaultSetSecret.push({ id, key, value });
+    });
+    ipcMain.handle('vault:deleteSecret', async (_e, _id: string, _key: string) => undefined);
+    ipcMain.handle(
+      'vault:deleteAllForWorkspace',
+      async (_e, id: string) => {
+        g.__calls.vaultDeleteAllForWorkspace.push(id);
+      }
+    );
     ipcMain.handle('fs:isDirectory', async (_e, p: string) => {
       g.__calls.isDirectory.push(p);
       return opts.isDirectoryReturns ?? true;

--- a/tests/workspace-actions.spec.ts
+++ b/tests/workspace-actions.spec.ts
@@ -1,0 +1,218 @@
+// PR-B coverage: chip ⋮ menu Edit / Clone / Delete entries, the new
+// EditWorkspaceModal + DeleteWorkspaceModal, the Clone flow (Saved-tab
+// row footer + chip menu both open the modal pre-filled), and the
+// restart-to-apply banner that appears for container-level edits.
+
+import { test, expect } from '@playwright/test';
+import { launch, mockMainIpc, getCalls } from './_helpers.js';
+
+const RUNNING_WS = {
+  id: '01TESTRUNNINGWORKSPACE0000',
+  name: 'happy-llama',
+  description: 'API server work',
+  labels: ['dev'],
+  state: 'running' as const,
+  containerId: 'fake-container-id',
+  workspaceRoot: '/tmp/happy-llama',
+  image: 'ghcr.io/imioimi/claude-fleet/runner:latest',
+  authMode: 'oauth' as const,
+  env: { plain: { FOO: 'bar' }, secretKeys: ['ANTHROPIC_API_KEY'] }
+};
+
+const STOPPED_WS = {
+  id: '01TESTSTOPPED0000000000000',
+  name: 'calm-otter',
+  description: 'Data pipeline',
+  labels: ['data'],
+  state: 'stopped' as const,
+  workspaceRoot: '/tmp/calm-otter',
+  image: 'ghcr.io/imioimi/claude-fleet/runner:latest'
+};
+
+async function openChipMenu(window: import('@playwright/test').Page, chipText: string) {
+  const group = window.locator('.ws-chip-group', { hasText: chipText });
+  await group.locator('.ws-chip-menu-trigger').click();
+  return window.locator('.ws-chip-menu');
+}
+
+test('Chip ⋮ menu: running workspace has Edit / Clone / Close / Delete entries', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    const menu = await openChipMenu(window, 'happy-llama');
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Edit…' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Clone…' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Close…' })).toBeVisible();
+    await expect(menu.getByRole('menuitem', { name: 'Delete…' })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Chip ⋮ Delete: opens the confirm modal, then purges container + state + vault', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Delete…' }).click();
+
+    // Confirmation modal appears.
+    await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeVisible();
+    await expect(window.locator('.modal').getByText(/Permanently delete/)).toBeVisible();
+
+    await window.getByRole('button', { name: 'Delete permanently' }).click();
+
+    // Wait for the modal to close before asserting calls — the modal
+    // closes only after stop + remove + vault all finish.
+    await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeHidden();
+
+    const calls = await getCalls(app);
+    expect(calls.stop).toContain(RUNNING_WS.containerId);
+    expect(calls.remove).toEqual([
+      { containerId: RUNNING_WS.containerId, deleteState: true }
+    ]);
+    expect(calls.vaultDeleteAllForWorkspace).toContain(RUNNING_WS.id);
+  } finally {
+    await app.close();
+  }
+});
+
+test('Chip ⋮ Clone: opens WorkspaceModal pre-filled with `<source>-2`', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Clone…' }).click();
+
+    // Modal opens to the New tab with the suggested clone name.
+    await expect(window.getByRole('tab', { name: 'New' })).toHaveAttribute('aria-selected', 'true');
+    await expect(window.getByLabel('Workspace name')).toHaveValue('happy-llama-2');
+    // Description carries over.
+    await expect(window.getByLabel('Workspace description')).toHaveValue('API server work');
+  } finally {
+    await app.close();
+  }
+});
+
+test('Saved-tab Delete: row Delete button opens confirm modal', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [STOPPED_WS] });
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+
+    const row = window.locator('.saved-row', { hasText: 'calm-otter' });
+    await row.locator('.saved-row-header').click();
+    await row.getByRole('button', { name: /Delete/ }).click();
+
+    // The Saved-tab Delete bubbles up, the workspace modal closes, and
+    // the confirmation modal opens at the top level.
+    await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Saved-tab Clone: row Clone button reopens the modal on New with suggested name', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [STOPPED_WS] });
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+
+    const row = window.locator('.saved-row', { hasText: 'calm-otter' });
+    await row.locator('.saved-row-header').click();
+    await row.getByRole('button', { name: /Clone/ }).click();
+
+    // Modal re-opens on New tab with `calm-otter-2` suggested.
+    await expect(window.getByRole('tab', { name: 'New' })).toHaveAttribute('aria-selected', 'true');
+    await expect(window.getByLabel('Workspace name')).toHaveValue('calm-otter-2');
+  } finally {
+    await app.close();
+  }
+});
+
+test('Chip ⋮ Edit: Save with no container-level changes does NOT show the restart banner', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    // Select the workspace so its TerminalPane is the visible one (the
+    // restart banner only renders inside the visible pane).
+    await window.locator('.ws-chip-group', { hasText: 'happy-llama' }).getByRole('button').first().click();
+
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Edit…' }).click();
+
+    // Edit modal opens.
+    await expect(window.locator('.modal-tab', { hasText: 'Edit happy-llama' })).toBeVisible();
+
+    // Change only render-only fields (description). Don't touch env/image/resources.
+    await window.getByLabel('Workspace description').fill('Edited description');
+
+    // Save.
+    await window.getByRole('button', { name: 'Save' }).click();
+    await expect(window.locator('.modal-tab', { hasText: 'Edit happy-llama' })).toBeHidden();
+
+    // writeManifest was called with the edited description.
+    const calls = await getCalls(app);
+    expect(calls.writeManifest).toHaveLength(1);
+    expect((calls.writeManifest[0] as { description: string }).description).toBe('Edited description');
+
+    // No restart banner — render-only edit.
+    await expect(window.locator('.restart-banner')).toBeHidden();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Chip ⋮ Edit: Save with container-level changes (image) shows the restart banner', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    await window.locator('.ws-chip-group', { hasText: 'happy-llama' }).getByRole('button').first().click();
+
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Edit…' }).click();
+
+    // Change the image — a container-level field.
+    const imageInput = window.getByLabel('Image reference');
+    await imageInput.fill('ghcr.io/imioimi/claude-fleet/runner:different');
+
+    await window.getByRole('button', { name: 'Save' }).click();
+    await expect(window.locator('.modal-tab', { hasText: 'Edit happy-llama' })).toBeHidden();
+
+    // Banner appears in the visible TerminalPane.
+    const banner = window.locator('.terminal-pane:not([aria-hidden="true"]) .restart-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Changes apply on next start');
+    await expect(banner.getByRole('button', { name: 'Restart now' })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Restart banner: Dismiss removes it; Restart now calls stop + start', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    await window.locator('.ws-chip-group', { hasText: 'happy-llama' }).getByRole('button').first().click();
+
+    // Open edit, change image, save → banner shows.
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Edit…' }).click();
+    await window.getByLabel('Image reference').fill('ghcr.io/imioimi/claude-fleet/runner:different');
+    await window.getByRole('button', { name: 'Save' }).click();
+
+    const banner = window.locator('.terminal-pane:not([aria-hidden="true"]) .restart-banner');
+    await expect(banner).toBeVisible();
+
+    // Restart now → stop + start fire; banner disappears.
+    await banner.getByRole('button', { name: 'Restart now' }).click();
+    await expect(banner).toBeHidden();
+
+    const calls = await getCalls(app);
+    expect(calls.stop).toContain(RUNNING_WS.containerId);
+    expect(calls.start).toContain(RUNNING_WS.id);
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/workspace-lifecycle.spec.ts
+++ b/tests/workspace-lifecycle.spec.ts
@@ -92,7 +92,8 @@ test('Saved tab: deleted workspace appears and Resume fires workspace:start', as
         {
           name: 'ghost-fox',
           state: 'deleted',
-          workspaceRoot: '/tmp/ghost-fox'
+          workspaceRoot: '/tmp/ghost-fox',
+          image: 'ghcr.io/imioimi/claude-fleet/runner:latest'
         }
       ]
     });

--- a/tests/workspace-modal.spec.ts
+++ b/tests/workspace-modal.spec.ts
@@ -4,6 +4,7 @@
 import { test, expect } from '@playwright/test';
 import { launch, mockMainIpc, getCalls } from './_helpers.js';
 
+const RUNNER = 'ghcr.io/imioimi/claude-fleet/runner:latest';
 const SAVED = [
   {
     id: '01TESTHAPPYLLAMA0000000000',
@@ -11,7 +12,8 @@ const SAVED = [
     description: 'API server work',
     labels: ['dev', 'api'],
     state: 'stopped' as const,
-    workspaceRoot: '/tmp/happy-llama'
+    workspaceRoot: '/tmp/happy-llama',
+    image: RUNNER
   },
   {
     id: '01TESTCALMOTTER000000000000',
@@ -19,7 +21,8 @@ const SAVED = [
     description: 'Data pipeline',
     labels: ['data'],
     state: 'stopped' as const,
-    workspaceRoot: '/tmp/calm-otter'
+    workspaceRoot: '/tmp/calm-otter',
+    image: RUNNER
   },
   {
     id: '01TESTBOLDFOX00000000000000',
@@ -27,7 +30,8 @@ const SAVED = [
     description: 'Frontend work',
     labels: ['dev', 'frontend'],
     state: 'stopped' as const,
-    workspaceRoot: '/tmp/bold-fox'
+    workspaceRoot: '/tmp/bold-fox',
+    image: RUNNER
   }
 ];
 


### PR DESCRIPTION
## Summary

Second of three PRs implementing [Phase 2 (Actions)](docs/design/workspace-modal.md) from the workspace-modal redesign (#56). Builds on PR-A's tabbed `WorkspaceModal` + `WorkspaceForm` scaffolding with the rest of the expanded-row footer actions and the live-workspace edit path.

- **`WorkspaceForm` footer** — Edit mode now renders `Delete · spacer · Cancel · Clone · primary`. Refactored `submit` into a shared `buildPayload({skipNameClash?})` pipeline reused by `clone`. The submit shape carries both `secretKeys` (full list, lands in `manifest.env.secretKeys`) and `secrets` (only newly-typed values for `vault.setSecret`).
- **`EditWorkspaceModal`** — single-purpose modal wrapping `WorkspaceForm` in edit mode, opened from the chip ⋮ menu Edit entry. Running workspaces aren't in the Saved tab by design, so they need a separate edit surface. On Save, `App.handleEditSave` persists secrets + `workspace:writeManifest`, then `containerLevelChanged` (exported helper) compares pre/post specs.
- **`DeleteWorkspaceModal`** — confirmation modal. On confirm: stop (if live) → `workspace:remove(containerId, { deleteState: true })` → `vault:deleteAllForWorkspace(id)`. Distinct from `CloseWorkspaceModal` which keeps the state dir.
- **Clone flow** — `App.openCloneFrom` is the central funnel: it strips id, auto-suggests `<source>-N` (`suggestCloneName` exported from `WorkspaceModal`), clears the color so a fresh hue is picked. The modal re-opens on the New tab pre-filled. Used by the Saved-row Clone button, the chip ⋮ Clone entry, and `EditWorkspaceModal`'s Clone button.
- **Chip ⋮ menu** — adds Edit / Clone / Delete entries alongside Pause/Stop/Start/Close.
- **Restart-to-apply banner** in `TerminalPane` — "Changes apply on next start. **[Restart now]** [×]" — shown when `EditWorkspaceModal` saves changes to any container-level field (env, image, authMode, resources) on a running/paused workspace. Render-only edits (name, description, labels, color) take effect immediately and never trigger the banner. Restart-now fires `workspace:stop` + `workspace:start`; dismiss clears without restart. Banner state keyed by workspace id so chip switches don't lose it.

## Out of scope (deferred)

- **PR-C** — Advanced image search modal opened by the magnifying-glass icon next to the Image field.

## Test plan

- [x] `npm run typecheck` — main + renderer clean
- [x] `npm run test:unit` — 40 unit tests passing
- [x] `npm run test:e2e` — 58 e2e passing (50 from PR-A + 8 new in `tests/workspace-actions.spec.ts` covering chip menu Edit / Clone / Delete entries, confirm modal behavior, container-level vs render-only banner triggering, and the banner's Restart/Dismiss actions)
- [x] `npm run build` — main + preload + renderer all clean
- [ ] **Reviewer** (mock mode): `CLAUDE_FLEET_MOCK=1 npm run dev`. From a running `mock-alpha` workspace, open chip ⋮ → Edit, change the image, Save → confirm restart banner appears in the terminal pane; click Restart now → banner clears. Repeat with only a description change → no banner.
- [ ] **Reviewer** (mock mode): chip ⋮ → Clone → modal opens on New tab with `mock-alpha-2` suggested + description carried over.
- [ ] **Reviewer** (mock mode): chip ⋮ → Delete → confirmation modal with explicit warning text; on confirm the workspace disappears from the strip.
- [ ] **Reviewer** (real Docker): create a workspace with an env var, edit it, save → restart banner; restart now; verify the new env reaches `claude`. Clone it, confirm the new ULID gets a fresh hue + suggested name.
- [ ] **Spec check**: `docs/SPEC.md` §5 (modal list grows EditWorkspaceModal + DeleteWorkspaceModal), §8 (Saved-tab Clone + Delete row footer, chip ⋮ menu, restart banner, user-flow renumbering), §10 (source tree).

Refs #56 (partial — PR 2 of 3). PR-C is the advanced image search modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)