### PR TITLE
fix(broker): reject concurrent ATTACH instead of stomping the writer (#64)

### DIFF
--- a/broker/internal/server/server_test.go
+++ b/broker/internal/server/server_test.go
@@ -20,8 +20,17 @@ import (
 // the server + manager down.
 func startTestServer(t *testing.T) (client *net.UnixConn, cleanup func()) {
 	t.Helper()
+	conn, _, cleanup := startTestServerWithPath(t)
+	return conn, cleanup
+}
+
+// startTestServerWithPath is startTestServer that also returns the socket
+// path, so a test can dial a second connection to the same broker (the #64
+// concurrent-attach repro).
+func startTestServerWithPath(t *testing.T) (client *net.UnixConn, sockPath string, cleanup func()) {
+	t.Helper()
 	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "broker.sock")
+	sockPath = filepath.Join(dir, "broker.sock")
 
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -57,7 +66,7 @@ func startTestServer(t *testing.T) (client *net.UnixConn, cleanup func()) {
 		mgr.CloseAll()
 		<-serveErr
 	}
-	return uc, cleanup
+	return uc, sockPath, cleanup
 }
 
 // expectFrame reads one frame and asserts the type, returning the payload.
@@ -73,6 +82,29 @@ func expectFrame(t *testing.T, conn net.Conn, want proto.FrameType) []byte {
 		t.Fatalf("frame type: got %v, want %v (payload %q)", got, want, payload)
 	}
 	return payload
+}
+
+// readUntilFrame keeps reading frames until one of wantType arrives (or
+// the deadline hits), skipping any frames in between. Needed when a stray
+// channel-data frame — e.g. the PTY line-discipline echo of just-sent
+// input, which arrives as a second OUTPUT alongside the program's own
+// stdout — may still be in flight ahead of a control-frame ack. The real
+// host client demuxes by frame type rather than expecting a rigid order.
+func readUntilFrame(t *testing.T, conn net.Conn, want proto.FrameType) []byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(deadline)
+		got, payload, err := proto.ReadFrame(conn)
+		if err != nil {
+			t.Fatalf("read frame: %v", err)
+		}
+		if got == want {
+			return payload
+		}
+	}
+	t.Fatalf("did not see frame %v before deadline", want)
+	return nil
 }
 
 // readUntilFrameContains keeps reading frames until one of the given
@@ -211,9 +243,10 @@ func TestServer_DetachAndReattachReplaysHistory(t *testing.T) {
 		t.Fatal("did not see initial OUTPUT")
 	}
 
-	// DETACH ch=1
+	// DETACH ch=1. A second OUTPUT frame (the PTY echo of "aaa\n") may still
+	// be in flight, so skip past any stray frames to the DETACHED ack.
 	_ = proto.WriteJSONFrame(conn, proto.FrameDetach, proto.ChannelRequest{Channel: 1})
-	expectFrame(t, conn, proto.FrameDetached)
+	readUntilFrame(t, conn, proto.FrameDetached)
 
 	// Re-ATTACH ch=2. Should produce a HISTORY frame containing the
 	// earlier "aaa" bytes.
@@ -222,5 +255,40 @@ func TestServer_DetachAndReattachReplaysHistory(t *testing.T) {
 
 	if !readUntilFrameContains(t, conn, proto.FrameHistory, []byte("aaa")) {
 		t.Fatal("expected HISTORY frame with 'aaa' after re-attach")
+	}
+}
+
+func TestServer_SecondConnAttachToHeldSessionRejected(t *testing.T) {
+	// #64 repro: a second connection ATTACHing a session that another
+	// connection already holds must be rejected (OK:false), not silently
+	// stomp the first connection's writer and blind it.
+	conn, sockPath, cleanup := startTestServerWithPath(t)
+	defer cleanup()
+
+	_ = proto.WriteJSONFrame(conn, proto.FrameCreate, proto.CreateRequest{ID: "held", Cols: 80, Rows: 24})
+	expectFrame(t, conn, proto.FrameCreated)
+	_ = proto.WriteJSONFrame(conn, proto.FrameAttach, proto.AttachRequest{ID: "held", Channel: 1})
+	expectFrame(t, conn, proto.FrameAttached)
+
+	// A separate connection probes the same session id.
+	conn2, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial second conn: %v", err)
+	}
+	defer conn2.Close()
+	_ = proto.WriteJSONFrame(conn2, proto.FrameAttach, proto.AttachRequest{ID: "held", Channel: 1})
+	payload := expectFrame(t, conn2, proto.FrameAttached)
+	var resp proto.AttachResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		t.Fatalf("unmarshal AttachResponse: %v", err)
+	}
+	if resp.OK {
+		t.Fatal("second attach to a held session should be rejected, got OK=true")
+	}
+
+	// The first connection still receives live OUTPUT — it was never stomped.
+	_ = proto.WriteFrame(conn, proto.FrameInput, proto.EncodeChannelData(1, []byte("zzz\n")))
+	if !readUntilFrameContains(t, conn, proto.FrameOutput, []byte("zzz")) {
+		t.Fatal("first connection went blind after the rejected second attach")
 	}
 }

--- a/broker/internal/session/manager.go
+++ b/broker/internal/session/manager.go
@@ -101,7 +101,8 @@ type SessionInfo struct {
 }
 
 var (
-	ErrIDInUse  = errors.New("session: id already in use")
-	ErrNotFound = errors.New("session: not found")
-	ErrEnded    = errors.New("session: already ended")
+	ErrIDInUse         = errors.New("session: id already in use")
+	ErrNotFound        = errors.New("session: not found")
+	ErrEnded           = errors.New("session: already ended")
+	ErrAlreadyAttached = errors.New("session: already attached")
 )

--- a/broker/internal/session/manager_test.go
+++ b/broker/internal/session/manager_test.go
@@ -175,6 +175,44 @@ func TestSession_DetachStopsDelivery(t *testing.T) {
 	}
 }
 
+func TestSession_AttachRejectedWhenAlreadyAttached(t *testing.T) {
+	// A second ATTACH for a session that already has a live writer must be
+	// rejected, never silently stomp the first writer (#64). A stomped
+	// writer goes blind — claude's OUTPUT flows to the new writer while the
+	// original connection still thinks it's attached.
+	mgr := NewManager(ManagerConfig{ClaudeExec: "/bin/cat", RingBufBytes: 1024})
+	defer mgr.CloseAll()
+
+	sess, err := mgr.Create("sess-dual", 80, 24, nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cw1 := &captureWriter{}
+	if _, err := sess.Attach(cw1, 1); err != nil {
+		t.Fatalf("first Attach: %v", err)
+	}
+
+	// A second connection probing the same session id (any channel) must be
+	// rejected outright.
+	cw2 := &captureWriter{}
+	if _, err := sess.Attach(cw2, 2); err != ErrAlreadyAttached {
+		t.Fatalf("second Attach: got %v, want ErrAlreadyAttached", err)
+	}
+
+	// The original writer keeps receiving live output; the rejected one
+	// receives nothing.
+	if err := sess.Input([]byte("needle\n")); err != nil {
+		t.Fatalf("Input: %v", err)
+	}
+	if !waitUntil(func() bool { return bytes.Contains(cw1.joined(), []byte("needle")) }) {
+		t.Errorf("original writer went blind after a rejected attach; got %q", cw1.joined())
+	}
+	if len(cw2.all()) != 0 {
+		t.Errorf("rejected writer received %d frames, want 0", len(cw2.all()))
+	}
+}
+
 func TestSession_ReattachReplaysHistory(t *testing.T) {
 	mgr := NewManager(ManagerConfig{ClaudeExec: "/bin/cat", RingBufBytes: 1024})
 	defer mgr.CloseAll()

--- a/broker/internal/session/session.go
+++ b/broker/internal/session/session.go
@@ -142,12 +142,22 @@ func (s *Session) ExitError() error {
 // Attach claims the session for delivery on the given channel via w.
 // Returns the ring buffer's current contents — the caller is expected
 // to ship these as HISTORY frames before live OUTPUT begins.
-// ErrEnded if the session has already exited.
+// ErrEnded if the session has already exited; ErrAlreadyAttached if a
+// live writer already holds the session (the caller must DETACH first).
 func (s *Session) Attach(w ChannelWriter, channel uint32) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.dead {
 		return s.ring.Snapshot(), ErrEnded
+	}
+	if s.attached.writer != nil {
+		// Already claimed by a live connection. Reject rather than stomp
+		// the existing writer — otherwise the original connection silently
+		// goes blind (its OUTPUT flows to the new writer) while still
+		// believing it's attached (#64). The host's normal re-attach
+		// DETACHes first, so it never trips this; only a second connection
+		// (external probe, future second window) reaches here.
+		return nil, ErrAlreadyAttached
 	}
 	s.attached = attachState{writer: w, channel: channel}
 	return s.ring.Snapshot(), nil

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -102,6 +102,8 @@ binds (per container):
 
 The **broker** is a small Go daemon (//broker) shipped inside the runner image. It owns every claude PTY in the container and exposes them via a Unix-socket protocol. The host's Electron main process attaches via the bind-mounted socket directory rather than running `docker exec claude` directly. This is the foundation of "expert workspaces" (issue #18): PTYs outlive any individual host disconnect (app quit, app crash), so when the user pauses + closes the app + reopens + unpauses, every session reattaches to the same live `claude` process with its in-memory context (analyses, file watches, MCP server state) intact.
 
+Each broker session has **at most one live writer**. An `ATTACH` to a session that already holds a writer is rejected (`ATTACHED` with `OK:false`, error `session: already attached`) rather than silently replacing it — otherwise the displaced connection keeps believing it's attached while claude's OUTPUT flows to the newcomer, blinding the original. The host's normal re-attach `DETACH`es first, so it never trips this; the guard exists for a second connection on the socket (an external probe, or a future second window). Reconnect-after-disconnect still works: a dropped connection's deferred cleanup `DETACH`es its sessions, clearing the writer for the next attach.
+
 **Main process** owns everything privileged:
 - Docker daemon access via `dockerode` (default socket).
 - OS keychain access via `keytar`.


### PR DESCRIPTION
Fixes #64.

## The bug

A broker `Session` held a single `attached.writer`. Any `ATTACH` for an already-attached session **overwrote** that writer without notifying the previous holder. The displaced connection's per-connection channel map was untouched, so it kept believing it was attached — while claude's OUTPUT silently rerouted to the newcomer. The original connection went blind (INPUT still worked), with no log line and no error to either side.

It never fires under normal single-host use (the host's re-attach `DETACH`es first), but:
- an external probe on the broker socket (diagnostics, ad-hoc HISTORY reader) silently breaks the live session;
- a future second window attaching to the same broker session would break the first.

## The fix

`Session.Attach` now returns a new `ErrAlreadyAttached` when a live writer already holds the session, **leaving the existing writer untouched**. The server already returns early on a non-`ErrEnded` `Attach` error (`ATTACHED` `OK:false`, without recording the channel), so the second client gets a clean rejection. Reconnect-after-disconnect is unaffected — a dropped connection's deferred cleanup `DETACH`es its sessions, clearing the writer for the next attach.

The host `BrokerClient` caller already checks `!attachResp.ok` and throws (`docker.ts:590`), routing to the `pty-attach-failed` error.log path — so even the unreachable case degrades gracefully with no host-side change.

## Tests (TDD)

- **`session.AttachRejectedWhenAlreadyAttached`** — second attach returns `ErrAlreadyAttached`; the original writer keeps receiving output. Written red-first (failed on the unfixed `Attach`), green after.
- **`server.SecondConnAttachToHeldSessionRejected`** — the issue's literal two-connection repro over a real Unix socket: second conn gets `OK:false`, first conn stays live.
- **Pre-existing flake fixed:** `DetachAndReattachReplaysHistory` failed ~40% of runs on `main` (confirmed by stashing this change) — the PTY line-discipline echo emits a *second* OUTPUT frame that raced ahead of the DETACHED ack. New `readUntilFrame` helper skips stray frames to the wanted control ack, mirroring how the real host demuxes by frame type. Now 15/15 stable.

Full broker suite green under `go test -race ./...`.

## Spec

Documented the single-writer-per-session invariant in the broker section (§5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)