### PR TITLE
#11 user-prompt log (JSONL-sourced): AskUserQuestion + ExitPlanMode

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -726,6 +726,10 @@ CREATE TABLE profile_settings (
 ### Permission-request log
 Always-on structured log of every prompt Claude makes to the user. Substrate for tuning `.claude/settings.json` permissions and CLAUDE.md guidance over time.
 
+**Implemented (capture v1) — JSONL-sourced.** Two approaches were investigated; the data sources forced the scope:
+- **Generic permission prompts are not capturable here.** They're not written to the transcript JSONL (a gated tool just goes `tool_use`→`tool_result`), and in claude-fleet they don't even occur — claude auto-allows tools (verified: `Bash` decided in ~5 ms, no prompt). A `Notification`-hook approach (provision a hook in the container that logs permission/idle notifications to a sidecar) was built and **abandoned**: live testing showed claude loads **zero** hooks from a provisioned `~/.claude/settings.json` (`--debug`: "Found 0 total hooks in registry"), apparently gated behind a hook-approval step with no documented way to pre-seed it.
+- **What ships:** `AskUserQuestion` and `ExitPlanMode` — the "Claude is waiting on the user" moments that *do* occur and *are* in the transcript as `tool_use` events already ingested into `events`. `db.userPromptsForWorkspace` is a query over `events` (no new table, no migration): tool_use rows with `tool_name IN ('AskUserQuestion','ExitPlanMode')`, LEFT-JOINed to their `tool_result` (by `tool_use_id`) to derive a `resolved` flag, mapped to `kind` `'ask'`/`'plan'` with the summarized `tool_input` as a preview. Exposed via `userPrompts:list(workspaceId)`. **Remaining:** the passive log UI and driving the chip "needs-input" affordance off unresolved prompts.
+
 **Decisions made:**
 - **Scope**: structured prompts only — permission requests (Bash/Edit/Write/etc. that hit `ask` rules or unlisted patterns), `AskUserQuestion` tool calls, `ExitPlanMode` approvals. Plain-text questions in assistant messages are out of scope; they don't map cleanly to settings.json entries.
 - **Storage**: SQLite table in the same DB the observability and sessions layers use.

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -441,6 +441,18 @@ export interface ToolCallCount {
   count: number;
 }
 
+export interface UserPrompt {
+  id: number;
+  sessionId: string;
+  ts: number | null;
+  /** 'ask' = AskUserQuestion, 'plan' = ExitPlanMode. */
+  kind: 'ask' | 'plan';
+  /** Summarized tool input (question/plan preview); full detail in raw_jsonl. */
+  input: string | null;
+  /** Whether a tool_result followed (the user answered / approved). */
+  resolved: boolean;
+}
+
 export interface ToolCall {
   name: string;
   /** Short input summary (command / path / pattern / …), or null. */
@@ -720,6 +732,53 @@ export function costSeriesForSession(sessionId: string, limit = 20): number[] {
         cacheCreationInputTokens: r.cache_creation_input_tokens,
       }),
     );
+}
+
+// ── user-prompt log (#11): moments Claude asks the user ───────────────────
+//
+// Sourced straight from the transcript: AskUserQuestion and ExitPlanMode are
+// tool_use events already ingested into `events`. (Generic permission prompts
+// don't appear in the JSONL and don't occur in claude-fleet — tools auto-allow
+// — so they're out of scope.) Each prompt is matched to its tool_result to
+// know whether the user resolved it. No extra table or capture mechanism.
+
+export function userPromptsForWorkspace(workspaceId: string, limit = 200): UserPrompt[] {
+  const d = openDbOrThrow();
+  const rows = d
+    .prepare(`
+      SELECT u.id        AS id,
+             u.session_id AS session_id,
+             u.ts        AS ts,
+             u.tool_name AS tool_name,
+             u.tool_input AS input,
+             (r.id IS NOT NULL) AS resolved
+      FROM events u
+      LEFT JOIN events r
+        ON r.session_id = u.session_id
+       AND r.tool_use_id = u.tool_use_id
+       AND r.tool_result_is_error IS NOT NULL
+      WHERE u.workspace_id = ?
+        AND u.tool_use_id IS NOT NULL
+        AND u.tool_name IN ('AskUserQuestion', 'ExitPlanMode')
+      ORDER BY u.ts DESC, u.id DESC
+      LIMIT ?
+    `)
+    .all(workspaceId, limit) as Array<{
+    id: number;
+    session_id: string;
+    ts: number | null;
+    tool_name: string;
+    input: string | null;
+    resolved: number;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    sessionId: r.session_id,
+    ts: r.ts,
+    kind: r.tool_name === 'ExitPlanMode' ? 'plan' : 'ask',
+    input: r.input,
+    resolved: !!r.resolved
+  }));
 }
 
 // ── broker_sessions: per-tab mapping ──────────────────────────────────────

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
   summaryForBrokerSession,
   costForSession,
   costForWorkspace,
+  userPromptsForWorkspace,
   learnBrokerSessionMapping,
   lookupBrokerSession,
 } from './db.js';
@@ -487,6 +488,12 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   );
   ipcMain.handle('observability:getCostForWorkspace', (_e, workspaceId: string) =>
     costForWorkspace(workspaceId)
+  );
+
+  // User-prompt log (#11): AskUserQuestion / ExitPlanMode moments from the
+  // transcript, newest first, each with a resolved flag.
+  ipcMain.handle('userPrompts:list', (_e, workspaceId: string) =>
+    userPromptsForWorkspace(workspaceId)
   );
 
   // Renderer-side error reporting bridge. The renderer's onerror /

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -65,6 +65,19 @@ export interface WorkspaceObservabilitySummary {
   costSeries: number[];
 }
 
+/** A moment Claude asked the user something (#11) — from the transcript. */
+export interface UserPromptRow {
+  id: number;
+  sessionId: string;
+  ts: number | null;
+  /** 'ask' = AskUserQuestion, 'plan' = ExitPlanMode. */
+  kind: 'ask' | 'plan';
+  /** Question/plan preview (summarized); full detail in the transcript. */
+  input: string | null;
+  /** Whether the user resolved it (a tool_result followed). */
+  resolved: boolean;
+}
+
 export interface ObservabilityCost {
   inputTokens: number;
   outputTokens: number;
@@ -269,6 +282,11 @@ const api = {
       ipcRenderer.on(channel, handler);
       return () => ipcRenderer.removeListener(channel, handler);
     }
+  },
+  userPrompts: {
+    /** Moments Claude asked the user (AskUserQuestion / ExitPlanMode), newest first (#11). */
+    list: (workspaceId: string): Promise<UserPromptRow[]> =>
+      ipcRenderer.invoke('userPrompts:list', workspaceId)
   }
 };
 

--- a/tests/observability.spec.ts
+++ b/tests/observability.spec.ts
@@ -260,6 +260,84 @@ test('Tool-call detail + cost series: ingest derives duration/status and per-tur
   }
 });
 
+test('User-prompt log: AskUserQuestion/ExitPlanMode surface with resolved status (#11)', async () => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'claude-fleet-prompts-'));
+  const id = '01TESTPROMPTS000000000WS';
+  const name = 'prompts-test-ws';
+  const stateDir = path.join(userDataDir, 'state', id);
+  const projectsDir = path.join(stateDir, '.claude', 'projects', '-workspace');
+  mkdirSync(projectsDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, 'workspace.json'),
+    JSON.stringify({
+      id, name, labels: [],
+      workspaceRoot: '/tmp/fleet-test-' + name, workspaceSubdir: '',
+      kind: 'container', image: 'mock', authMode: 'oauth',
+      env: { plain: {}, secretKeys: [] }, createdAt: Date.now(), lastUsedAt: Date.now()
+    })
+  );
+
+  const app = await electron.launch({
+    args: [REPO_ROOT, `--user-data-dir=${userDataDir}`],
+    cwd: REPO_ROOT,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([k]) => k !== 'CLAUDE_FLEET_MOCK')
+    ) as Record<string, string>
+  });
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  try {
+    await new Promise((r) => setTimeout(r, 500));
+    const sessionId = randomUUID();
+    const lines = [
+      // AskUserQuestion, answered (a tool_result follows).
+      {
+        type: 'assistant', uuid: randomUUID(), timestamp: '2026-01-01T00:00:00.000Z',
+        message: { model: 'claude-opus-4-8', content: [
+          { type: 'tool_use', id: 'toolu_ask', name: 'AskUserQuestion', input: { questions: [{ question: 'Pick one' }] } }
+        ] }
+      },
+      {
+        type: 'user', uuid: randomUUID(), timestamp: '2026-01-01T00:00:05.000Z',
+        message: { content: [{ type: 'tool_result', tool_use_id: 'toolu_ask', is_error: false }] }
+      },
+      // ExitPlanMode, still pending (no tool_result).
+      {
+        type: 'assistant', uuid: randomUUID(), timestamp: '2026-01-01T00:00:10.000Z',
+        message: { model: 'claude-opus-4-8', content: [
+          { type: 'tool_use', id: 'toolu_plan', name: 'ExitPlanMode', input: { plan: 'do the thing' } }
+        ] }
+      }
+    ];
+    writeFileSync(
+      path.join(projectsDir, `${sessionId}.jsonl`),
+      lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+    );
+
+    await expect
+      .poll(
+        async () =>
+          window.evaluate(async (wsId) => {
+            const r = await window.api.userPrompts.list(wsId);
+            return r.length;
+          }, id),
+        { timeout: 8_000, intervals: [200, 500, 1000] }
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    const prompts = await window.evaluate((wsId) => window.api.userPrompts.list(wsId), id);
+    const ask = prompts!.find((p) => p.kind === 'ask');
+    const plan = prompts!.find((p) => p.kind === 'plan');
+    expect(ask).toBeTruthy();
+    expect(ask!.resolved).toBe(true);
+    expect(plan).toBeTruthy();
+    expect(plan!.resolved).toBe(false);
+  } finally {
+    await app.close();
+  }
+});
+
 test('Cost sparkline: renders one bar per costSeries entry in the pane', async () => {
   const { app, window } = await launch();
   try {


### PR DESCRIPTION
Reworks #11 after #76's Notification-hook approach was abandoned (live testing showed claude loads **zero** hooks from a provisioned `settings.json`, and permission prompts don't occur in claude-fleet — tools auto-allow). This captures the "Claude is waiting on the user" moments that **do** occur and **are** already in the transcript.

## Approach

`AskUserQuestion` and `ExitPlanMode` are `tool_use` events already ingested into `events` (Phase B). So this is a **pure query** — no new table, no migration, no hooks, no watcher/container changes:

- `db.userPromptsForWorkspace(workspaceId)` — `tool_use` rows with `tool_name IN ('AskUserQuestion','ExitPlanMode')`, LEFT-JOINed to their `tool_result` (by `tool_use_id`) for a **`resolved`** flag, mapped to **`kind`** `'ask'`/`'plan'` with the summarized `tool_input` as a preview.
- `userPrompts:list(workspaceId)` IPC + preload `api.userPrompts.list`.

## Why not the hook approach (context)

Documented in SPEC §11: generic permission prompts aren't in the JSONL and don't happen here (claude auto-allowed `Bash` in ~5 ms, no prompt); and a `Notification` hook provisioned into the container never loaded (`--debug`: "Found 0 total hooks in registry"), apparently behind a hook-approval gate with no way to pre-seed. So the JSONL `tool_use` path is the reliable source.

## Tests

- +1 e2e (real watcher): ingests an **answered** `AskUserQuestion` + a **pending** `ExitPlanMode`; `userPrompts:list` returns both with correct `kind` and `resolved` (`true`/`false`).
- **56 unit + 72 e2e**, all green. SPEC §11 updated.

## Deferred

The passive log **UI** and wiring the chip **needs-input** affordance off unresolved prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)