### PR TITLE
Keep e2e fleet folders out of the real ~/fleet

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -203,7 +203,7 @@ Host-filesystem helpers used by the workspace-create flow and the observability 
 
 ### Settings (app config)
 App-level settings persist to `<userData>/config.json`. Currently just the **fleet root** — the single host dir holding every workspace's private folder (`<fleetRoot>/<id>`) and the shared folder (`<fleetRoot>/shared`).
-- `config:get()` → `{ fleetRoot, sharedDir }` — current fleet root (defaults to `~/fleet` when unset) and its derived `<fleetRoot>/shared`.
+- `config:get()` → `{ fleetRoot, sharedDir }` — current fleet root and its derived `<fleetRoot>/shared`. Precedence: `CLAUDE_FLEET_ROOT` env override (the e2e suite sets this in `tests/_helpers.ts` so test runs don't pollute the real `~/fleet`) → the persisted config value → the `~/fleet` default.
 - `config:setFleetRoot(path)` → `{ fleetRoot, sharedDir }` — persist a new fleet root (the dir is created). Surfaced via the top-strip gear → `SettingsModal`. Takes effect for new containers and for existing ones on next restart (running containers keep their current mounts until recreated).
 
 ### Clipboard + context menu

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -43,8 +43,14 @@ async function write(next: AppConfig): Promise<void> {
   await writeFile(configPath(), JSON.stringify(next, null, 2) + '\n', 'utf8');
 }
 
-/** The configured fleet root, or the default when unset. Always absolute. */
+/**
+ * The fleet root. Precedence: `CLAUDE_FLEET_ROOT` env override (used by the
+ * e2e suite to keep test runs out of the real `~/fleet`) → the persisted
+ * config value → the `~/fleet` default. Always absolute.
+ */
 export async function getFleetRoot(): Promise<string> {
+  const override = process.env.CLAUDE_FLEET_ROOT?.trim();
+  if (override) return override;
   const cfg = await read();
   return cfg.fleetRoot ?? defaultFleetRoot();
 }

--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -19,6 +19,14 @@ import path from 'node:path';
 
 export const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 
+// Keep the e2e suite's fleet folders out of the real ~/fleet. This module is
+// imported by every spec, so the assignment runs in each Playwright worker
+// before any app launch; config.ts reads CLAUDE_FLEET_ROOT ahead of the
+// ~/fleet default, and the launch envs all spread `process.env`, so the
+// startup migration + workspace creates land in a throwaway temp dir.
+// `??=` lets an explicit shell value still win.
+process.env.CLAUDE_FLEET_ROOT ??= path.join(tmpdir(), 'claude-fleet-test-root');
+
 /**
  * Scope locators to the currently-visible TerminalPane. Every live
  * workspace's pane is always-mounted (see App.tsx's


### PR DESCRIPTION
Follow-up to #83. The fleet-folder startup migration derives its root from `$HOME`, so e2e runs were quietly creating per-workspace test dirs (`01TEST*`) and `shared/` in the developer's real `~/fleet`.

## Fix
- `config.ts` honors a **`CLAUDE_FLEET_ROOT`** env override: env → persisted config → `~/fleet` default.
- `tests/_helpers.ts` sets it (`??=`, so a shell value still wins) to a temp dir at module load. That runs **in each Playwright worker** before any app launch, and every launch env spreads `process.env`, so the override reaches the launched app reliably (a `playwright.config.ts` side-effect does **not** propagate to workers).

## Verified
Full suite (69) green; every migration dir lands in `…/claude-fleet-test-root`, and `~/fleet` is left untouched (just the real workspaces). Cleaned up the stray `01TEST*` dirs a prior run left in `~/fleet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)