### PR TITLE
Top-bar visual parity: workspace chip redesign + brand/daemon polish

### DIFF
--- a/src/renderer/src/components/WorkspaceTabStrip.tsx
+++ b/src/renderer/src/components/WorkspaceTabStrip.tsx
@@ -185,9 +185,12 @@ export function WorkspaceTabStrip({
   return (
     <div className="top-strip">
       <div className="app-name">
-        claude-fleet
-        <span className="meta">
-          {live.length} workspace{live.length === 1 ? '' : 's'}
+        <span className="brand-tile" aria-hidden="true">cf</span>
+        <span className="brand-label">
+          <span className="title">claude-fleet</span>
+          <span className="meta">
+            {live.length} workspace{live.length === 1 ? '' : 's'}
+          </span>
         </span>
       </div>
 
@@ -270,9 +273,9 @@ export function WorkspaceTabStrip({
             MOCK MODE
           </span>
         )}
-        <span className="daemon-status">
+        <span className={`daemon-status ${backendReady === false ? 'down' : ''}`}>
           <span className={`dot ${backendReady === false ? 'unreachable' : ''}`} />
-          {backendReady === false ? 'disconnected' : 'docker'}
+          {backendReady === false ? 'No daemon' : 'Docker'}
         </span>
       </div>
 

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -52,6 +52,10 @@
   --r-lg: 10px;
   --r-xl: 14px;
 
+  /* elevation (design tokens.css: --shadow-sm/--shadow/--shadow-lg) */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+
   font-family: var(--font-sans);
 }
 
@@ -86,24 +90,52 @@ body {
   padding: 10px 14px;
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--border-subtle);
-  min-height: 56px;
+  /* 72px to fit the 48px chips with breathing room (issue #20). */
+  min-height: 72px;
   overflow-x: auto;
 }
+/* Brand mark: a 28×28 "cf" tile + stacked claude-fleet / N-workspaces
+   label, matching design/components/hi-fi-top-bar.jsx. */
 .top-strip .app-name {
-  font-family: var(--font-mono);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: 0.02em;
-  padding: 4px 12px 4px 4px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-right: 12px;
   border-right: 1px solid var(--border-subtle);
   margin-right: 4px;
   white-space: nowrap;
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
-.top-strip .app-name .meta { color: var(--text-muted); font-weight: 400; font-size: 11px; }
+.top-strip .app-name .brand-tile {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: var(--text-primary);
+  color: var(--bg-base);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: -0.02em;
+  flex-shrink: 0;
+}
+.top-strip .app-name .brand-label {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+}
+.top-strip .app-name .brand-label .title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+.top-strip .app-name .meta {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 10px;
+}
 
 .ws-chip {
   display: inline-flex;
@@ -193,13 +225,18 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  padding: 4px 9px;
+  border-radius: var(--r-md);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
   font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-muted);
+  font-size: 10px;
+  color: var(--text-secondary);
 }
+.daemon-status.down { color: var(--state-error); border-color: var(--state-error); }
 .daemon-status .dot {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   background: var(--state-running);
 }
@@ -923,24 +960,56 @@ body {
   position: relative;
   display: inline-flex;
   align-items: stretch;
-  border-radius: var(--r-md);
-  border: 1.5px solid var(--border-subtle);
+  /* Raised-card chip sized to the design (220–280 × 48). */
+  min-width: 220px;
+  max-width: 280px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: var(--r-lg);
+  border: 1px solid var(--border-subtle);
   background: transparent;
   overflow: visible;
-  transition: background 0.1s ease, border-color 0.1s ease;
+  transition: background 0.1s ease, border-color 0.1s ease, box-shadow 0.14s ease;
+}
+/* 3px color-identity bar on the left edge, the workspace hue. Dimmed when
+   inactive, full when selected (design/components/hi-fi-top-bar.jsx). */
+.ws-chip-group::before {
+  content: '';
+  align-self: center;
+  width: 3px;
+  height: 28px;
+  margin-left: 8px;
+  border-radius: 2px;
+  background: var(--hue, var(--accent));
+  opacity: 0.85;
+  flex-shrink: 0;
 }
 .ws-chip-group:hover { background: var(--bg-card); }
 .ws-chip-group.active {
   background: var(--bg-card);
   border-color: var(--hue, var(--accent));
+  box-shadow: var(--shadow-sm);
 }
+.ws-chip-group.active::before { opacity: 1; }
 /* The chip + trigger inside the group share the group's border now;
    suppress the chip's own border styling. */
 .ws-chip-group .ws-chip {
   border: none;
   border-radius: 0;
   background: transparent;
-  padding-right: 8px;
+  /* The color bar supplies the left inset; grow to fill so the ⋮ trigger
+     hugs the right edge and long names ellipsis instead of widening. */
+  flex: 1;
+  min-width: 0;
+  padding: 0 8px 0 10px;
+}
+.ws-chip-group .ws-chip .ws-chip-text { min-width: 0; }
+.ws-chip-group .ws-chip .name,
+.ws-chip-group .ws-chip .ws-chip-sub {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .ws-chip-group .ws-chip:hover { background: transparent; }
 .ws-chip-group.active .ws-chip { color: var(--text-primary); }
@@ -1083,7 +1152,7 @@ body {
   gap: 0;
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--border-subtle);
-  height: 32px;
+  height: 42px;
   padding: 0 2px;
   overflow-x: auto;
   overflow-y: hidden;


### PR DESCRIPTION
Phase A of aligning the implementation with the planned design (a gap audit flagged the workspace chip as the biggest visual divergence). Top-bar only, **no data-model changes** — matches `design/components/hi-fi-top-bar.jsx` and addresses the visual half of issue #20.

## Changes

- **Workspace chip** → raised card at the design size (220–280 × 48, radius 10) with:
  - a **3px hue color-identity bar** on the left edge (opacity 0.85 inactive, full when selected)
  - **shadow** on the selected chip
  - long names **ellipsis** instead of widening the card
- **Top-strip** min-height 56 → 72px (fits the taller chips).
- **Brand mark** → a "cf" tile + stacked `claude-fleet` / `N workspaces` label (was plain text).
- **Daemon status** → bordered badge, 7px dot, reads `Docker` / `No daemon` (was `docker` / `disconnected`).
- **Session-tab strip** height 32 → 42px.
- Added `--shadow-sm` / `--shadow` elevation tokens (design `tokens.css` names).

## Deliberately out of scope

- **Kept "New workspace"** — the design artboard's "New container" predates the container→workspace rename; reverting one button would be inconsistent with the SPEC/IPC.
- **Terminal pips** and the **needs-input** chip affordance — both need per-terminal / pending-prompt observability data that doesn't exist yet (Phase C, after the observability data layer).
- **oklch / light-mode token migration** — that's its own issue (#28).

## Verification

- Tests: **56 unit + 66 e2e**, no selector regressions (chip-menu, saved-tab, etc. all green).
- Verified visually in mock mode (`CLAUDE_FLEET_MOCK=1 npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)