### PR TITLE
Fix: context bar blanked by --hue angle/color mismatch

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -482,7 +482,11 @@ export function App() {
 
         <main
           className="main-pane"
-          style={selected ? { ['--hue' as never]: `${hueFor(selected)}deg` } : undefined}
+          // `--hue` is a full color (same as the chips, via colorFor) — every
+          // CSS consumer (context-accent band, active session-tab underline)
+          // uses it directly as a color. A bare `${hueFor}deg` angle is an
+          // invalid color there, which silently blanked the context bar.
+          style={selected ? { ['--hue' as never]: colorFor(selected) } : undefined}
         >
           <div className="main-body">
             {backendReady === false ? (

--- a/tests/context-bar.spec.ts
+++ b/tests/context-bar.spec.ts
@@ -1,0 +1,37 @@
+// Regression guard for the workspace context-accent bar at the top of the
+// terminal. It's filled with the workspace hue via the `--hue` CSS custom
+// property, which every consumer (this bar, the active session-tab underline)
+// reads as a full color. A regression once set `--hue` to a bare `Ndeg`
+// angle on .main-pane — an invalid color for `background`/`color-mix`, which
+// silently blanked the bar. These tests assert `--hue` resolves to a real
+// color and the bar fill actually paints.
+
+import { test, expect } from '@playwright/test';
+import { launch, activePane } from './_helpers.js';
+
+test('Context bar: --hue on .main-pane is a color, and the accent bar paints', async () => {
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  try {
+    await window.locator('.ws-chip', { hasText: 'mock-alpha' }).click();
+
+    // --hue must be a real color, not an angle (e.g. "210deg"), or every
+    // color consumer scoped under .main-pane silently fails.
+    const hue = await window
+      .locator('.main-pane')
+      .evaluate((el) => getComputedStyle(el).getPropertyValue('--hue').trim());
+    expect(hue).not.toBe('');
+    expect(hue.endsWith('deg')).toBe(false);
+
+    // The bar fill should resolve to a non-transparent background. An invalid
+    // `--hue` would leave it transparent (var() fallback doesn't kick in once
+    // the property is set, even to an invalid value).
+    const fill = activePane(window).locator('.terminal-accent-band-fill');
+    await expect(fill).toBeVisible();
+    const bg = await fill.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe('');
+    expect(bg).not.toBe('rgba(0, 0, 0, 0)');
+    expect(bg).not.toBe('transparent');
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Bug

The workspace **context-accent bar** at the top of the terminal disappeared. (The active **session-tab underline** was silently broken the same way.)

## Root cause

Both read the `--hue` custom property *directly as a color*:
```css
.terminal-accent-band      { background: color-mix(in oklab, var(--hue, var(--accent)) 22%, transparent); }
.terminal-accent-band-fill { background: var(--hue, var(--accent)); }
.session-tab.active        { border-bottom-color: var(--hue, var(--accent)); }
```
But `.main-pane` set `--hue` to a bare **angle** — `${hueFor(selected)}deg` (e.g. `210deg`) — since #59. `background: 210deg` / `color-mix(in oklab, 210deg …)` are invalid, so the declarations were dropped and the bar painted transparent. The `var()` fallback doesn't help: it only applies when `--hue` is *unset*, not when it's set to an invalid value.

All 8 CSS consumers of `--hue` expect a color, and the workspace chips already set it correctly via `colorFor()`. `.main-pane` was the lone outlier.

## Fix

One line — `.main-pane` now sets `--hue` to `colorFor(selected)` (a full `oklch(…)` color), consistent with the chips. Fixes both the context bar and the active session-tab underline.

## Tests

Adds `tests/context-bar.spec.ts`:
- `--hue` on `.main-pane` resolves to a color (not an angle).
- the bar fill paints a non-transparent background.

Verified as a real regression guard: the test **fails** on the pre-fix `deg` value (negative control) and passes after. Suite: **56 unit + 67 e2e**.

## Note

This predates the recent top-bar work (#70) — it's been broken since #59. Not a Phase A regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)