### PR TITLE
Fix: deleting a saved workspace does nothing

### DIFF
--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -443,28 +443,41 @@ export async function stopWorkspace(containerId: string): Promise<void> {
 export interface RemoveWorkspaceOpts {
   /** When true, also wipe the host-side state dir (manifest + .claude + broker). */
   deleteState?: boolean;
+  /**
+   * Workspace ULID. Required to delete the state dir of a *saved* workspace
+   * (one with no live container) — without a container we can't recover the
+   * id from a label. Live-path callers may omit it; the id is then read from
+   * the container's ID_LABEL.
+   */
+  id?: string;
 }
 
 export async function removeWorkspace(
   containerId: string,
   opts: RemoveWorkspaceOpts = {}
 ): Promise<void> {
-  const c = docker.getContainer(containerId);
-
-  let id: string | undefined;
-  if (opts.deleteState) {
+  // Prefer the caller-supplied ULID (the only way to identify a saved
+  // workspace, whose container no longer exists). Fall back to the
+  // container's label for live-path callers that pass only a containerId.
+  let id = opts.id;
+  if (opts.deleteState && !id && containerId) {
     try {
-      const info = await c.inspect();
+      const info = await docker.getContainer(containerId).inspect();
       id = info.Config.Labels?.[ID_LABEL];
     } catch (err: unknown) {
       if ((err as { statusCode?: number }).statusCode !== 404) throw err;
     }
   }
 
-  try {
-    await c.remove({ force: true });
-  } catch (err: unknown) {
-    if ((err as { statusCode?: number }).statusCode !== 404) throw err;
+  // Remove the container. Prefer the explicit ref; otherwise derive the name
+  // from the id (a saved workspace has none, so this 404s harmlessly).
+  const ref = containerId || (id ? containerNameFor(id) : undefined);
+  if (ref) {
+    try {
+      await docker.getContainer(ref).remove({ force: true });
+    } catch (err: unknown) {
+      if ((err as { statusCode?: number }).statusCode !== 404) throw err;
+    }
   }
 
   if (opts.deleteState && id) {

--- a/src/main/mock.ts
+++ b/src/main/mock.ts
@@ -1,10 +1,12 @@
 import { Duplex } from 'node:stream';
+import { rm } from 'node:fs/promises';
 import type {
   CreateWorkspaceInput,
   PullProgress,
   RemoveWorkspaceOpts,
   PtyHandle
 } from './docker.js';
+import { workspaceStateDir } from './paths.js';
 import type { Workspace } from './workspaces.js';
 
 // In mock mode the workspace id doubles as the containerId. Real backend
@@ -149,8 +151,19 @@ export async function stopWorkspace(containerId: string): Promise<void> {
   }
 }
 
-export async function removeWorkspace(containerId: string, _opts: RemoveWorkspaceOpts = {}): Promise<void> {
-  workspaces.delete(containerId);
+export async function removeWorkspace(
+  containerId: string,
+  opts: RemoveWorkspaceOpts = {}
+): Promise<void> {
+  // In mock the map is keyed by id (== containerId for live mock entries).
+  // A saved workspace isn't in the map at all; its only trace is the on-disk
+  // manifest, so honor deleteState by wiping the state dir keyed off the ULID.
+  const id = opts.id || containerId;
+  if (containerId) workspaces.delete(containerId);
+  if (opts.id) workspaces.delete(opts.id);
+  if (opts.deleteState && id) {
+    await rm(workspaceStateDir(id), { recursive: true, force: true });
+  }
 }
 
 class FakeShell extends Duplex {

--- a/src/main/removeWorkspace.test.ts
+++ b/src/main/removeWorkspace.test.ts
@@ -1,0 +1,68 @@
+// Unit tests for the mock backend's removeWorkspace, covering the
+// saved-workspace delete bug: a workspace with no live container (its only
+// trace is the on-disk manifest) must still have its state dir wiped when
+// deleteState is set, keyed off the ULID. Mirrors the real docker.ts path.
+//
+// electron is mocked so paths.ts resolves to a temp userData dir.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let userDataDir = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (which: string) => {
+      if (which === 'userData') return userDataDir;
+      throw new Error(`unexpected getPath: ${which}`);
+    }
+  }
+}));
+
+const { removeWorkspace } = await import('./mock.js');
+const { workspaceStateDir } = await import('./paths.js');
+
+async function seedSavedWorkspace(id: string): Promise<string> {
+  const dir = workspaceStateDir(id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'workspace.json'), JSON.stringify({ id, name: id }), 'utf8');
+  return dir;
+}
+
+beforeEach(async () => {
+  userDataDir = await mkdtemp(join(tmpdir(), 'claude-fleet-remove-'));
+});
+
+afterEach(async () => {
+  await rm(userDataDir, { recursive: true, force: true });
+});
+
+describe('removeWorkspace (saved workspace, no container)', () => {
+  it('wipes the state dir when deleteState + id are given', async () => {
+    const id = '01KSAVED00000000000000000A';
+    const dir = await seedSavedWorkspace(id);
+    await expect(stat(dir)).resolves.toBeTruthy();
+
+    // No containerId — exactly the saved-workspace case that used to be skipped.
+    await removeWorkspace('', { deleteState: true, id });
+
+    await expect(stat(dir)).rejects.toThrow();
+  });
+
+  it('leaves the state dir alone when deleteState is not set', async () => {
+    const id = '01KSAVED00000000000000000B';
+    const dir = await seedSavedWorkspace(id);
+
+    await removeWorkspace('', { deleteState: false, id });
+
+    await expect(stat(dir)).resolves.toBeTruthy();
+  });
+
+  it('is a no-op without throwing when the state dir is already gone', async () => {
+    const id = '01KSAVED00000000000000000C';
+    // Never created on disk.
+    await expect(removeWorkspace('', { deleteState: true, id })).resolves.toBeUndefined();
+  });
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -112,7 +112,7 @@ const api = {
       ipcRenderer.invoke('workspace:writeManifest', spec),
     stop: (containerId: string) => ipcRenderer.invoke('workspace:stop', containerId),
     pause: (containerId: string) => ipcRenderer.invoke('workspace:pause', containerId),
-    remove: (containerId: string, opts?: { deleteState?: boolean }) =>
+    remove: (containerId: string, opts?: { deleteState?: boolean; id?: string }) =>
       ipcRenderer.invoke('workspace:remove', containerId, opts),
     ensureImage: async (onProgress: (p: { message: string }) => void): Promise<void> => {
       const channelId = globalThis.crypto.randomUUID();

--- a/src/renderer/src/components/DeleteWorkspaceModal.tsx
+++ b/src/renderer/src/components/DeleteWorkspaceModal.tsx
@@ -33,10 +33,15 @@ export function DeleteWorkspaceModal({ workspace, onClose, onDeleted }: Props) {
           console.warn('workspace.stop during delete failed:', err);
         }
       }
-      if (workspace.containerId) {
-        setStatus('Removing container + state dir…');
-        await window.api.workspace.remove(workspace.containerId, { deleteState: true });
-      }
+      // Always remove + purge the state dir, even for a saved workspace with
+      // no live container — pass the ULID so the main process can wipe the
+      // state dir without a container to read the id from. (Gating this on
+      // containerId was the bug: saved workspaces were never deleted.)
+      setStatus('Removing container + state dir…');
+      await window.api.workspace.remove(workspace.containerId ?? '', {
+        deleteState: true,
+        id: workspace.id
+      });
       setStatus('Purging vault entries…');
       try {
         await window.api.vault.deleteAllForWorkspace(workspace.id);

--- a/tests/workspace-actions.spec.ts
+++ b/tests/workspace-actions.spec.ts
@@ -70,7 +70,7 @@ test('Chip ⋮ Delete: opens the confirm modal, then purges container + state + 
     const calls = await getCalls(app);
     expect(calls.stop).toContain(RUNNING_WS.containerId);
     expect(calls.remove).toEqual([
-      { containerId: RUNNING_WS.containerId, deleteState: true }
+      { containerId: RUNNING_WS.containerId, deleteState: true, id: RUNNING_WS.id }
     ]);
     expect(calls.vaultDeleteAllForWorkspace).toContain(RUNNING_WS.id);
   } finally {
@@ -108,6 +108,37 @@ test('Saved-tab Delete: row Delete button opens confirm modal', async () => {
     // The Saved-tab Delete bubbles up, the workspace modal closes, and
     // the confirmation modal opens at the top level.
     await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Saved-tab Delete: confirming purges a containerless saved workspace (regression)', async () => {
+  // Regression for the bug where deleting a saved workspace did nothing:
+  // DeleteWorkspaceModal gated the remove call on workspace.containerId,
+  // which is absent for saved/deleted entries, so the call was skipped and
+  // the state dir was never wiped — the workspace reappeared. The fix fires
+  // remove regardless and threads the ULID so main can delete by id.
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [STOPPED_WS] });
+    await window.locator('.top-strip').getByRole('button', { name: '+ New workspace' }).click();
+
+    const row = window.locator('.saved-row', { hasText: 'calm-otter' });
+    await row.locator('.saved-row-header').click();
+    await row.getByRole('button', { name: /Delete/ }).click();
+
+    await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeVisible();
+    await window.getByRole('button', { name: 'Delete permanently' }).click();
+    await expect(window.getByRole('heading', { name: 'Delete workspace' })).toBeHidden();
+
+    const calls = await getCalls(app);
+    // The remove call must fire even with no containerId, carrying the ULID
+    // so main can wipe the state dir.
+    expect(calls.remove).toEqual([
+      { containerId: '', deleteState: true, id: STOPPED_WS.id }
+    ]);
+    expect(calls.vaultDeleteAllForWorkspace).toContain(STOPPED_WS.id);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
## Problem

Deleting a **saved** workspace — one shown in the Saved tab with no live `cf-` container (e.g. a stopped/deleted entry that exists only as a manifest on disk) — silently did nothing. Confirming "Delete permanently" closed the modal but the workspace reappeared in the Saved tab.

## Root cause (two compounding bugs)

1. **Renderer** (`DeleteWorkspaceModal`): the `workspace.remove()` call was gated on `workspace.containerId`. Saved/deleted entries are built from the manifest and carry no `containerId`, so the call was **skipped entirely** — only the vault purge ran, leaving the manifest + state dir on disk.
2. **Main** (`docker.ts removeWorkspace`): it recovered the workspace ULID *only* by inspecting the container. With no container, `inspect()` 404s, `id` stays `undefined`, and the state-dir wipe (`if (deleteState && id)`) never runs.

So even fixing one side alone wouldn't have worked.

## Fix

Thread the workspace **ULID** through the delete path:

- `removeWorkspace` now accepts `opts.id`. It removes the container if one exists (deriving the `cf-<id>` name when only the id is known — a saved workspace 404s harmlessly), and wipes the state dir keyed off the ULID. Live-path callers that pass only a `containerId` still work (id falls back to the container's label).
- `DeleteWorkspaceModal` always calls `remove` (ungated) and passes `id: workspace.id`.
- Mirrored in the mock backend so it's exercised under mock-mode e2e.

## Tests

- **+3 unit** (`removeWorkspace.test.ts`): the mock backend wipes the state dir for a containerless workspace when `deleteState + id` are given; leaves it alone without `deleteState`; no-throw when the dir is already gone.
- **+1 e2e** (`workspace-actions.spec.ts`): confirm-delete on a containerless saved workspace asserts `remove` now fires with `{ containerId: '', deleteState: true, id }` (it was previously never called). Updated the existing chip-delete assertion to include the new `id` arg.
- 56 unit + 66 e2e green.

## Note

This also lets the UI clean up pre-existing orphan saved workspaces (e.g. ULID state dirs left from earlier testing) that previously couldn't be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)