### PR TITLE
fix(test): mockMainIpc workspaces need a mirror field (#93 regression)

### DIFF
--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -126,6 +126,7 @@ export interface MockOpts {
     resources?: { cpus?: number; memoryMb?: number };
     authMode?: 'oauth' | 'apikey';
     env?: { plain: Record<string, string>; secretKeys: string[] };
+    mirror?: { default: 'on' | 'off'; cleanup: 'delete' | 'preserve' };
     createdAt?: number;
     lastUsedAt?: number;
   }>;
@@ -222,6 +223,10 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       authMode: w.authMode ?? 'oauth',
       env: w.env ?? { plain: {}, secretKeys: [] },
       workspaceSubdir: '',
+      // Durable-mirror settings (#93). The renderer reads `w.mirror.default`
+      // unconditionally (App.tsx → TerminalPane), so a mock workspace without
+      // this field crashes the render. Default to the factory values.
+      mirror: w.mirror ?? { default: 'on', cleanup: 'delete' },
       createdAt: now,
       lastUsedAt: now,
       ...w


### PR DESCRIPTION
**Main is currently red** — #93 (durable transcript mirror) added `WorkspaceSpec.mirror` and the renderer now reads `w.mirror.default` unconditionally (`App.tsx` → `TerminalPane`). #93 updated the real mock backend (`mock.ts`) to include `mirror`, but **not** the `mockMainIpc` test helper. So every `launch()`+`mockMainIpc` workspace lacked `mirror`, the renderer threw on render, and all those non-mock e2e tests timed out — **8 failures** across `workspace-actions` + `workspace-lifecycle`, the suite ballooning to ~9 min of timeouts.

Fix: default `mirror` to the factory `{ default: 'on', cleanup: 'delete' }` in `mockMainIpc` (overridable per-workspace via the new optional field), mirroring how `authMode`/`env`/`labels` already default.

**Full e2e: 73 passed (1.3m)**, back from 8 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)