### PR TITLE
Make the Workspace Path row open the folder under WSL

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -197,7 +197,7 @@ Both main and renderer hook the standard "uncaught" channels and forward each cr
 Host-filesystem helpers used by the workspace-create flow and the observability rail. The renderer is contextIsolated/sandboxed, so all disk access goes through main:
 - `fs:isDirectory(path)` → `boolean` — whether `path` is an existing directory (workspace-root validation).
 - `fs:mkdirp(path)` → `void` — create a directory and parents.
-- `fs:openPath(path)` → `string` — reveal a host path in the OS file manager via `shell.openPath` (cross-platform: Finder/Explorer/file manager). Resolves `''` on success or an error string; never rejects. Empty/non-string input returns `'No path provided'`. Drives the observability rail's Workspace **Path** row.
+- `fs:openPath(path)` → `string` — reveal a host path in the OS file manager. On native macOS/Windows/Linux this is `shell.openPath`. **Under WSL** (detected once at load via `src/main/wsl.ts` — Linux platform + `WSL_DISTRO_NAME` or "microsoft" in `/proc/version`) `shell.openPath` can't reach a GUI file manager (no `xdg-open`/no Linux file manager), so the path is translated with `wslpath -w` and opened with `explorer.exe` (whose exit code is ignored — it returns 1 even on success). Resolves `''` on success or an error string; never rejects. Empty/non-string input returns `'No path provided'`. Drives the observability rail's Workspace **Path** row; the renderer routes any error string to `app:logError`.
 - `dialog:pickDirectory(defaultPath?)` → `string | null` — native open-directory dialog; null on cancel.
 
 ### Clipboard + context menu

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,8 @@
 import { ipcMain, BrowserWindow, dialog, clipboard, Menu, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { isWslEnvironment } from './wsl.js';
 import * as realDocker from './docker.js';
 import * as mockDocker from './mock.js';
 import * as vault from './vault.js';
@@ -38,6 +41,48 @@ export const MOCK_MODE = process.env.CLAUDE_FLEET_MOCK === '1';
 const backend = MOCK_MODE ? mockDocker : realDocker;
 
 const ptySessions = new Map<string, PtyHandle>();
+
+// Detected once at load: are we running under WSL? (Drives `fs:openPath`.)
+const RUNNING_IN_WSL = ((): boolean => {
+  let procVersion = '';
+  try {
+    procVersion = readFileSync('/proc/version', 'utf8');
+  } catch {
+    /* not linux / no procfs */
+  }
+  return isWslEnvironment({
+    platform: process.platform,
+    wslDistroName: process.env.WSL_DISTRO_NAME,
+    procVersion
+  });
+})();
+
+/**
+ * Open a host path in Windows Explorer from WSL: translate the Linux path to a
+ * Windows path via `wslpath -w`, then hand it to explorer.exe. explorer.exe
+ * exits 1 even on success, so its exit code is ignored — once we have a
+ * translated path we resolve optimistically. Resolves '' on success or an
+ * error string if the translation itself fails.
+ */
+function openPathViaExplorer(path: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile('wslpath', ['-w', path], (err, stdout) => {
+      if (err) {
+        resolve(`wslpath failed: ${err.message}`);
+        return;
+      }
+      const winPath = stdout.trim();
+      if (!winPath) {
+        resolve('wslpath returned an empty path');
+        return;
+      }
+      execFile('explorer.exe', [winPath], () => {
+        /* explorer.exe exits 1 even on success — ignore */
+      });
+      resolve('');
+    });
+  });
+}
 
 interface RegisterIpcOpts {
   jsonlWatcher: JsonlWatcher | null;
@@ -274,10 +319,12 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   ipcMain.handle('fs:mkdirp', (_e, path: string) => fs.mkdirp(path));
 
   // Reveal a host path in the OS file manager (Finder/Explorer/etc.). Returns
-  // '' on success, or an error string — shell.openPath never rejects.
+  // '' on success, or an error string. Under WSL `shell.openPath` can't reach a
+  // GUI file manager (no xdg-open / no Linux file manager), so route through
+  // explorer.exe instead. Neither path rejects — callers get a string.
   ipcMain.handle('fs:openPath', async (_e, path: string) => {
     if (typeof path !== 'string' || path.length === 0) return 'No path provided';
-    return shell.openPath(path);
+    return RUNNING_IN_WSL ? openPathViaExplorer(path) : shell.openPath(path);
   });
 
   ipcMain.handle('dialog:pickDirectory', async (event, defaultPath?: string) => {

--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { isWslEnvironment } from './wsl';
+
+describe('isWslEnvironment', () => {
+  it('is false on non-linux platforms', () => {
+    expect(isWslEnvironment({ platform: 'darwin', wslDistroName: 'Ubuntu' })).toBe(false);
+    expect(isWslEnvironment({ platform: 'win32' })).toBe(false);
+  });
+
+  it('is true on linux when WSL_DISTRO_NAME is set', () => {
+    expect(isWslEnvironment({ platform: 'linux', wslDistroName: 'Ubuntu-24.04' })).toBe(true);
+  });
+
+  it('is true on linux when /proc/version names microsoft', () => {
+    expect(
+      isWslEnvironment({
+        platform: 'linux',
+        procVersion: 'Linux version 6.6.114.1-microsoft-standard-WSL2'
+      })
+    ).toBe(true);
+  });
+
+  it('is false on plain linux (no WSL markers)', () => {
+    expect(
+      isWslEnvironment({ platform: 'linux', procVersion: 'Linux version 6.8.0-generic' })
+    ).toBe(false);
+    expect(isWslEnvironment({ platform: 'linux' })).toBe(false);
+  });
+});

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,0 +1,22 @@
+// WSL detection for host-path opening. Under WSL2 there is typically no Linux
+// file manager and no `xdg-open`, so Electron's `shell.openPath` fails
+// silently. We instead translate the path with `wslpath -w` and hand it to
+// `explorer.exe`. This module isolates the (pure) detection so it can be unit
+// tested without spawning anything.
+
+/**
+ * True when the process is running inside WSL — `shell.openPath` won't reach a
+ * GUI file manager and the explorer.exe bridge should be used instead.
+ *
+ * Detection order: only Linux can be WSL; `WSL_DISTRO_NAME` is set in every
+ * WSL shell; otherwise `/proc/version` contains "microsoft" under WSL kernels.
+ */
+export function isWslEnvironment(opts: {
+  platform: NodeJS.Platform;
+  wslDistroName?: string;
+  procVersion?: string;
+}): boolean {
+  if (opts.platform !== 'linux') return false;
+  if (opts.wslDistroName && opts.wslDistroName.length > 0) return true;
+  return (opts.procVersion ?? '').toLowerCase().includes('microsoft');
+}

--- a/src/renderer/src/components/ObservabilityPane.tsx
+++ b/src/renderer/src/components/ObservabilityPane.tsx
@@ -258,7 +258,13 @@ function WorkspaceBlock({ workspace }: { workspace: WorkspaceSummary }) {
 
   const openFolder = async () => {
     const err = await window.api.fs.openPath(fullPath);
-    if (err) console.warn(`Could not open ${fullPath}: ${err}`);
+    if (err) {
+      void window.api.app.logError({
+        type: 'openPath',
+        message: `Could not open workspace folder: ${err}`,
+        extra: { path: fullPath }
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
Follow-up to #81. The Workspace **Path** row called `shell.openPath`, which **silently fails under WSL2** — there's no Linux file manager and no `xdg-open`, so clicking the folder did nothing (the error only reached the console). That's why "clicking the folder icon doesn't pull up a file explorer."

## Fix
- Detect WSL once at load (`src/main/wsl.ts`: Linux + `WSL_DISTRO_NAME` or "microsoft" in `/proc/version`).
- Under WSL, route `fs:openPath` through **explorer.exe**: translate the Linux path with `wslpath -w`, then open it. explorer.exe exits 1 even on success, so its exit code is ignored.
- Native macOS / Windows / Linux are unchanged (`shell.openPath`).
- The renderer now logs any error string via `app:logError` instead of `console.warn` — a future silent failure leaves a trace in `error.log`.

## Tests
- Unit: +4 (`wsl.test.ts`) — 74 total green.
- Verified the **real** `fs:openPath` handler (no mock) returns `''` and opens Explorer in this WSL environment.
- Full e2e suite green (72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)