### PR TITLE
Shared OAuth credentials: one login covers every OAuth workspace (#57)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -298,7 +298,7 @@ Today the only workspace backend is a Docker container. The container name is `c
 ### Docker container shape
 - `Tty: true`, `OpenStdin: true`, `StdinOnce: false` — required for interactive `docker exec` later.
 - `WorkingDir: /workspace/${subdir}` (or `/workspace` if subdir is empty).
-- Binds: `${workspaceRoot}:/workspace:rw` (the user's host dir), `<userData>/state/<id>/.claude:/home/fleet/.claude:rw` (per-workspace persistent Claude state), and `<userData>/state/<id>/broker:/run/broker:rw` (the directory the in-container broker creates its Unix socket in).
+- Binds: `${workspaceRoot}:/workspace:rw` (the user's host dir), `<userData>/state/<id>/.claude:/home/fleet/.claude:rw` (per-workspace persistent Claude state), and `<userData>/state/<id>/broker:/run/broker:rw` (the directory the in-container broker creates its Unix socket in). When `authMode === 'oauth'`, one additional **file-bind** is layered on top of the `.claude` dir bind: `<userData>/claude-shared/.credentials.json:/home/fleet/.claude/.credentials.json:rw` — so the first workspace's Claude.ai login covers every subsequent one and token refresh in any workspace propagates to all of them. The shared host file is created (touched empty) by `docker.ts:ensureSharedCredentialsFile()` before the container starts, because Docker refuses to file-bind a missing host path. `apikey` workspaces don't get the file-bind — auth comes via `ANTHROPIC_API_KEY` in the env.
 - Env: `manifest.env.plain` merged with secret values resolved at create time via `vault.resolveEnv(id, plain, secretKeys)` (missing secret keys resolve to the empty string so the container still starts; claude itself surfaces the auth failure). `HOME=/home/fleet` is also set so tooling finds the bind-mounted `.claude/`.
 - `User: <hostUid>:<hostGid>` so bind-mounted files are owned by the host user.
 - Optional resource limits: `cpus` (→ `NanoCpus`), `memoryMb` (→ `Memory`).
@@ -379,7 +379,10 @@ Values are read from the renderer only on explicit `vault:getSecret`; during nor
 
 ### Startup
 1. Main creates the window, registers IPC handlers.
-2. Before any IPC traffic, main runs `runStartupMigration()` from `src/main/migration.ts`. This is idempotent: legacy name-keyed state dirs get a fresh ULID and the dir is renamed in place (with the manifest rewritten to the new shape — `authMode='oauth'`, empty `env`, etc.), and any keytar entry under `service=claude-fleet` whose account doesn't fit the new `<id>:<key>` / `__secrets__:<id>` shape is deleted (`__profiles__:*` purge). Re-running the migration on an already-migrated install is a no-op.
+2. Before any IPC traffic, main runs `runStartupMigration()` from `src/main/migration.ts`. Three idempotent passes:
+   1. Legacy name-keyed state dirs get a fresh ULID and the dir is renamed in place (with the manifest rewritten to the new shape — `authMode='oauth'`, empty `env`, etc.).
+   2. Any keytar entry under `service=claude-fleet` whose account doesn't fit the new `<id>:<key>` / `__secrets__:<id>` shape is deleted (`__profiles__:*` purge).
+   3. **OAuth credentials consolidation** (Phase 3, #57): every workspace's per-workspace `.claude/.credentials.json` that's a *real non-empty file* (not a symlink, not empty) is folded into the shared file at `<userData>/claude-shared/.credentials.json`. If the shared file doesn't exist (or is empty) and at least one workspace has real credentials, the most-recently-modified one is promoted to the shared path; the others are backed up as `.credentials.json.old`. Every per-workspace path becomes a symlink to the shared file so the host-side filesystem reflects reality.
 3. Renderer mounts; on first render it calls `workspace:ping`. If false, the main pane shows "Docker daemon unreachable — start Docker Desktop (with WSL2 integration)."
 4. If reachable, renderer calls `workspace:list` and polls every 5s thereafter to pick up state changes from outside the app. The list includes live workspaces (running/stopped) and deleted workspaces (manifest on disk, no container). The renderer keys selection by the ULID `id`; `containerId` is present only for live workspaces and is what stop/pause/remove/attach take.
 
@@ -820,11 +823,13 @@ A local-build fallback (`docker build` from the bundled `docker/` dir) is useful
 - **Pull progress UI.** Whether the first-run pull is blocking (modal with progress bar) or background (spinner + queued container-create).
 
 ### How `claude` authenticates inside the container
-Two modes, picked at create-container time:
+Two modes, picked at create-container time via `manifest.authMode`:
 
-- **API key**: profile carries an `apiKey`; container env includes `ANTHROPIC_API_KEY` at create time. Used when the user has a Console API key.
-- **OAuth (Claude.ai Pro/Max)**: profile-name field is left blank in the create flow. No `ANTHROPIC_API_KEY` is injected; the first time `claude` runs in the terminal it prints a login code, the user completes the flow in their browser, and OAuth tokens are written to `<container-state>/.claude/.credentials.json` (host side, via the bind-mount from #1). Future sessions in this container — or in a recreated container with the same name — pick up the credentials automatically.
+- **API key**: env contains `ANTHROPIC_API_KEY` (typically as a secret env var resolved from the per-workspace vault entry at container-start time). Used when the user has a Console API key.
+- **OAuth (Claude.ai Pro/Max)**: no `ANTHROPIC_API_KEY` is injected. A single shared credentials file at `<userData>/claude-shared/.credentials.json` is file-bound into every OAuth workspace as `/home/fleet/.claude/.credentials.json` (layered on top of the per-workspace `.claude` dir bind). The first OAuth workspace's run of `claude` prints a login code; the user completes the flow in their browser; OAuth tokens land in the shared file. Every subsequent OAuth workspace mounts the same file and skips the browser dance. Token refresh in any workspace updates the shared file in place and propagates to all of them.
 
 Claude Code's auth precedence puts `ANTHROPIC_API_KEY` ahead of OAuth tokens, which is why API-key and OAuth modes are mutually exclusive at the env-injection level: OAuth mode skips the env var entirely so the OAuth path is reached.
 
-**Open** (none right now — both modes are wired up).
+**Non-goals (deferred):**
+- Per-workspace OAuth isolation (a different Claude.ai account per workspace). A future `oauthIsolated: boolean` setting could opt a workspace out of the shared bind in favor of a per-workspace file. Not built because nobody's asked for it yet.
+- Multiple Claude.ai accounts simultaneously.

--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -12,16 +12,18 @@
 // the user renames the workspace's label. Lookup is always by label.
 
 import Docker from 'dockerode';
-import { mkdir, rm, stat } from 'node:fs/promises';
+import { mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import type { Duplex } from 'node:stream';
 import {
   assertValidWorkspaceId,
+  sharedClaudeCredentialsPath,
   workspaceBrokerDir,
   workspaceBrokerSocket,
   workspaceClaudeDir,
   workspaceStateDir
 } from './paths.js';
-import type { Workspace, WorkspaceEnv, WorkspaceResources } from './workspaces.js';
+import type { AuthMode, Workspace, WorkspaceEnv, WorkspaceResources } from './workspaces.js';
 import { BrokerClient, brokerPtyStream } from './broker.js';
 import { recordPendingAttach } from './pendingAttaches.js';
 import { resolveEnv } from './vault.js';
@@ -49,6 +51,14 @@ export interface CreateWorkspaceInput {
   /** Image reference to launch. Defaults to the bundled runner image. */
   image?: string;
   resources?: WorkspaceResources;
+  /**
+   * Auth mode. When 'oauth', `createWorkspace` adds a bind-mount of the
+   * shared credentials file (`paths.sharedClaudeCredentialsPath()`) over
+   * `/home/fleet/.claude/.credentials.json` so the first browser login
+   * propagates to every other OAuth workspace. 'apikey' workspaces don't
+   * get the shared bind — their credentials come via the env-var path.
+   */
+  authMode: AuthMode;
 }
 
 export interface ImageInspectResult {
@@ -193,6 +203,26 @@ export async function listLiveWorkspaces(): Promise<Workspace[]> {
     .filter((w): w is Workspace => w !== null);
 }
 
+/**
+ * Ensure `<userData>/claude-shared/.credentials.json` exists as a real
+ * file on disk so Docker can file-bind it into an OAuth-mode container.
+ * Docker refuses to file-bind a missing host path; if we let it auto-
+ * create the missing inode it would become a directory, which would
+ * make `claude`'s `read .credentials.json` fail. Touching an empty
+ * file up front matches what `claude` would write on first OAuth
+ * completion — the file is overwritten with real JSON the first time
+ * a workspace logs in.
+ */
+export async function ensureSharedCredentialsFile(): Promise<string> {
+  const filePath = sharedClaudeCredentialsPath();
+  await mkdir(dirname(filePath), { recursive: true });
+  const existing = await stat(filePath).catch(() => null);
+  if (!existing) {
+    await writeFile(filePath, '', 'utf8');
+  }
+  return filePath;
+}
+
 export async function createWorkspace(spec: CreateWorkspaceInput): Promise<Workspace> {
   assertValidWorkspaceId(spec.id);
 
@@ -216,16 +246,31 @@ export async function createWorkspace(spec: CreateWorkspaceInput): Promise<Works
   // later via its own error path).
   const resolvedEnv = await resolveEnv(spec.id, spec.env.plain, spec.env.secretKeys);
   const envArr = ['HOME=/home/fleet', ...Object.entries(resolvedEnv).map(([k, v]) => `${k}=${v}`)];
+
+  const binds: string[] = [
+    `${spec.workspaceRoot}:/workspace:rw`,
+    `${claudeDir}:/home/fleet/.claude:rw`,
+    // The in-container broker creates its socket here. Bind-mounting
+    // the *directory* (not the file) lets the broker create the
+    // socket node on its own — Docker can't bind-mount a file that
+    // doesn't exist yet on the host side.
+    `${brokerDir}:/run/broker:rw`
+  ];
+
+  // OAuth mode: file-bind the shared credentials file on top of the
+  // per-workspace .claude dir. Docker layers this file bind over the
+  // dir bind, so reads/writes of `/home/fleet/.claude/.credentials.json`
+  // hit the shared host file. First OAuth workspace populates it on
+  // login; every subsequent OAuth workspace sees an already-valid
+  // credentials file and skips the browser dance. Token refresh in any
+  // workspace updates the shared file in place.
+  if (spec.authMode === 'oauth') {
+    const sharedCreds = await ensureSharedCredentialsFile();
+    binds.push(`${sharedCreds}:/home/fleet/.claude/.credentials.json:rw`);
+  }
+
   const hostCfg: Docker.HostConfig = {
-    Binds: [
-      `${spec.workspaceRoot}:/workspace:rw`,
-      `${claudeDir}:/home/fleet/.claude:rw`,
-      // The in-container broker creates its socket here. Bind-mounting
-      // the *directory* (not the file) lets the broker create the
-      // socket node on its own — Docker can't bind-mount a file that
-      // doesn't exist yet on the host side.
-      `${brokerDir}:/run/broker:rw`
-    ],
+    Binds: binds,
     AutoRemove: false
   };
   if (spec.resources?.cpus) hostCfg.NanoCpus = Math.round(spec.resources.cpus * 1e9);
@@ -261,7 +306,7 @@ export async function createWorkspace(spec: CreateWorkspaceInput): Promise<Works
     workspaceSubdir: spec.workspaceSubdir,
     kind: 'container',
     image,
-    authMode: 'oauth',
+    authMode: spec.authMode,
     env: spec.env,
     resources: spec.resources,
     createdAt,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -170,7 +170,8 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
         workspaceSubdir: input.workspaceSubdir,
         env: input.env,
         image: input.image,
-        resources: input.resources
+        resources: input.resources,
+        authMode: input.authMode
       });
 
       const spec: WorkspaceSpec = {

--- a/src/main/migration.test.ts
+++ b/src/main/migration.test.ts
@@ -1,0 +1,172 @@
+// Unit tests for the shared-OAuth credentials migration (Phase 3, #57).
+//
+// We mock the `electron` module so `app.getPath('userData')` resolves to
+// a per-test temp dir. The rest of the migration is plain fs work, so
+// the test can drive it directly against a populated state-dir tree.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let userDataDir = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (which: string) => {
+      if (which === 'userData') return userDataDir;
+      throw new Error(`unexpected getPath: ${which}`);
+    }
+  }
+}));
+
+// Imported AFTER the mock so paths.ts picks up the stubbed electron.app.
+const { runStartupMigration } = await import('./migration.js');
+const { sharedClaudeCredentialsPath, workspaceClaudeDir } = await import('./paths.js');
+
+async function seedCreds(id: string, body: string, mtimeMs?: number): Promise<string> {
+  const dir = workspaceClaudeDir(id);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, '.credentials.json');
+  await writeFile(path, body, 'utf8');
+  if (mtimeMs != null) {
+    // Force a specific mtime so we can assert which file the migration
+    // picks as the "most recent".
+    const { utimes } = await import('node:fs/promises');
+    const t = mtimeMs / 1000;
+    await utimes(path, t, t);
+  }
+  return path;
+}
+
+beforeEach(async () => {
+  userDataDir = await mkdtemp(join(tmpdir(), 'claude-fleet-migration-'));
+});
+
+afterEach(async () => {
+  await rm(userDataDir, { recursive: true, force: true });
+});
+
+describe('migrateOAuthCredentials', () => {
+  it('no-ops when no workspaces exist', async () => {
+    await runStartupMigration();
+    // Shared dir may not exist at all — that's fine.
+    const exists = await lstat(sharedClaudeCredentialsPath()).catch(() => null);
+    expect(exists).toBeNull();
+  });
+
+  it('no-ops when a workspace has no credentials file', async () => {
+    await mkdir(workspaceClaudeDir('01TESTA00000000000000000XY'), { recursive: true });
+    await runStartupMigration();
+    const exists = await lstat(sharedClaudeCredentialsPath()).catch(() => null);
+    expect(exists).toBeNull();
+  });
+
+  it('promotes the most-recently-modified credentials file to the shared path', async () => {
+    const idA = '01TESTAAAA00000000000000XY';
+    const idB = '01TESTBBBB00000000000000XY';
+    await seedCreds(idA, JSON.stringify({ token: 'A' }), 1_700_000_000_000);
+    await seedCreds(idB, JSON.stringify({ token: 'B' }), 1_800_000_000_000); // newer
+
+    await runStartupMigration();
+
+    const shared = await readFile(sharedClaudeCredentialsPath(), 'utf8');
+    expect(JSON.parse(shared).token).toBe('B');
+  });
+
+  it('replaces every per-workspace creds file with a symlink to the shared path', async () => {
+    const idA = '01TESTAAAA00000000000000XY';
+    const idB = '01TESTBBBB00000000000000XY';
+    await seedCreds(idA, JSON.stringify({ token: 'A' }));
+    await seedCreds(idB, JSON.stringify({ token: 'B' }));
+
+    await runStartupMigration();
+
+    const credsA = join(workspaceClaudeDir(idA), '.credentials.json');
+    const credsB = join(workspaceClaudeDir(idB), '.credentials.json');
+    const lstA = await lstat(credsA);
+    const lstB = await lstat(credsB);
+    expect(lstA.isSymbolicLink()).toBe(true);
+    expect(lstB.isSymbolicLink()).toBe(true);
+    expect(await readlink(credsA)).toBe(sharedClaudeCredentialsPath());
+    expect(await readlink(credsB)).toBe(sharedClaudeCredentialsPath());
+  });
+
+  it('backs up the losers as .credentials.json.old', async () => {
+    const idA = '01TESTAAAA00000000000000XY';
+    const idB = '01TESTBBBB00000000000000XY';
+    await seedCreds(idA, JSON.stringify({ token: 'A' }), 1_700_000_000_000);
+    await seedCreds(idB, JSON.stringify({ token: 'B' }), 1_800_000_000_000);
+
+    await runStartupMigration();
+
+    // The winner (B) was renamed to the shared path — there's no .old
+    // backup for it. The loser (A) gets a .old backup.
+    const backupA = await readFile(
+      join(workspaceClaudeDir(idA), '.credentials.json.old'),
+      'utf8'
+    );
+    expect(JSON.parse(backupA).token).toBe('A');
+
+    const backupB = await lstat(
+      join(workspaceClaudeDir(idB), '.credentials.json.old')
+    ).catch(() => null);
+    expect(backupB).toBeNull();
+  });
+
+  it('is idempotent: a second run does nothing', async () => {
+    const idA = '01TESTAAAA00000000000000XY';
+    await seedCreds(idA, JSON.stringify({ token: 'A' }));
+
+    await runStartupMigration();
+    const sharedAfterFirst = await readFile(sharedClaudeCredentialsPath(), 'utf8');
+
+    await runStartupMigration();
+    const sharedAfterSecond = await readFile(sharedClaudeCredentialsPath(), 'utf8');
+    expect(sharedAfterSecond).toBe(sharedAfterFirst);
+
+    // No .old files appear on the second run — the per-workspace file
+    // is already a symlink, so the migration sees nothing to back up.
+    const stillNoBackup = await lstat(
+      join(workspaceClaudeDir(idA), '.credentials.json.old')
+    ).catch(() => null);
+    expect(stillNoBackup).toBeNull();
+  });
+
+  it('skips empty credentials files (treats them as not real)', async () => {
+    const idA = '01TESTAAAA00000000000000XY';
+    await seedCreds(idA, ''); // empty
+
+    await runStartupMigration();
+
+    // Shared file shouldn't have been created (nothing to promote).
+    const exists = await lstat(sharedClaudeCredentialsPath()).catch(() => null);
+    expect(exists).toBeNull();
+  });
+
+  it('leaves a usable shared file alone when a new per-workspace file is added', async () => {
+    // Prior run: shared file already has content.
+    const sharedPath = sharedClaudeCredentialsPath();
+    await mkdir(join(userDataDir, 'claude-shared'), { recursive: true });
+    await writeFile(sharedPath, JSON.stringify({ token: 'SHARED' }), 'utf8');
+
+    // User externally restored a per-workspace creds file.
+    const idA = '01TESTAAAA00000000000000XY';
+    await seedCreds(idA, JSON.stringify({ token: 'WORKSPACE-A' }));
+
+    await runStartupMigration();
+
+    // Shared content is preserved — the per-workspace file is treated
+    // as stale and backed up.
+    const shared = await readFile(sharedPath, 'utf8');
+    expect(JSON.parse(shared).token).toBe('SHARED');
+    const backup = await readFile(
+      join(workspaceClaudeDir(idA), '.credentials.json.old'),
+      'utf8'
+    );
+    expect(JSON.parse(backup).token).toBe('WORKSPACE-A');
+    // And the per-workspace path is now a symlink to shared.
+    const credsA = join(workspaceClaudeDir(idA), '.credentials.json');
+    expect((await lstat(credsA)).isSymbolicLink()).toBe(true);
+  });
+});

--- a/src/main/migration.ts
+++ b/src/main/migration.ts
@@ -18,19 +18,20 @@
 // Idempotent: running this twice is a no-op once the state dir is
 // already keyed by id and the keytar entries already conform.
 
-import { readdir, readFile, rename, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { lstat, mkdir, readdir, readFile, rename, symlink, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { ulid } from 'ulid';
-import { stateRoot, workspaceManifestPath } from './paths.js';
+import { sharedClaudeCredentialsPath, stateRoot, workspaceClaudeDir, workspaceManifestPath } from './paths.js';
 import type { WorkspaceSpec } from './workspaces.js';
 
 const SERVICE = 'claude-fleet';
 const SECRET_INDEX_PREFIX = '__secrets__:';
 
 /**
- * Run both halves of the clean-slate migration. Best-effort: errors are
- * logged and swallowed so a broken state dir doesn't keep the app from
- * starting. The startup IPC path tolerates a partly-migrated layout.
+ * Run every startup migration step. Best-effort: errors are logged and
+ * swallowed so a broken state dir doesn't keep the app from starting.
+ * Order matters — state-dir renames must finish before credentials
+ * migration walks state dirs by id.
  */
 export async function runStartupMigration(): Promise<void> {
   try {
@@ -42,6 +43,11 @@ export async function runStartupMigration(): Promise<void> {
     await purgeLegacyKeytarEntries();
   } catch (err) {
     console.warn('[migration] keytar purge failed:', err);
+  }
+  try {
+    await migrateOAuthCredentials();
+  } catch (err) {
+    console.warn('[migration] credentials migration failed:', err);
   }
 }
 
@@ -122,6 +128,129 @@ async function migrateStateDirs(): Promise<void> {
       console.log(`[migration] state dir "${dirName}" → "${id}" (name "${name}")`);
     } catch (err) {
       console.warn(`[migration] failed to migrate state dir "${dirName}":`, err);
+    }
+  }
+}
+
+/**
+ * Move every workspace's per-workspace `.claude/.credentials.json` to
+ * a single shared location and replace the per-workspace files with
+ * symlinks to it. Idempotent.
+ *
+ * The shared file backs Phase 3 of the workspace-modal redesign
+ * (issue #57): one Claude.ai login covers every OAuth workspace. The
+ * actual bind-mount lives in `docker.ts createWorkspace`; this
+ * migration just consolidates pre-existing per-workspace files so the
+ * shared file picks up real credentials on first run rather than
+ * staying empty until the user logs in again.
+ *
+ * Rules:
+ *   - "Real file" = exists, is a regular file, is non-empty. Empty
+ *     files (from a stale touch) and symlinks are treated as
+ *     already-migrated.
+ *   - If the shared file isn't real yet and at least one workspace has
+ *     a real credentials file, promote the most-recently-modified one
+ *     to the shared path.
+ *   - For every other workspace that still has a real credentials
+ *     file: back it up as `.credentials.json.old` and replace the
+ *     original with a symlink to the shared path.
+ *   - For the workspace whose file became the shared one: also create
+ *     the symlink so the per-workspace path keeps resolving to real
+ *     credentials.
+ */
+async function migrateOAuthCredentials(): Promise<void> {
+  const root = stateRoot();
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === 'ENOENT') return;
+    throw err;
+  }
+
+  // Probe each workspace's credentials.json — collect the ones that
+  // are real, non-empty files (not symlinks, not directories).
+  interface RealCredsFile {
+    id: string;
+    path: string;
+    mtimeMs: number;
+  }
+  const realFiles: RealCredsFile[] = [];
+  for (const id of entries) {
+    let credsPath: string;
+    try {
+      credsPath = join(workspaceClaudeDir(id), '.credentials.json');
+    } catch {
+      // Invalid id (path-safety check) — skip.
+      continue;
+    }
+    try {
+      const lst = await lstat(credsPath);
+      if (lst.isSymbolicLink()) continue;
+      if (!lst.isFile()) continue;
+      if (lst.size === 0) continue;
+      realFiles.push({ id, path: credsPath, mtimeMs: lst.mtimeMs });
+    } catch {
+      // No file — fine, nothing to migrate for this workspace.
+      continue;
+    }
+  }
+
+  const sharedPath = sharedClaudeCredentialsPath();
+  await mkdir(dirname(sharedPath), { recursive: true });
+
+  // "Real" shared file = exists, regular file, non-empty.
+  let sharedIsReal = false;
+  try {
+    const lst = await lstat(sharedPath);
+    sharedIsReal = lst.isFile() && lst.size > 0;
+  } catch {
+    sharedIsReal = false;
+  }
+
+  // Promote: if the shared file isn't real yet but at least one
+  // workspace has credentials, move the most-recently-modified one
+  // into the shared path.
+  if (!sharedIsReal && realFiles.length > 0) {
+    realFiles.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    const winner = realFiles[0];
+    // Drop the existing shared file (likely empty stub from a prior
+    // run that called ensureSharedCredentialsFile but never logged in).
+    try {
+      await unlink(sharedPath);
+    } catch (err: unknown) {
+      if ((err as { code?: string }).code !== 'ENOENT') throw err;
+    }
+    await rename(winner.path, sharedPath);
+    console.log(
+      `[migration] promoted ${winner.id}'s credentials to shared (mtime ${new Date(winner.mtimeMs).toISOString()})`
+    );
+    sharedIsReal = true;
+    // Symlink the winner's path back to shared so the workspace's
+    // .claude/.credentials.json keeps resolving.
+    await symlink(sharedPath, winner.path);
+  }
+
+  // Back up + symlink everyone else.
+  for (const { id, path: credsPath } of realFiles) {
+    // Use lstat so a symlink (from the promotion step above, or a
+    // previous run's migration) is recognized — stat would follow it
+    // and we'd treat the symlink itself as a "real file" worth
+    // backing up.
+    const lst = await lstat(credsPath).catch(() => null);
+    if (!lst || !lst.isFile()) continue;
+    const backupPath = credsPath + '.old';
+    try {
+      await rename(credsPath, backupPath);
+    } catch (err) {
+      console.warn(`[migration] failed to back up ${id}'s credentials:`, err);
+      continue;
+    }
+    try {
+      await symlink(sharedPath, credsPath);
+      console.log(`[migration] backed up ${id}'s credentials → .old + symlinked to shared`);
+    } catch (err) {
+      console.warn(`[migration] failed to symlink ${id}'s credentials:`, err);
     }
   }
 }

--- a/src/main/mock.ts
+++ b/src/main/mock.ts
@@ -91,7 +91,7 @@ export async function createWorkspace(spec: CreateWorkspaceInput): Promise<Works
     workspaceSubdir: spec.workspaceSubdir,
     kind: 'container',
     image: spec.image ?? 'ghcr.io/imioimi/claude-fleet/runner:latest',
-    authMode: 'oauth',
+    authMode: spec.authMode,
     env: spec.env,
     resources: spec.resources,
     createdAt: Date.now(),

--- a/tests/shared-oauth.spec.ts
+++ b/tests/shared-oauth.spec.ts
@@ -1,0 +1,65 @@
+// Phase 3 — shared OAuth credentials surface in the renderer.
+//
+// The actual bind-mount happens in main/docker.ts (covered by manual
+// verification against real Docker). What we can guarantee at the
+// renderer layer is that the `authMode` field flows correctly through
+// workspace:create — that's what selects whether the shared bind
+// gets added in main.
+
+import { test, expect } from '@playwright/test';
+import { launch, mockMainIpc, getCalls } from './_helpers.js';
+
+test('Create: default form submit ships authMode=oauth', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { isDirectoryReturns: true });
+
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+    await expect(window.getByRole('tab', { name: 'New' })).toHaveAttribute('aria-selected', 'true');
+
+    await window.getByLabel('Workspace name').fill('test-oauth');
+    await window.getByPlaceholder('/home/troy/repos').fill('/tmp/test-oauth');
+    await window.getByRole('button', { name: 'Create & start' }).click();
+
+    await expect(window.getByRole('tab', { name: 'New' })).toBeHidden();
+
+    const calls = await getCalls(app);
+    expect(calls.create).toHaveLength(1);
+    expect((calls.create[0] as { authMode: string }).authMode).toBe('oauth');
+  } finally {
+    await app.close();
+  }
+});
+
+test('Create: switching to API key + supplying ANTHROPIC_API_KEY ships authMode=apikey', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { isDirectoryReturns: true });
+
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+
+    await window.getByLabel('Workspace name').fill('test-apikey');
+    await window.getByPlaceholder('/home/troy/repos').fill('/tmp/test-apikey');
+
+    // Open Env vars disclosure → add ANTHROPIC_API_KEY plain (so the
+    // API-key radio unlocks without needing the keychain).
+    await window.locator('.form-disclosure > summary', { hasText: 'Env vars' }).click();
+    await window.getByRole('button', { name: '+ Add env var' }).click();
+    await window.getByLabel('Env key 1').fill('ANTHROPIC_API_KEY');
+    await window.getByLabel('Env value 1').fill('sk-ant-test');
+
+    // Pick API key.
+    await window.getByRole('radio', { name: /API key/ }).check();
+
+    await window.getByRole('button', { name: 'Create & start' }).click();
+    await expect(window.getByRole('tab', { name: 'New' })).toBeHidden();
+
+    const calls = await getCalls(app);
+    expect(calls.create).toHaveLength(1);
+    const spec = calls.create[0] as { authMode: string; env: { plain: Record<string, string> } };
+    expect(spec.authMode).toBe('apikey');
+    expect(spec.env.plain.ANTHROPIC_API_KEY).toBe('sk-ant-test');
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary

Phase 3 of the [workspace-modal redesign](docs/design/workspace-modal.md) — independent of the earlier phases, ships on its own. Self-contained.

A single shared host file at `<userData>/claude-shared/.credentials.json` is file-bound into each OAuth-mode workspace at `/home/fleet/.claude/.credentials.json` (layered on top of the existing per-workspace `.claude` dir bind).

- **First OAuth workspace** prints the Claude.ai login URL; user completes the flow in their browser; tokens land in the shared file.
- **Every subsequent OAuth workspace** mounts the same file and skips the browser dance.
- **Token refresh** in any workspace updates the shared file in place and propagates to all of them.
- **`apikey` workspaces** don't get the file-bind — their auth comes via `ANTHROPIC_API_KEY` in the env-var chain (same as before).

## Implementation

- **`docker.ts`** — `CreateWorkspaceInput` grows `authMode`. New `ensureSharedCredentialsFile()` helper touches the host file before container start (Docker refuses to file-bind a missing path; letting it auto-create makes it a directory). When `authMode === 'oauth'`, the shared file-bind is appended to `HostConfig.Binds`.
- **`migration.ts`** — third pass in `runStartupMigration` consolidates any pre-existing per-workspace `.credentials.json` files. Promotes the most-recently-modified one to the shared path when the shared file doesn't yet exist, backs up the rest as `.credentials.json.old`, and replaces every per-workspace path with a symlink to the shared file. Uses `lstat` (not `stat`) to recognize symlinks from previous runs — that's the idempotency hinge.
- **`ipc.ts` + `mock.ts`** — pass `authMode` through to the backend; mock echoes it back instead of hard-coding 'oauth'.

## Test plan

- [x] `npm run typecheck` — main + renderer clean
- [x] `npm run test:unit` — 48 unit tests passing (8 new in `src/main/migration.test.ts`: no-op cases, promotion-by-mtime, symlinks created for every workspace, `.old` backups for losers, idempotency, empty-file skip, shared-already-usable case)
- [x] `npm run test:e2e` — 65 e2e passing (63 existing + 2 new in `tests/shared-oauth.spec.ts`: default form ships `authMode=oauth`; switching to API key with `ANTHROPIC_API_KEY` in env ships `authMode=apikey`)
- [x] `npm run build` — clean
- [ ] **Reviewer** (real Docker, fresh install): launch `npm run dev`; create your first OAuth workspace; complete browser login; create a second OAuth workspace — `claude` should NOT print a login URL this time. Verify `<userData>/claude-shared/.credentials.json` contains real tokens; verify both workspaces' `.claude/.credentials.json` are symlinks to it.
- [ ] **Reviewer** (real Docker, pre-existing creds): seed `<userData>/state/<id>/.claude/.credentials.json` with real credentials in two workspaces, then start the app. Migration should promote one to the shared path (the more recent), back up the other as `.old`, and symlink both back. Subsequent OAuth workspace creates skip the browser dance.
- [ ] **Reviewer** (real Docker, apikey mode): create a workspace with `authMode=apikey` and `ANTHROPIC_API_KEY` in env. Confirm the shared file is NOT bound into this workspace (`docker inspect` shows two binds, not three).
- [ ] **Spec check**: `docs/SPEC.md` §7 (Binds list grows conditional file-bind), §8 (third migration pass), §11 OAuth section rewrite.

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)