### PR TITLE
Advanced image search modal (Phase 2 PR 3/3)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -396,7 +396,7 @@ Values are read from the renderer only on explicit `vault:getSecret`; during nor
 7. **Cancel** in the expanded form collapses the row without applying changes.
 6. The **New** tab is the Create form. The user fills:
    - **Type** radio: Container (default — isolated Docker runner) or Local ("coming soon" — submit throws).
-   - For Container, an **Image** input appears with the inline image-library picker beneath it (default = most-recently-used library entry, or the bundled runner).
+   - For Container, an **Image** input appears with the inline image-library picker beneath it (default = most-recently-used library entry, or the bundled runner). A magnifying-glass button right of the input opens **`AdvancedImageSearchModal`** — a focused search surface mirroring the Saved-tab Variant-B shape (text input matches ref + digest, **Tags** dropdown filters by the `:tag` segment with OR semantics + pills). Each row in the list also surfaces which workspaces currently use the image (stopped consumers called out in warning color), so pinning a specific build is informed.
    - **Name** with pet-name placeholder and a **color swatch** to the left (popover with 14 OKLCH preset hues + Random). The swatch is dashed when no hue has been picked — `WorkspaceTabStrip` falls back to a name-hash of the same palette in that case so the chip still gets a stable distinct color.
    - **Description** textarea (optional).
    - **Labels** chip input with `<datalist>` autocomplete drawn from every other workspace's `labels[]`. Used for filtering in the Saved-tab list (PR 2 surface).
@@ -535,6 +535,7 @@ claude-fleet/
                 ├── WorkspaceForm.tsx      # reusable form (color, description, labels, env, resources); mode-aware
                 ├── EditWorkspaceModal.tsx # single-purpose edit modal for live workspaces (chip ⋮ Edit)
                 ├── DeleteWorkspaceModal.tsx # confirm modal: stop + remove + purge keytar
+                ├── AdvancedImageSearchModal.tsx # magnifying-glass next to Image: ref/digest search + Tags filter
                 └── CloseWorkspaceModal.tsx
 ```
 

--- a/src/renderer/src/components/AdvancedImageSearchModal.tsx
+++ b/src/renderer/src/components/AdvancedImageSearchModal.tsx
@@ -1,0 +1,320 @@
+// Advanced image search modal — the magnifying-glass affordance next
+// to the Image input in WorkspaceForm. Mirrors the Saved-workspaces
+// Variant-B search shape: text input (matches ref + digest) + Tags
+// dropdown filter (OR semantics) + active filter pills.
+//
+// Each row also surfaces which workspaces currently use the image —
+// including stopped/deleted ones called out in warning color — so the
+// user can spot when "pinning" a specific build will impact existing
+// work.
+
+import { useEffect, useMemo, useState } from 'react';
+import type { WorkspaceSummary } from '../App';
+
+export interface ImageEntry {
+  ref: string;
+  digest?: string;
+  labels: Record<string, string>;
+  firstUsedAt: number;
+  lastUsedAt: number;
+  useCount: number;
+}
+
+interface Props {
+  open: boolean;
+  library: ImageEntry[];
+  workspaces: WorkspaceSummary[];
+  /** Used to highlight the currently-selected image. */
+  currentImage?: string;
+  onPick: (ref: string) => void;
+  onClose: () => void;
+}
+
+/** Parse the `:tag` suffix from an image ref. Defaults to "latest". */
+export function parseTag(ref: string): string {
+  // `:[tag]` at the end, with no `/` or `:` in the tag itself. Works
+  // for both `image:tag` and `host/path/image:tag`; misses tag for
+  // digest-pinned refs (`ref@sha256:…`), which fall back to 'latest'.
+  const m = ref.match(/:([^/:]+)$/);
+  return m ? m[1] : 'latest';
+}
+
+function relativeTime(ms: number): string {
+  const delta = Date.now() - ms;
+  if (delta < 60_000) return 'just now';
+  const m = Math.floor(delta / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30);
+  return `${mo}mo ago`;
+}
+
+function shortDigest(d: string | undefined): string {
+  if (!d) return '';
+  // Strip the algorithm prefix (sha256:…) and keep the first 12 hex chars.
+  const colonIdx = d.indexOf(':');
+  const hex = colonIdx >= 0 ? d.slice(colonIdx + 1) : d;
+  return hex.slice(0, 12);
+}
+
+export function AdvancedImageSearchModal({
+  open,
+  library,
+  workspaces,
+  currentImage,
+  onPick,
+  onClose
+}: Props) {
+  const [searchText, setSearchText] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagsDropdownOpen, setTagsDropdownOpen] = useState(false);
+
+  // Reset state each time the modal opens.
+  useEffect(() => {
+    if (open) {
+      setSearchText('');
+      setSelectedTags([]);
+      setTagsDropdownOpen(false);
+    }
+  }, [open]);
+
+  // Close the tags dropdown on outside-click / Escape.
+  useEffect(() => {
+    if (!tagsDropdownOpen) return;
+    const close = (e: MouseEvent | KeyboardEvent): void => {
+      if (e instanceof KeyboardEvent && e.key !== 'Escape') return;
+      setTagsDropdownOpen(false);
+    };
+    document.addEventListener('click', close);
+    document.addEventListener('keydown', close);
+    return () => {
+      document.removeEventListener('click', close);
+      document.removeEventListener('keydown', close);
+    };
+  }, [tagsDropdownOpen]);
+
+  // All tags in the library with usage counts. Sorted alphabetically;
+  // `latest` is conventionally most common so it floats to the top by
+  // count when shared.
+  const tagCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const img of library) {
+      const tag = parseTag(img.ref);
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [library]);
+
+  // Group workspaces by image ref so each row can show its consumers.
+  const workspacesByImage = useMemo(() => {
+    const m = new Map<string, WorkspaceSummary[]>();
+    for (const w of workspaces) {
+      if (!w.image) continue;
+      const list = m.get(w.image) ?? [];
+      list.push(w);
+      m.set(w.image, list);
+    }
+    return m;
+  }, [workspaces]);
+
+  const filtered = useMemo(() => {
+    const needle = searchText.trim().toLowerCase();
+    return library.filter((img) => {
+      if (needle) {
+        const hay = `${img.ref} ${img.digest ?? ''}`.toLowerCase();
+        if (!hay.includes(needle)) return false;
+      }
+      if (selectedTags.length > 0) {
+        const tag = parseTag(img.ref);
+        if (!selectedTags.includes(tag)) return false;
+      }
+      return true;
+    });
+  }, [library, searchText, selectedTags]);
+
+  const sorted = useMemo(
+    () => [...filtered].sort((a, b) => b.lastUsedAt - a.lastUsedAt),
+    [filtered]
+  );
+
+  if (!open) return null;
+
+  const toggleTag = (t: string): void =>
+    setSelectedTags((prev) =>
+      prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]
+    );
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-tabs" role="tablist">
+          <div className="modal-tab active" aria-current="page">
+            Image library
+          </div>
+          {library.length > 0 && (
+            <span className="modal-tab-count" style={{ alignSelf: 'center' }}>
+              {library.length}
+            </span>
+          )}
+        </div>
+        <div className="saved-tab" role="tabpanel">
+          <div className="saved-search">
+            <input
+              type="text"
+              aria-label="Search image library"
+              placeholder="Search ref or digest…"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+            />
+            <div className="labels-filter">
+              <button
+                type="button"
+                className={`btn labels-button ${selectedTags.length ? 'active' : ''}`}
+                aria-expanded={tagsDropdownOpen}
+                aria-haspopup="menu"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setTagsDropdownOpen((v) => !v);
+                }}
+                disabled={tagCounts.length === 0}
+                title={tagCounts.length === 0 ? 'No tags yet' : 'Filter by tag'}
+              >
+                Tags
+                {selectedTags.length > 0 && (
+                  <span className="labels-count">{selectedTags.length}</span>
+                )}
+              </button>
+              {tagsDropdownOpen && (
+                <div
+                  className="labels-dropdown"
+                  role="menu"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {tagCounts.map(([tag, count]) => (
+                    <label key={tag} className="labels-dropdown-row">
+                      <input
+                        type="checkbox"
+                        checked={selectedTags.includes(tag)}
+                        onChange={() => toggleTag(tag)}
+                      />
+                      <span className="labels-dropdown-name">{tag}</span>
+                      <span className="labels-dropdown-count">{count}</span>
+                    </label>
+                  ))}
+                  {selectedTags.length > 0 && (
+                    <div className="labels-dropdown-footer">
+                      <button
+                        type="button"
+                        className="labels-dropdown-clear"
+                        onClick={() => setSelectedTags([])}
+                      >
+                        Clear all
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {(selectedTags.length > 0 || sorted.length !== library.length) && (
+            <div className="saved-active-filters">
+              {selectedTags.map((t) => (
+                <span key={t} className="filter-pill">
+                  {t}
+                  <button
+                    type="button"
+                    aria-label={`Remove tag filter ${t}`}
+                    onClick={() => toggleTag(t)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              <span className="saved-count">
+                {sorted.length} of {library.length}
+              </span>
+            </div>
+          )}
+
+          {sorted.length === 0 ? (
+            <div className="saved-empty">
+              <p>
+                {library.length === 0
+                  ? 'No images recorded yet. The first workspace create populates the library.'
+                  : 'No images match the current filter.'}
+              </p>
+            </div>
+          ) : (
+            <ul className="image-search-list">
+              {sorted.map((img) => {
+                const tag = parseTag(img.ref);
+                const users = workspacesByImage.get(img.ref) ?? [];
+                const isCurrent = img.ref === currentImage;
+                return (
+                  <li
+                    key={img.ref}
+                    className={`image-search-row ${isCurrent ? 'current' : ''}`}
+                  >
+                    <button
+                      type="button"
+                      className="image-search-row-button"
+                      onClick={() => {
+                        onPick(img.ref);
+                        onClose();
+                      }}
+                      title={img.ref}
+                    >
+                      <div className="image-search-row-top">
+                        <span className="image-search-ref">{img.ref}</span>
+                        <span className="image-search-tag-chip">{tag}</span>
+                      </div>
+                      <div className="image-search-row-meta">
+                        {img.digest && (
+                          <span className="image-search-digest" title={img.digest}>
+                            digest <code>{shortDigest(img.digest)}</code>
+                          </span>
+                        )}
+                        <span className="image-search-when">
+                          last used {relativeTime(img.lastUsedAt)}
+                        </span>
+                      </div>
+                      {users.length > 0 && (
+                        <div className="image-search-users">
+                          used by{' '}
+                          {users.map((w, i) => (
+                            <span key={w.id}>
+                              {i > 0 && ', '}
+                              <span
+                                className={`image-search-user ws-state ${w.state}`}
+                                title={w.state}
+                              >
+                                {w.name}
+                              </span>
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function IconSearch(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+      <circle cx="5" cy="5" r="3.2" />
+      <path d="M7.5 7.5 L10 10" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/renderer/src/components/WorkspaceForm.tsx
+++ b/src/renderer/src/components/WorkspaceForm.tsx
@@ -15,6 +15,7 @@ import type {
   WorkspaceResources,
   WorkspaceSummary
 } from '../App';
+import { AdvancedImageSearchModal, IconSearch } from './AdvancedImageSearchModal';
 
 export type WorkspaceKind = 'container' | 'local';
 
@@ -180,6 +181,7 @@ export function WorkspaceForm({
   const [kind, setKind] = useState<WorkspaceKind>(initial?.kind ?? 'container');
   const [image, setImage] = useState<string>(initial?.image ?? '');
   const [libraryImages, setLibraryImages] = useState<ImageEntry[]>([]);
+  const [imageSearchOpen, setImageSearchOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -444,18 +446,38 @@ export function WorkspaceForm({
       {kind === 'container' && (
         <div className="form-row">
           <label>Image</label>
-          <input
-            aria-label="Image reference"
-            value={image}
-            onChange={(e) => setImage(e.target.value)}
-            placeholder={DEFAULT_RUNNER_IMAGE}
-            disabled={busy}
-          />
+          <div className="input-with-button">
+            <input
+              aria-label="Image reference"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              placeholder={DEFAULT_RUNNER_IMAGE}
+              disabled={busy}
+            />
+            <button
+              type="button"
+              className="image-search-trigger"
+              aria-label="Open advanced image search"
+              title="Search past images"
+              onClick={() => setImageSearchOpen(true)}
+              disabled={busy}
+            >
+              <IconSearch />
+            </button>
+          </div>
           <ImagePicker
             library={libraryImages}
             filter={image}
             onPick={setImage}
             busy={busy}
+          />
+          <AdvancedImageSearchModal
+            open={imageSearchOpen}
+            library={libraryImages}
+            workspaces={workspaces}
+            currentImage={image}
+            onPick={setImage}
+            onClose={() => setImageSearchOpen(false)}
           />
         </div>
       )}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1665,3 +1665,108 @@ body {
   line-height: 1;
 }
 .restart-banner-dismiss:hover { color: var(--text-primary); }
+
+/* ── PR-C: Advanced image search modal ───────────────────────────── */
+
+.image-search-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  background: transparent;
+  border: 1px solid var(--border, #2a2f38);
+  border-left: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 0 6px 6px 0;
+}
+.image-search-trigger:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-card, #181c24);
+}
+.image-search-trigger:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.image-search-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.image-search-row {
+  border: 1px solid var(--border, #2a2f38);
+  border-radius: 8px;
+  background: var(--bg-card, #181c24);
+  overflow: hidden;
+}
+.image-search-row.current { border-color: var(--accent, #5fa1de); }
+.image-search-row-button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.image-search-row-button:hover { background: var(--bg-hover, #1a1e26); }
+
+.image-search-row-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.image-search-ref {
+  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.image-search-tag-chip {
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--bg-input, #11151c);
+  border: 1px solid var(--border, #2a2f38);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.image-search-row-meta {
+  display: flex;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.image-search-digest code {
+  font-size: 10px;
+  background: var(--bg-input, #11151c);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.image-search-users {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.image-search-user {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--bg-input, #11151c);
+}
+.image-search-user.ws-state.stopped,
+.image-search-user.ws-state.paused,
+.image-search-user.ws-state.deleted {
+  color: var(--state-warn, #d3b964);
+  border: 1px solid color-mix(in oklab, var(--state-warn, #d3b964) 30%, transparent);
+}

--- a/tests/advanced-image-search.spec.ts
+++ b/tests/advanced-image-search.spec.ts
@@ -1,0 +1,158 @@
+// Advanced image search modal — opened by the magnifying-glass icon
+// next to the Image input in WorkspaceForm. Tests cover the modal's
+// open/close, text + tag filtering, the per-row "used by" annotation
+// (with warning styling for stopped consumers), and the pick action.
+
+import { test, expect } from '@playwright/test';
+import { launch, mockMainIpc } from './_helpers.js';
+
+const IMAGES = [
+  {
+    ref: 'ghcr.io/imioimi/claude-fleet/runner:latest',
+    digest: 'sha256:abcdef1234567890aaaabbbbccccdddd',
+    labels: { 'com.claude-fleet.kind': 'runner', language: 'node' }
+  },
+  {
+    ref: 'docker.io/library/python:3.12-slim',
+    digest: 'sha256:1111222233334444aaaabbbbccccdddd',
+    labels: { language: 'python', purpose: 'data-science' }
+  },
+  {
+    ref: 'docker.io/library/golang:1.22',
+    digest: 'sha256:5555666677778888aaaabbbbccccdddd',
+    labels: { language: 'go', purpose: 'backend' }
+  }
+];
+
+async function openSearchModal(window: import('@playwright/test').Page) {
+  await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+  // Make sure we're on the New tab (default when no saved workspaces).
+  await expect(window.getByRole('tab', { name: 'New' })).toHaveAttribute('aria-selected', 'true');
+  await window.getByRole('button', { name: 'Open advanced image search' }).click();
+}
+
+test('Advanced image search: trigger opens the modal listing every library entry', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { imageLibrary: IMAGES });
+    await openSearchModal(window);
+
+    await expect(window.locator('.modal-tab', { hasText: 'Image library' })).toBeVisible();
+    for (const img of IMAGES) {
+      await expect(window.locator('.image-search-row', { hasText: img.ref })).toBeVisible();
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test('Advanced image search: text input filters across ref and digest', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { imageLibrary: IMAGES });
+    await openSearchModal(window);
+
+    const search = window.getByLabel('Search image library');
+
+    // Ref substring.
+    await search.fill('python');
+    await expect(window.locator('.image-search-row', { hasText: 'python:3.12-slim' })).toBeVisible();
+    await expect(window.locator('.image-search-row', { hasText: 'runner:latest' })).toBeHidden();
+
+    // Digest prefix — pick the first 8 hex chars of the golang image.
+    await search.fill('55556666');
+    await expect(window.locator('.image-search-row', { hasText: 'golang:1.22' })).toBeVisible();
+    await expect(window.locator('.image-search-row', { hasText: 'python:3.12-slim' })).toBeHidden();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Advanced image search: Tags dropdown filters with OR semantics + pills', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { imageLibrary: IMAGES });
+    await openSearchModal(window);
+
+    await window.getByRole('button', { name: /Tags/ }).click();
+    const dropdown = window.locator('.labels-dropdown');
+    await expect(dropdown).toBeVisible();
+
+    // Pick `latest` → matches runner only.
+    await dropdown.locator('.labels-dropdown-row', { hasText: 'latest' }).click();
+    await expect(window.locator('.image-search-row', { hasText: 'runner:latest' })).toBeVisible();
+    await expect(window.locator('.image-search-row', { hasText: 'python:3.12-slim' })).toBeHidden();
+    await expect(window.locator('.image-search-row', { hasText: 'golang:1.22' })).toBeHidden();
+
+    // Add `3.12-slim` → OR with latest, matches both.
+    await dropdown.locator('.labels-dropdown-row', { hasText: '3.12-slim' }).click();
+    await expect(window.locator('.image-search-row', { hasText: 'runner:latest' })).toBeVisible();
+    await expect(window.locator('.image-search-row', { hasText: 'python:3.12-slim' })).toBeVisible();
+
+    // Filter pills appear.
+    await expect(window.locator('.filter-pill', { hasText: 'latest' })).toBeVisible();
+    await expect(window.locator('.filter-pill', { hasText: '3.12-slim' })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Advanced image search: clicking a row picks the image and closes the modal', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { imageLibrary: IMAGES });
+    await openSearchModal(window);
+
+    await window.locator('.image-search-row', { hasText: 'python:3.12-slim' }).locator('button').click();
+
+    // Modal closed.
+    await expect(window.locator('.modal-tab', { hasText: 'Image library' })).toBeHidden();
+
+    // Image input now reflects the picked ref.
+    await expect(window.getByLabel('Image reference')).toHaveValue(
+      'docker.io/library/python:3.12-slim'
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('Advanced image search: each row surfaces workspaces using the image, stopped ones flagged', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, {
+      imageLibrary: IMAGES,
+      // Two workspaces using the python image — one running, one stopped.
+      workspaceList: [
+        {
+          id: '01ALPHARUNNING0000000000WS',
+          name: 'alpha-running',
+          state: 'running',
+          workspaceRoot: '/tmp/alpha',
+          image: 'docker.io/library/python:3.12-slim'
+        },
+        {
+          id: '01BETAPAUSED000000000000WS',
+          name: 'beta-stopped',
+          state: 'stopped',
+          workspaceRoot: '/tmp/beta',
+          image: 'docker.io/library/python:3.12-slim'
+        }
+      ]
+    });
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+    // Workspaces exist → Saved tab is default; switch to New first.
+    await window.getByRole('tab', { name: 'New' }).click();
+    await window.getByRole('button', { name: 'Open advanced image search' }).click();
+
+    const pythonRow = window.locator('.image-search-row', { hasText: 'python:3.12-slim' });
+    await expect(pythonRow.getByText('alpha-running')).toBeVisible();
+    await expect(pythonRow.getByText('beta-stopped')).toBeVisible();
+
+    // The stopped consumer has the warning styling.
+    const beta = pythonRow.locator('.image-search-user', { hasText: 'beta-stopped' });
+    await expect(beta).toHaveClass(/stopped/);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary

Third and final PR for [Phase 2 (Actions)](docs/design/workspace-modal.md) of the workspace-modal redesign (#56). Adds the magnifying-glass affordance + dedicated search modal alongside the inline picker that's been there since Foundation.

- **`AdvancedImageSearchModal`** — mirrors the Saved-tab Variant-B shape: split bar with a text input (matches ref + digest, case-insensitive) + **Tags** dropdown (checkbox list of every `:tag` segment in the library with OR semantics + count badges + clear-all). Active filters surface as removable pills above the list with an `N of M` count on the right.
- **Per-row display**: ref, tag chip, short digest (12 hex chars), last-used relative time, and the workspaces using the image. Stopped consumers are rendered in warning color so the user can spot when "pinning" a specific build will impact existing work.
- **Pick** fills the form's Image input and closes the modal.
- **`parseTag(ref)`** exported helper — defaults to `latest` for refs without an explicit tag (including digest-pinned ones).
- **`WorkspaceForm`** — Image input grows a search trigger button (IconSearch) on the right; click opens the modal with the library + workspaces.

## Test plan

- [x] `npm run typecheck` — main + renderer clean
- [x] `npm run test:unit` — 40 unit tests passing
- [x] `npm run test:e2e` — 63 e2e passing (58 existing + 5 new in `tests/advanced-image-search.spec.ts` covering trigger, text-and-digest filtering, Tags OR-filter + pills, pick action, and the "used by" annotation including stopped-consumer warning color)
- [x] `npm run build` — clean
- [ ] **Reviewer** (mock mode): `CLAUDE_FLEET_MOCK=1 npm run dev`. Open + New workspace → New tab → click the search icon. Filter by `python` or by the `latest` tag. Click an image; confirm the input updates + modal closes.
- [ ] **Reviewer** (real Docker): create a workspace pinned to a non-`latest` tag; reopen the modal and confirm the row shows that workspace in its "used by" list.
- [ ] **Spec check**: `docs/SPEC.md` §8 (Create-flow Image field), §10 (source tree adds `AdvancedImageSearchModal.tsx`).

Refs #56 (PR 3 of 3). Closes #56 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)