### PR TITLE
feat: hardware-acceleration toggle in Settings + env override (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ The top strip pre-populates with two fake workspaces; `+ New workspace` adds mor
 
 Mock mode is dev-only — the env var is ignored by the packaged build.
 
+### Quiet the WSLg GPU error
+
+On WSLg, Chromium's GPU process fails to initialize (`viz_main_impl.cc(166) ERROR: Exiting GPU process due to errors during initialization`). It's harmless — rendering falls back to CPU — but it clutters the dev terminal every session and buries real errors. Disable hardware acceleration to silence it:
+
+```bash
+CLAUDE_FLEET_DISABLE_HWA=1 npm run dev
+```
+
 ## Test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Mock mode is dev-only — the env var is ignored by the packaged build.
 
 ### Quiet the WSLg GPU error
 
-On WSLg, Chromium's GPU process fails to initialize (`viz_main_impl.cc(166) ERROR: Exiting GPU process due to errors during initialization`). It's harmless — rendering falls back to CPU — but it clutters the dev terminal every session and buries real errors. Disable hardware acceleration to silence it:
+On WSLg, Chromium's GPU process fails to initialize (`viz_main_impl.cc(166) ERROR: Exiting GPU process due to errors during initialization`). It's harmless — rendering falls back to CPU — but it clutters the dev terminal every session and buries real errors.
+
+Turn on **Settings (gear icon) → Disable hardware acceleration** and restart the app. For a one-off dev run, the `CLAUDE_FLEET_DISABLE_HWA=1` env var forces it on without touching the setting:
 
 ```bash
 CLAUDE_FLEET_DISABLE_HWA=1 npm run dev

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -837,10 +837,10 @@ Intentionally narrow scope: this is for iterating on UI without a daemon, image,
 - **Test fixtures.** Shared in-memory DB seed vs. per-test container/profile fixtures.
 
 ### App-level Settings surface
-No Settings panel exists yet. The first concrete item that needs one is a toggle for hardware acceleration (issue #13) — Chromium's GPU process fails noisily on WSLg with `viz_main_impl.cc(166) ERROR: Exiting GPU process during initialization`. The fix in code is one line — `app.disableHardwareAcceleration()` before `app.whenReady()` — but it needs a UI control to flip without editing source.
+No Settings panel exists yet. The hardware-acceleration toggle (issue #13) ships today as an **env-var escape hatch**: setting `CLAUDE_FLEET_DISABLE_HWA=1` calls `app.disableHardwareAcceleration()` before the `ready` event, suppressing Chromium's noisy GPU-init failure on WSLg (`viz_main_impl.cc(166) ERROR: Exiting GPU process during initialization` — harmless, but it spams the dev terminal every session). This matches the dev-fallback pattern already used for `CLAUDE_FLEET_MOCK` / `ANTHROPIC_API_KEY`. A real Settings modal is still the right end state — it's just not the blocker for silencing the GPU log.
 
 **Open:**
-- **Env-var escape hatch first, or full panel up front.** `CLAUDE_FLEET_DISABLE_HWA=1` would be a five-minute shortcut (and matches the dev-fallback pattern we already use for `ANTHROPIC_API_KEY`); a real Settings modal is more work but is the right end state.
+- **Full Settings panel.** A real UI control would let a non-dev user flip HWA (and future toggles) without setting an env var. The env-var hatch unblocks the WSLg noise in the meantime.
 - **Persistence.** SQLite alongside `profile_settings` is the natural home — same DB the watcher and the rest of the app already share. A JSON config file under `userData` is the alternative if we want the Settings to survive a DB wipe.
 - **Likely future occupants** once the surface exists: log-verbosity, default `mirrorDefault`/`cleanupDefault` for new profiles, dev-shortcut indicators ("ANTHROPIC_API_KEY is sourced from env"), pull-progress UI preference, fast-mode toggle, etc.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -212,9 +212,12 @@ Host-filesystem helpers used by the workspace-create flow and the observability 
 - `dialog:pickDirectory(defaultPath?)` → `string | null` — native open-directory dialog; null on cancel.
 
 ### Settings (app config)
-App-level settings persist to `<userData>/config.json`. Currently just the **fleet root** — the single host dir holding every workspace's private folder (`<fleetRoot>/<id>`) and the shared folder (`<fleetRoot>/shared`).
-- `config:get()` → `{ fleetRoot, sharedDir }` — current fleet root and its derived `<fleetRoot>/shared`. Precedence: `CLAUDE_FLEET_ROOT` env override (the e2e suite sets this in `tests/_helpers.ts` so test runs don't pollute the real `~/fleet`) → the persisted config value → the `~/fleet` default.
-- `config:setFleetRoot(path)` → `{ fleetRoot, sharedDir }` — persist a new fleet root (the dir is created). Surfaced via the top-strip gear → `SettingsModal`. Takes effect for new containers and for existing ones on next restart (running containers keep their current mounts until recreated).
+App-level settings persist to `<userData>/config.json`: `{ fleetRoot?: string, disableHardwareAcceleration?: boolean }`. Both are surfaced via the top-strip gear → `SettingsModal`.
+- **Fleet root** — the single host dir holding every workspace's private folder (`<fleetRoot>/<id>`) and the shared folder (`<fleetRoot>/shared`).
+- **disableHardwareAcceleration** — when true, the app calls `app.disableHardwareAcceleration()` at startup. Silences Chromium's noisy GPU-init failure on WSLg (rendering falls back to CPU). Must be read **synchronously** at module load, before the `ready` event — `config.ts:hardwareAccelDisabledAtStartup()` does a `readFileSync` of `config.json` rather than going through the async cache. Changing it requires an app restart to take effect.
+- `config:get()` → `{ fleetRoot, sharedDir, disableHardwareAcceleration }` — current fleet root + its derived `<fleetRoot>/shared` + the persisted HWA flag (the persisted value, not the effective one — the env override below isn't reflected). Fleet-root precedence: `CLAUDE_FLEET_ROOT` env override (the e2e suite sets this in `tests/_helpers.ts` so test runs don't pollute the real `~/fleet`) → the persisted config value → the `~/fleet` default.
+- `config:setFleetRoot(path)` → `{ fleetRoot, sharedDir }` — persist a new fleet root (the dir is created). Takes effect for new containers and for existing ones on next restart (running containers keep their current mounts until recreated).
+- `config:setHardwareAccelDisabled(disabled)` → `{ disableHardwareAcceleration }` — persist the HWA flag. `CLAUDE_FLEET_DISABLE_HWA=1` is an env override (dev shortcut) that forces it on regardless of the persisted value, matching the `CLAUDE_FLEET_MOCK` / `ANTHROPIC_API_KEY` pattern.
 
 ### Clipboard + context menu
 The renderer cannot use `navigator.clipboard` reliably (focus/permission gotchas in Electron, and the renderer is contextIsolated). All clipboard access goes through main:
@@ -837,12 +840,10 @@ Intentionally narrow scope: this is for iterating on UI without a daemon, image,
 - **Test fixtures.** Shared in-memory DB seed vs. per-test container/profile fixtures.
 
 ### App-level Settings surface
-No Settings panel exists yet. The hardware-acceleration toggle (issue #13) ships today as an **env-var escape hatch**: setting `CLAUDE_FLEET_DISABLE_HWA=1` calls `app.disableHardwareAcceleration()` before the `ready` event, suppressing Chromium's noisy GPU-init failure on WSLg (`viz_main_impl.cc(166) ERROR: Exiting GPU process during initialization` — harmless, but it spams the dev terminal every session). This matches the dev-fallback pattern already used for `CLAUDE_FLEET_MOCK` / `ANTHROPIC_API_KEY`. A real Settings modal is still the right end state — it's just not the blocker for silencing the GPU log.
+The `SettingsModal` (top-strip gear) is the app-level Settings panel. It holds the **fleet root** and the **hardware-acceleration toggle** (issue #13 — see §6 *Settings*), both persisted to `config.json`. Settings live in `config.json` (not SQLite) so they survive a DB wipe and, critically, can be read synchronously at startup before the `ready` event (the HWA toggle's hard requirement).
 
 **Open:**
-- **Full Settings panel.** A real UI control would let a non-dev user flip HWA (and future toggles) without setting an env var. The env-var hatch unblocks the WSLg noise in the meantime.
-- **Persistence.** SQLite alongside `profile_settings` is the natural home — same DB the watcher and the rest of the app already share. A JSON config file under `userData` is the alternative if we want the Settings to survive a DB wipe.
-- **Likely future occupants** once the surface exists: log-verbosity, default `mirrorDefault`/`cleanupDefault` for new profiles, dev-shortcut indicators ("ANTHROPIC_API_KEY is sourced from env"), pull-progress UI preference, fast-mode toggle, etc.
+- **Likely future occupants:** log-verbosity, default `mirrorDefault`/`cleanupDefault` for new profiles, dev-shortcut indicators ("ANTHROPIC_API_KEY is sourced from env"), pull-progress UI preference, fast-mode toggle, etc. The modal is currently a single untabbed panel; it gains tabs/sections once enough toggles accumulate.
 
 ### Create-container UX
 The current flow is three sequential `window.prompt()` dialogs. Functional but crude. Needs a real modal form with: name, workspace root (with a directory picker — `dialog.showOpenDialog` from main), subdir, profile dropdown (populated from `vault:list`), and optional CPU/memory caps.

--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for the hardware-acceleration setting (#13). The `electron`
+// module is mocked so `app.getPath()` resolves to a per-test temp dir; the
+// rest is plain config.json fs work driven directly.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let userDataDir = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (which: string) => {
+      if (which === 'userData') return userDataDir;
+      if (which === 'home') return userDataDir;
+      throw new Error(`unexpected getPath: ${which}`);
+    }
+  }
+}));
+
+const {
+  hardwareAccelDisabledAtStartup,
+  getHardwareAccelDisabled,
+  setHardwareAccelDisabled,
+  setFleetRoot,
+  getFleetRoot,
+  _resetConfigCacheForTests
+} = await import('./config.js');
+
+const configPath = () => join(userDataDir, 'config.json');
+
+beforeEach(async () => {
+  userDataDir = await mkdtemp(join(tmpdir(), 'cf-config-'));
+  _resetConfigCacheForTests();
+  delete process.env.CLAUDE_FLEET_DISABLE_HWA;
+});
+
+afterEach(async () => {
+  await rm(userDataDir, { recursive: true, force: true });
+});
+
+describe('hardwareAccelDisabledAtStartup', () => {
+  it('is false when no config file exists', () => {
+    expect(hardwareAccelDisabledAtStartup()).toBe(false);
+  });
+
+  it('reflects the persisted setting (sync read of config.json)', async () => {
+    await writeFile(configPath(), JSON.stringify({ disableHardwareAcceleration: true }), 'utf8');
+    expect(hardwareAccelDisabledAtStartup()).toBe(true);
+  });
+
+  it('env override forces it on even when persisted false', async () => {
+    await writeFile(configPath(), JSON.stringify({ disableHardwareAcceleration: false }), 'utf8');
+    process.env.CLAUDE_FLEET_DISABLE_HWA = '1';
+    expect(hardwareAccelDisabledAtStartup()).toBe(true);
+  });
+});
+
+describe('get/setHardwareAccelDisabled', () => {
+  it('round-trips through config.json and is visible to the sync startup read', async () => {
+    expect(await getHardwareAccelDisabled()).toBe(false);
+    await setHardwareAccelDisabled(true);
+    expect(await getHardwareAccelDisabled()).toBe(true);
+    // The sync startup path reads disk directly, bypassing the cache.
+    _resetConfigCacheForTests();
+    expect(hardwareAccelDisabledAtStartup()).toBe(true);
+  });
+
+  it('does not clobber the fleet root, and vice versa', async () => {
+    const root = join(userDataDir, 'fleet');
+    await setFleetRoot(root);
+    await setHardwareAccelDisabled(true);
+    expect(await getFleetRoot()).toBe(root);
+    expect(await getHardwareAccelDisabled()).toBe(true);
+
+    // The on-disk file carries both keys.
+    const parsed = JSON.parse(await readFile(configPath(), 'utf8'));
+    expect(parsed.fleetRoot).toBe(root);
+    expect(parsed.disableHardwareAcceleration).toBe(true);
+  });
+});

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -6,11 +6,14 @@
 
 import { app } from 'electron';
 import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { assertValidWorkspaceId } from './paths.js';
 
 interface AppConfig {
   fleetRoot?: string;
+  /** When true, the app skips Chromium hardware acceleration at startup. */
+  disableHardwareAcceleration?: boolean;
 }
 
 function configPath(): string {
@@ -30,7 +33,8 @@ async function read(): Promise<AppConfig> {
     const raw = await readFile(configPath(), 'utf8');
     const parsed = JSON.parse(raw) as AppConfig;
     cached = {
-      fleetRoot: typeof parsed.fleetRoot === 'string' && parsed.fleetRoot ? parsed.fleetRoot : undefined
+      fleetRoot: typeof parsed.fleetRoot === 'string' && parsed.fleetRoot ? parsed.fleetRoot : undefined,
+      disableHardwareAcceleration: parsed.disableHardwareAcceleration === true
     };
   } catch {
     cached = {};
@@ -62,6 +66,36 @@ export async function setFleetRoot(path: string): Promise<void> {
   await mkdir(trimmed, { recursive: true });
   const cfg = await read();
   await write({ ...cfg, fleetRoot: trimmed });
+}
+
+/**
+ * Whether to disable Chromium hardware acceleration, decided at startup.
+ * Precedence: `CLAUDE_FLEET_DISABLE_HWA=1` env override (dev shortcut) → the
+ * persisted setting → off. Read **synchronously** because
+ * `app.disableHardwareAcceleration()` must be called before the `ready`
+ * event, before the async config cache is warmed. `app.getPath('userData')`
+ * is available this early.
+ */
+export function hardwareAccelDisabledAtStartup(): boolean {
+  if (process.env.CLAUDE_FLEET_DISABLE_HWA === '1') return true;
+  try {
+    const parsed = JSON.parse(readFileSync(configPath(), 'utf8')) as AppConfig;
+    return parsed.disableHardwareAcceleration === true;
+  } catch {
+    return false;
+  }
+}
+
+/** The persisted hardware-acceleration setting (ignores the env override). */
+export async function getHardwareAccelDisabled(): Promise<boolean> {
+  const cfg = await read();
+  return cfg.disableHardwareAcceleration === true;
+}
+
+/** Persist the hardware-acceleration setting. Takes effect on next launch. */
+export async function setHardwareAccelDisabled(disabled: boolean): Promise<void> {
+  const cfg = await read();
+  await write({ ...cfg, disableHardwareAcceleration: disabled });
 }
 
 /** `<fleetRoot>/<id>` — a workspace's private folder, mounted at /workspace. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,15 @@ const jsonlWatcher = isMock ? null : new JsonlWatcher();
 
 const isDev = process.env.NODE_ENV === 'development' || !!process.env.ELECTRON_RENDERER_URL;
 
+// On WSLg (and some headless/virtualized Linux setups) Chromium's GPU process
+// fails to initialize ("Exiting GPU process due to errors during
+// initialization") — harmless (rendering falls back to CPU) but it spams the
+// dev terminal every session and buries real errors. Set CLAUDE_FLEET_DISABLE_HWA=1
+// to skip GPU acceleration entirely. Must run before the `ready` event.
+if (process.env.CLAUDE_FLEET_DISABLE_HWA === '1') {
+  app.disableHardwareAcceleration();
+}
+
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
     width: 1400,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import { JsonlWatcher } from './jsonlWatcher.js';
 import { listWorkspaceManifests } from './workspaces.js';
 import { installMainProcessHandlers, getLogPath } from './errorLog.js';
 import { runStartupMigration } from './migration.js';
+import { hardwareAccelDisabledAtStartup } from './config.js';
 
 // Mock mode is for UI iteration without Docker; no real JSONLs exist, so the
 // watcher and DB stay dormant.
@@ -17,9 +18,10 @@ const isDev = process.env.NODE_ENV === 'development' || !!process.env.ELECTRON_R
 // On WSLg (and some headless/virtualized Linux setups) Chromium's GPU process
 // fails to initialize ("Exiting GPU process due to errors during
 // initialization") — harmless (rendering falls back to CPU) but it spams the
-// dev terminal every session and buries real errors. Set CLAUDE_FLEET_DISABLE_HWA=1
-// to skip GPU acceleration entirely. Must run before the `ready` event.
-if (process.env.CLAUDE_FLEET_DISABLE_HWA === '1') {
+// dev terminal every session and buries real errors. Controlled by the
+// Settings panel toggle (persisted in config.json) or the CLAUDE_FLEET_DISABLE_HWA
+// env override. Must run before the `ready` event, hence the sync read.
+if (hardwareAccelDisabledAtStartup()) {
   app.disableHardwareAcceleration();
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5,7 +5,14 @@ import { readFileSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
 import { workspaceTranscriptPath } from './paths.js';
 import { isWslEnvironment } from './wsl.js';
-import { getFleetRoot, setFleetRoot, fleetPrivateDir, fleetSharedDir } from './config.js';
+import {
+  getFleetRoot,
+  setFleetRoot,
+  fleetPrivateDir,
+  fleetSharedDir,
+  getHardwareAccelDisabled,
+  setHardwareAccelDisabled
+} from './config.js';
 import * as realDocker from './docker.js';
 import * as mockDocker from './mock.js';
 import * as vault from './vault.js';
@@ -417,11 +424,16 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   // surface a "Shared" link without recomputing the join.
   ipcMain.handle('config:get', async () => ({
     fleetRoot: await getFleetRoot(),
-    sharedDir: await fleetSharedDir()
+    sharedDir: await fleetSharedDir(),
+    disableHardwareAcceleration: await getHardwareAccelDisabled()
   }));
   ipcMain.handle('config:setFleetRoot', async (_e, path: string) => {
     await setFleetRoot(path);
     return { fleetRoot: await getFleetRoot(), sharedDir: await fleetSharedDir() };
+  });
+  ipcMain.handle('config:setHardwareAccelDisabled', async (_e, disabled: boolean) => {
+    await setHardwareAccelDisabled(!!disabled);
+    return { disableHardwareAcceleration: await getHardwareAccelDisabled() };
   });
 
   ipcMain.handle('dialog:pickDirectory', async (event, defaultPath?: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,10 +203,19 @@ const api = {
     openPath: (path: string): Promise<string> => ipcRenderer.invoke('fs:openPath', path)
   },
   config: {
-    /** App-level settings: the fleet root and its derived shared folder. */
-    get: (): Promise<{ fleetRoot: string; sharedDir: string }> => ipcRenderer.invoke('config:get'),
+    /** App-level settings: the fleet root, its derived shared folder, and the
+     *  hardware-acceleration toggle. */
+    get: (): Promise<{
+      fleetRoot: string;
+      sharedDir: string;
+      disableHardwareAcceleration: boolean;
+    }> => ipcRenderer.invoke('config:get'),
     setFleetRoot: (path: string): Promise<{ fleetRoot: string; sharedDir: string }> =>
-      ipcRenderer.invoke('config:setFleetRoot', path)
+      ipcRenderer.invoke('config:setFleetRoot', path),
+    setHardwareAccelDisabled: (
+      disabled: boolean
+    ): Promise<{ disableHardwareAcceleration: boolean }> =>
+      ipcRenderer.invoke('config:setHardwareAccelDisabled', disabled)
   },
   dialog: {
     pickDirectory: (defaultPath?: string): Promise<string | null> =>

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -1,8 +1,8 @@
-// App-level settings. Currently just the fleet root — the single host
-// directory that holds every workspace's private folder (<root>/<id>) and
-// the shared folder (<root>/shared) mounted into every container. Changing
-// it takes effect for new containers and on the next restart of existing
-// ones (running containers keep their current mounts until recreated).
+// App-level settings: the fleet root — the single host directory that holds
+// every workspace's private folder (<root>/<id>) and the shared folder
+// (<root>/shared) mounted into every container (changing it takes effect for
+// new containers and on the next restart of existing ones) — plus the
+// hardware-acceleration toggle (applied at the next app launch).
 
 import { useEffect, useState } from 'react';
 
@@ -14,6 +14,10 @@ interface Props {
 
 export function SettingsModal({ onClose, onSaved }: Props) {
   const [fleetRoot, setFleetRoot] = useState('');
+  const [hwaDisabled, setHwaDisabled] = useState(false);
+  // The persisted HWA value at open time — used to know whether the toggle
+  // actually changed, so we only nudge "restart to apply" when it did.
+  const [hwaInitial, setHwaInitial] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,6 +27,8 @@ export function SettingsModal({ onClose, onSaved }: Props) {
     void window.api.config.get().then((cfg) => {
       if (live) {
         setFleetRoot(cfg.fleetRoot);
+        setHwaDisabled(cfg.disableHardwareAcceleration);
+        setHwaInitial(cfg.disableHardwareAcceleration);
         setLoaded(true);
       }
     });
@@ -46,6 +52,9 @@ export function SettingsModal({ onClose, onSaved }: Props) {
     setBusy(true);
     setError(null);
     try {
+      if (hwaDisabled !== hwaInitial) {
+        await window.api.config.setHardwareAccelDisabled(hwaDisabled);
+      }
       const cfg = await window.api.config.setFleetRoot(trimmed);
       onSaved(cfg);
       onClose();
@@ -85,6 +94,24 @@ export function SettingsModal({ onClose, onSaved }: Props) {
             <code>&lt;root&gt;/shared</code> folder mounted into every container at{' '}
             <code>/shared</code>. Changing the root applies to new containers and to existing ones
             on their next restart.
+          </p>
+          <div className="form-row">
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                checked={hwaDisabled}
+                onChange={(e) => setHwaDisabled(e.target.checked)}
+                disabled={busy || !loaded}
+              />
+              <span>Disable hardware acceleration</span>
+            </label>
+          </div>
+          <p className="form-hint">
+            Turn this on if Chromium&apos;s GPU process logs errors on startup (common on WSLg) —
+            rendering falls back to CPU. Applies the next time you launch claude-fleet.
+            {hwaDisabled !== hwaInitial && (
+              <strong> Restart required to take effect.</strong>
+            )}
           </p>
           {error && <div className="form-hint error-text">{error}</div>}
           <div className="modal-footer">

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1004,6 +1004,19 @@ button.obs-ws-row:hover .obs-ws-icon { opacity: 1; color: var(--text-primary); }
 }
 .form-row input:disabled { opacity: 0.5; }
 .form-row .form-hint { font-size: 11px; margin-top: 4px; color: var(--text-muted); }
+/* Checkbox setting: a horizontal box + label, not the uppercase field label. */
+.form-row label.checkbox-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.form-row label.checkbox-row input { width: auto; margin: 0; cursor: pointer; }
 .error-text { color: var(--state-error); }
 .form-status { font-size: 11px; color: var(--text-secondary); margin: 8px 0; font-family: var(--font-mono); }
 


### PR DESCRIPTION
Closes #13.

## Problem
On WSLg, Chromium's GPU process fails to initialize every session:
```
[ERROR:viz_main_impl.cc(166)] Exiting GPU process due to errors during initialization
```
Harmless (CPU fallback renders fine) but it's noise that buries real errors. WSLg is a primary dev target.

## Change
A **hardware-acceleration toggle in the Settings panel** (top-strip gear), persisted to `config.json`, plus a `CLAUDE_FLEET_DISABLE_HWA=1` env override for one-off dev runs.

- **`config.ts`** — `disableHardwareAcceleration` added to `AppConfig`/`config.json`. `hardwareAccelDisabledAtStartup()` reads it **synchronously** (env override → persisted → off), because `app.disableHardwareAcceleration()` must run before the `ready` event, before the async config cache warms. Async `get/setHardwareAccelDisabled` back the IPC layer.
- **`index.ts`** — startup gate calls the sync reader.
- **`ipc.ts` / `preload`** — `config:get` returns the flag; new `config:setHardwareAccelDisabled` channel.
- **`SettingsModal`** — checkbox with a "restart required to take effect" hint; persisted alongside the fleet root on Save.
- **`styles.css`** — `.checkbox-row` (horizontal box + normal-case label, not the uppercase field label).

The setting lives in `config.json` (not SQLite) so it survives a DB wipe and can be read synchronously at startup — the toggle's hard requirement.

## Tests
- New **`config.test.ts`** (5): precedence (env override forces on, persisted true/false, missing file → off) and round-trip + no-clobber between `fleetRoot` and the HWA flag.
- Full unit suite (79) green; both typechecks + `build` clean.

## Verification (live, under WSLg)
| Config | GPU-error lines | Boots |
|--------|-----------------|-------|
| baseline (no setting, no env) | 1 (`viz_main_impl.cc(166)`) | ✅ |
| env var `CLAUDE_FLEET_DISABLE_HWA=1` | 0 | ✅ |
| **persisted setting only** (no env) | 0 | ✅ |

## Docs
- `docs/SPEC.md` §6 (Settings IPC + `config.json` shape) and §11 (App-level Settings surface) updated.
- `README.md` leads with the gear-icon toggle; env var documented as the dev shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)