### PR TITLE
feat: read-only MCP server over a Unix socket (#12, slice 1)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -567,6 +567,8 @@ claude-fleet/
     │   ├── sessions.ts                # per-workspace sessions.json read/write
     │   ├── imageLibrary.ts            # imageLibrary.json read/write + auto-record
     │   ├── db.ts                      # SQLite cache: events/sessions tables, ingest, summary, cost queries
+    │   ├── mcpServer.ts               # read-only MCP server (#12) on <userData>/mcp.sock; tools over the state DB
+    │   ├── mcpReadonlySql.ts          # pure read-only-SQL guard for the MCP `query` escape hatch
     │   ├── jsonlWatcher.ts            # chokidar-based JSONL tailer feeding db.ingestLine
     │   ├── pricing.ts                 # Claude 4.x USD rates + costFor(model, tier, tokens)
     │   ├── pricing.test.ts            # Vitest unit tests for pricing math
@@ -782,30 +784,34 @@ The same watcher that drives observability emits `prompts` rows when it sees the
 - **Cross-session aggregation.** If the same `Bash(...)` pattern triggers a prompt across many sessions, surfacing the aggregate (count, first/last seen) would highlight high-value allowlist candidates. Worth doing in the same UI iteration.
 
 ### In-container SQLite access via MCP
-Read-only MCP server exposed by claude-fleet that lets the agent inside each container query the application's state DB (sessions, cost, events, prompts).
+Read-only MCP server exposed by claude-fleet that lets the agent inside each container query the application's state DB (sessions, events, derived cost).
+
+**Status: host-side server SHIPPED (#12, slice 1); container wiring PENDING (slice 2).** The server runs and is e2e-tested over its socket; what remains is plumbing in-container `claude` to it (see *Container wiring* below).
 
 **Decisions made:**
 - **Mechanism**: MCP server. Idiomatic for Claude Code, which supports MCP natively. The agent gets typed tools instead of having to learn raw SQL by default.
-- **Access pattern**: strictly read-only. No mutation tools. The DB is owned by the desktop app; the agent has no business modifying its own cost data, session metadata, or prompt log.
-- **Tool surface**: typed tools cover common cases; a raw `query(sql)` tool covers the rest. Read-only at the DB connection layer makes the escape hatch safe.
-- **Connection**: HTTP over a Unix socket bind-mounted into each container. No network exposure; auth is implicit via filesystem permissions; survives Docker network changes.
+- **Access pattern**: strictly read-only. No mutation tools.
+- **Transport**: newline-delimited JSON-RPC 2.0 over a Unix socket — **not** HTTP. MCP's HTTP transport wants a URL, which would force a network port; a stdio bridge over the socket keeps it network-free. (Hand-rolled, no MCP SDK dep — matches the broker.)
+- **Visibility = fleet-global**: a `sessions`/`events` row from one workspace is queryable by the agent in another, matching the "sessions are global" goal. Per-workspace scoping (stamp the connection with a workspace id) is a future option.
+- **Runaway protection**: the read-only connection is the hard write-guard; `query` is additionally gated by `isReadOnlySql` (rejects writes + multi-statement injection) and results are row-capped (1000).
 
-**Implementation:**
-The main process opens the SQLite file in read-write mode for its own writers (observability watcher, sessions reconciler, prompt-log writer). The MCP server uses a separate connection opened in read-only mode (via the SQLite URI form `file:state.db?mode=ro`). The server listens on `<app-data>/mcp.sock` on the host. Each container's create spec adds a bind-mount of this socket to `/fleet/mcp.sock` inside the container.
+**Implementation (`src/main/mcpServer.ts`):**
+The main process's writers use the read-write `state.db` connection; the MCP server opens its **own** `better-sqlite3` connection `{ readonly: true, fileMustExist: true }`. It listens on `<userData>/mcp.sock` (started in `index.ts` whenReady after `openDb`, stopped on `before-quit`); each accepted connection is one MCP session (newline-delimited JSON-RPC: `initialize` / `tools/list` / `tools/call` / `ping`, notifications get no reply). The SQL read-only guard lives in the pure, unit-tested `src/main/mcpReadonlySql.ts`.
 
-**Tool surface (sketch):**
-- `list_sessions({ container?, since?, until?, limit? })` → rows from `sessions`
-- `get_session({ id })` → one row with all metadata
-- `get_cost({ session_id })` → row from `cost`
-- `list_prompts({ container?, session_id?, kind?, since?, limit? })` → rows from `prompts`
-- `list_events({ session_id, type?, since?, limit? })` → rows from `events`
-- `query({ sql })` → arbitrary read-only SQL; rejected at the connection layer if the statement is a write
+**Tool surface (shipped):**
+- `list_sessions({ workspace_id?, since?, until?, limit? })` → rows from `sessions`
+- `get_session({ id })` → one row
+- `get_cost({ session_id })` → token totals + USD **derived** from per-(model, service_tier) usage via `pricing.ts` (there is no `cost` table)
+- `list_events({ session_id, type?, since?, limit? })` → curated event columns (omits `raw_jsonl`)
+- `query({ sql })` → arbitrary read-only SQL (guarded), row-capped; the tool description embeds the table schemas
+- (`list_prompts` dropped — the prompt log #11 is blocked, so there is no `prompts` table.)
 
-**Open:**
-- **MCP config delivery to the container.** Options: bake `.mcp.json` into the runner image at `/etc/claude/mcp.json` (or similar), write `.mcp.json` into the bind-mounted workspace at container-create time, or pass `--mcp-config` to `claude` when launching it. Choice affects whether per-container customization is possible.
-- **Schema documentation.** Typed-tool descriptions usually suffice; raw-SQL users may want the schema spelled out. Decide whether to ship a CLAUDE.md fragment with the schema, embed it in the `query` tool's description, or both.
-- **Cross-container visibility.** Today the schema doesn't restrict by container at the DB level — a `sessions` row from container A is visible to the agent in container B. Matches the goal that sessions are global, but explicitly decide whether the MCP server should optionally scope to "this container's data only" by stamping each connection with its container ID at the time the socket is opened.
-- **Runaway-query protection.** Even read-only queries can be expensive. Decide on per-query statement timeout, row-count cap, or both.
+**Container wiring (slice 2, pending live verification):**
+- Bind `<userData>/mcp.sock` → `/fleet/mcp.sock` (ro) in each container's create spec.
+- Add `socat` to the runner image (no `socat`/`nc` today) for the stdio↔socket bridge.
+- Seed `mcpServers` into the per-workspace `~/.claude.json` (`ensureWorkspaceClaudeJson`): `{ "claude-fleet": { command: "socat", args: ["-", "UNIX-CONNECT:/fleet/mcp.sock"] } }` so `claude` auto-connects on start.
+- **Unknown to verify on a real container**: whether `claude` auto-connects to a user-scope MCP server without an approval gate (echoes of the managed-settings saga, §11) — verify before relying on it.
+- **Schema docs**: embedded in the `query` tool description (decided); a CLAUDE.md fragment can follow if raw-SQL use is common.
 
 ### Dev-mode mock fleet
 When `CLAUDE_FLEET_MOCK=1` is set in the main process's environment, `ipc.ts` swaps the real `docker.ts` implementation for `src/main/mock.ts`. The mock:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'node:path';
 import { registerIpc } from './ipc.js';
 import { openDb, closeDb } from './db.js';
+import { startMcpServer, stopMcpServer } from './mcpServer.js';
 import { JsonlWatcher } from './jsonlWatcher.js';
 import { listWorkspaceManifests } from './workspaces.js';
 import { installMainProcessHandlers, getLogPath } from './errorLog.js';
@@ -70,6 +71,9 @@ app.whenReady().then(async () => {
 
   if (jsonlWatcher) {
     openDb(app.getPath('userData'));
+    // Read-only MCP server over <userData>/mcp.sock so in-container claude can
+    // query the state DB (sessions/events/cost). Opens its own readonly conn.
+    startMcpServer(app.getPath('userData'));
     const manifests = await listWorkspaceManifests();
     // Seed each workspace's durable-mirror default from its manifest before the
     // watcher starts ingesting, so the very first lines are mirrored per the
@@ -87,6 +91,7 @@ app.whenReady().then(async () => {
 
 app.on('before-quit', async () => {
   await jsonlWatcher?.stop();
+  stopMcpServer();
   closeDb();
 });
 

--- a/src/main/mcpReadonlySql.test.ts
+++ b/src/main/mcpReadonlySql.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isReadOnlySql } from './mcpReadonlySql';
+
+describe('isReadOnlySql', () => {
+  it('allows SELECT / WITH / EXPLAIN / VALUES', () => {
+    expect(isReadOnlySql('SELECT * FROM sessions').ok).toBe(true);
+    expect(isReadOnlySql('  select 1  ').ok).toBe(true);
+    expect(isReadOnlySql('WITH x AS (SELECT 1) SELECT * FROM x').ok).toBe(true);
+    expect(isReadOnlySql('EXPLAIN QUERY PLAN SELECT * FROM events').ok).toBe(true);
+    expect(isReadOnlySql('VALUES (1),(2)').ok).toBe(true);
+    expect(isReadOnlySql('SELECT 1;').ok).toBe(true); // single trailing ;
+  });
+
+  it('allows read-form PRAGMA but not assignment', () => {
+    expect(isReadOnlySql('PRAGMA table_info(events)').ok).toBe(true);
+    expect(isReadOnlySql('PRAGMA user_version = 5').ok).toBe(false);
+  });
+
+  it('rejects writes', () => {
+    for (const sql of [
+      'DELETE FROM events',
+      'INSERT INTO sessions VALUES (1)',
+      'UPDATE sessions SET ai_title = "x"',
+      'DROP TABLE events',
+      'CREATE TABLE t (a)',
+      'ALTER TABLE events ADD COLUMN x'
+    ]) {
+      expect(isReadOnlySql(sql).ok, sql).toBe(false);
+    }
+  });
+
+  it('rejects multi-statement injection', () => {
+    expect(isReadOnlySql('SELECT 1; DROP TABLE events').ok).toBe(false);
+    expect(isReadOnlySql('SELECT 1; SELECT 2').ok).toBe(false);
+  });
+
+  it('is not fooled by a leading comment', () => {
+    expect(isReadOnlySql('/* hi */ DELETE FROM events').ok).toBe(false);
+    expect(isReadOnlySql('-- c\nSELECT 1').ok).toBe(true);
+  });
+
+  it('rejects empty / non-string', () => {
+    expect(isReadOnlySql('   ').ok).toBe(false);
+    expect(isReadOnlySql('' as string).ok).toBe(false);
+    expect(isReadOnlySql(undefined as unknown as string).ok).toBe(false);
+  });
+});

--- a/src/main/mcpReadonlySql.ts
+++ b/src/main/mcpReadonlySql.ts
@@ -1,0 +1,45 @@
+// Guard for the MCP `query` escape hatch. The read-only DB connection is the
+// hard guarantee — better-sqlite3 opened `{ readonly: true }` rejects any write
+// at the engine level. This check is defense-in-depth: it rejects writes (and
+// multi-statement injection) earlier, with a clearer message than a raw SQLite
+// error, before the statement ever reaches the connection.
+
+export interface SqlCheck {
+  ok: boolean;
+  reason?: string;
+}
+
+// Read-only statement kinds. PRAGMA is allowed only in its query form (no `=`),
+// since `PRAGMA user_version = 5` is a write.
+const ALLOWED_LEADING = /^(SELECT|WITH|EXPLAIN|VALUES|PRAGMA)\b/i;
+
+/** Strip -- line and / * * / block comments so a comment can't mask the keyword. */
+function stripComments(sql: string): string {
+  return sql.replace(/--[^\n]*/g, ' ').replace(/\/\*[\s\S]*?\*\//g, ' ');
+}
+
+export function isReadOnlySql(sql: string): SqlCheck {
+  if (typeof sql !== 'string') return { ok: false, reason: 'sql must be a string.' };
+  const stripped = stripComments(sql).trim();
+  if (!stripped) return { ok: false, reason: 'Empty query.' };
+
+  // Allow at most one statement (a single optional trailing semicolon). This
+  // blocks `SELECT 1; DROP TABLE events` style injection through the escape hatch.
+  const body = stripped.replace(/;\s*$/, '');
+  if (body.includes(';')) {
+    return { ok: false, reason: 'Only a single statement is allowed.' };
+  }
+
+  if (!ALLOWED_LEADING.test(body)) {
+    return {
+      ok: false,
+      reason: 'Only read-only statements are allowed (SELECT / WITH / EXPLAIN / VALUES / PRAGMA).'
+    };
+  }
+
+  if (/^PRAGMA\b/i.test(body) && body.includes('=')) {
+    return { ok: false, reason: 'Assignment PRAGMAs (writes) are not allowed.' };
+  }
+
+  return { ok: true };
+}

--- a/src/main/mcpServer.ts
+++ b/src/main/mcpServer.ts
@@ -1,0 +1,331 @@
+// Read-only MCP server exposing the state DB to the agent inside each
+// container (issue #12, SPEC §11). Hand-rolled JSON-RPC over a Unix-domain
+// socket — no SDK dep, matching the broker's "own the protocol" approach.
+//
+// Transport: the server speaks newline-delimited JSON-RPC 2.0 on a Unix socket
+// at `<userData>/mcp.sock`. In-container `claude` reaches it over a stdio
+// bridge (`socat - UNIX-CONNECT:/fleet/mcp.sock`) configured in the workspace's
+// ~/.claude.json — wired in the container-side slice (docker.ts / runner image).
+//
+// Safety: a single connection opened `{ readonly: true }` is the hard guarantee
+// that nothing here can mutate the DB; the typed tools use parameterized SQL,
+// and the raw `query` escape hatch is additionally gated by isReadOnlySql.
+// Visibility is fleet-global (a session row from one workspace is queryable by
+// another) — matching the "sessions are global" goal; per-workspace scoping is
+// a future option (SPEC §11).
+
+import { createServer, type Server, type Socket } from 'node:net';
+import { existsSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { costFor } from './pricing.js';
+import { isReadOnlySql } from './mcpReadonlySql.js';
+
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_INFO = { name: 'claude-fleet-state', version: '1.0.0' };
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+export function mcpSocketPath(userDataDir: string): string {
+  return join(userDataDir, 'mcp.sock');
+}
+
+let server: Server | null = null;
+let rodb: Database.Database | null = null;
+
+/** Open the read-only DB connection + start listening. No-op if already up. */
+export function startMcpServer(userDataDir: string): void {
+  if (server) return;
+  const dbPath = join(userDataDir, 'state.db');
+  rodb = new Database(dbPath, { readonly: true, fileMustExist: true });
+  const sockPath = mcpSocketPath(userDataDir);
+  // A stale socket file from a previous run blocks listen() with EADDRINUSE.
+  try {
+    if (existsSync(sockPath)) unlinkSync(sockPath);
+  } catch {
+    /* best effort */
+  }
+  server = createServer((sock) => handleConnection(sock));
+  server.on('error', (err) => console.warn('[mcp] server error:', err));
+  server.listen(sockPath, () => console.log(`[mcp] listening on ${sockPath}`));
+}
+
+export function stopMcpServer(): void {
+  try {
+    server?.close();
+  } catch {
+    /* ignore */
+  }
+  try {
+    rodb?.close();
+  } catch {
+    /* ignore */
+  }
+  server = null;
+  rodb = null;
+}
+
+function handleConnection(sock: Socket): void {
+  let buf = '';
+  sock.setEncoding('utf8');
+  sock.on('data', (chunk: string) => {
+    buf += chunk;
+    let nl: number;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (line) dispatchLine(line, sock);
+    }
+  });
+  sock.on('error', () => sock.destroy());
+}
+
+function dispatchLine(line: string, sock: Socket): void {
+  let msg: { id?: unknown; method?: string; params?: Record<string, unknown> };
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    send(sock, { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } });
+    return;
+  }
+  const { id, method, params } = msg;
+  // Notifications (no id) get no reply — e.g. notifications/initialized.
+  const isNotification = id === undefined || id === null;
+
+  try {
+    const result = handleMethod(method ?? '', params ?? {});
+    if (!isNotification && result !== NO_REPLY) {
+      send(sock, { jsonrpc: '2.0', id, result });
+    }
+  } catch (err) {
+    if (!isNotification) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code = err instanceof RpcError ? err.code : -32603;
+      send(sock, { jsonrpc: '2.0', id, error: { code, message } });
+    }
+  }
+}
+
+const NO_REPLY = Symbol('no-reply');
+
+class RpcError extends Error {
+  constructor(
+    readonly code: number,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function handleMethod(method: string, params: Record<string, unknown>): unknown {
+  switch (method) {
+    case 'initialize':
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO
+      };
+    case 'ping':
+      return {};
+    case 'tools/list':
+      return { tools: TOOLS.map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })) };
+    case 'tools/call':
+      return callTool(params);
+    default:
+      if (method.startsWith('notifications/')) return NO_REPLY;
+      throw new RpcError(-32601, `Method not found: ${method}`);
+  }
+}
+
+function callTool(params: Record<string, unknown>): unknown {
+  const name = params.name as string;
+  const args = (params.arguments as Record<string, unknown>) ?? {};
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) throw new RpcError(-32602, `Unknown tool: ${name}`);
+  if (!rodb) throw new RpcError(-32603, 'Database not open');
+  try {
+    const result = tool.run(rodb, args);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    // Tool-level failures surface to the model as an error result (MCP
+    // convention), not a protocol error, so it can read the message and adapt.
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: 'text', text: `Error: ${message}` }], isError: true };
+  }
+}
+
+function send(sock: Socket, obj: unknown): void {
+  try {
+    sock.write(JSON.stringify(obj) + '\n');
+  } catch {
+    /* connection went away mid-write */
+  }
+}
+
+function clampLimit(v: unknown): number {
+  const n = typeof v === 'number' && Number.isFinite(v) ? Math.floor(v) : DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, n));
+}
+
+interface Tool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  run: (db: Database.Database, args: Record<string, unknown>) => unknown;
+}
+
+// Curated event columns (omit raw_jsonl by default — it's large and the
+// extract columns cover the common needs).
+const EVENT_COLS =
+  'id, session_id, workspace_id, ts, type, subtype, model, tool_name, input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, service_tier';
+
+const TOOLS: Tool[] = [
+  {
+    name: 'list_sessions',
+    description:
+      'List Claude sessions (newest first). Optional filters: workspace_id, since/until (epoch ms on last_active_at), limit.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: { type: 'string' },
+        since: { type: 'number', description: 'epoch ms, last_active_at >= since' },
+        until: { type: 'number', description: 'epoch ms, last_active_at <= until' },
+        limit: { type: 'number', description: `default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}` }
+      }
+    },
+    run: (db, a) => {
+      const where: string[] = [];
+      const p: unknown[] = [];
+      if (typeof a.workspace_id === 'string') {
+        where.push('workspace_id = ?');
+        p.push(a.workspace_id);
+      }
+      if (typeof a.since === 'number') {
+        where.push('last_active_at >= ?');
+        p.push(a.since);
+      }
+      if (typeof a.until === 'number') {
+        where.push('last_active_at <= ?');
+        p.push(a.until);
+      }
+      const sql = `SELECT * FROM sessions ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY last_active_at DESC LIMIT ?`;
+      return db.prepare(sql).all(...p, clampLimit(a.limit));
+    }
+  },
+  {
+    name: 'get_session',
+    description: 'Fetch one session row (all metadata) by its id.',
+    inputSchema: {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+      required: ['id']
+    },
+    run: (db, a) => {
+      if (typeof a.id !== 'string') throw new Error('id is required');
+      return db.prepare('SELECT * FROM sessions WHERE id = ?').get(a.id) ?? null;
+    }
+  },
+  {
+    name: 'get_cost',
+    description:
+      'Token totals + derived USD for a session. USD is computed from per-(model, tier) usage via the app pricing table.',
+    inputSchema: {
+      type: 'object',
+      properties: { session_id: { type: 'string' } },
+      required: ['session_id']
+    },
+    run: (db, a) => {
+      if (typeof a.session_id !== 'string') throw new Error('session_id is required');
+      const rows = db
+        .prepare(
+          `SELECT model, service_tier,
+                  SUM(COALESCE(input_tokens,0)) AS input,
+                  SUM(COALESCE(output_tokens,0)) AS output,
+                  SUM(COALESCE(cache_read_input_tokens,0)) AS cacheRead,
+                  SUM(COALESCE(cache_creation_input_tokens,0)) AS cacheCreate
+           FROM events WHERE session_id = ? AND type = 'assistant'
+           GROUP BY model, service_tier`
+        )
+        .all(a.session_id) as Array<{
+        model: string | null;
+        service_tier: string | null;
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheCreate: number;
+      }>;
+      let usd = 0;
+      const totals = { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 };
+      for (const r of rows) {
+        const tokens = {
+          inputTokens: r.input,
+          outputTokens: r.output,
+          cacheReadInputTokens: r.cacheRead,
+          cacheCreationInputTokens: r.cacheCreate
+        };
+        usd += costFor(r.model, r.service_tier, tokens);
+        totals.inputTokens += r.input;
+        totals.outputTokens += r.output;
+        totals.cacheReadInputTokens += r.cacheRead;
+        totals.cacheCreationInputTokens += r.cacheCreate;
+      }
+      return { session_id: a.session_id, usd, ...totals };
+    }
+  },
+  {
+    name: 'list_events',
+    description:
+      'List events for a session in id order (omits the raw JSONL body). Optional filters: type, since (epoch ms on ts), limit.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        session_id: { type: 'string' },
+        type: { type: 'string' },
+        since: { type: 'number' },
+        limit: { type: 'number', description: `default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}` }
+      },
+      required: ['session_id']
+    },
+    run: (db, a) => {
+      if (typeof a.session_id !== 'string') throw new Error('session_id is required');
+      const where = ['session_id = ?'];
+      const p: unknown[] = [a.session_id];
+      if (typeof a.type === 'string') {
+        where.push('type = ?');
+        p.push(a.type);
+      }
+      if (typeof a.since === 'number') {
+        where.push('ts >= ?');
+        p.push(a.since);
+      }
+      const sql = `SELECT ${EVENT_COLS} FROM events WHERE ${where.join(' AND ')} ORDER BY id ASC LIMIT ?`;
+      return db.prepare(sql).all(...p, clampLimit(a.limit));
+    }
+  },
+  {
+    name: 'query',
+    description:
+      'Run an arbitrary read-only SQL statement against the state DB and return the rows ' +
+      `(capped at ${MAX_LIMIT}). Writes are rejected. Tables: ` +
+      'events(id, session_id, workspace_id, ts, type, subtype, uuid, parent_uuid, model, ' +
+      'input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, ' +
+      'service_tier, tool_name, raw_jsonl); ' +
+      'sessions(id, workspace_id, cwd, started_at, last_active_at, ai_title, first_user_message, user_set_name); ' +
+      'broker_sessions(workspace_id, broker_session_id, claude_session_id, learned_at).',
+    inputSchema: {
+      type: 'object',
+      properties: { sql: { type: 'string' } },
+      required: ['sql']
+    },
+    run: (db, a) => {
+      const sql = a.sql as string;
+      const check = isReadOnlySql(sql);
+      if (!check.ok) throw new Error(check.reason ?? 'Rejected.');
+      const rows = db.prepare(sql).all() as unknown[];
+      if (rows.length > MAX_LIMIT) {
+        return { truncated: true, returned: MAX_LIMIT, rows: rows.slice(0, MAX_LIMIT) };
+      }
+      return { truncated: false, returned: rows.length, rows };
+    }
+  }
+];

--- a/tests/mcp-server.spec.ts
+++ b/tests/mcp-server.spec.ts
@@ -1,0 +1,172 @@
+// Read-only MCP server (#12) end-to-end: launch the real app (non-mock so the
+// DB + MCP server start), seed a workspace manifest + a JSONL event for the
+// watcher to ingest, then drive the Unix socket at <userData>/mcp.sock with
+// newline-delimited JSON-RPC — exactly how the in-container `socat` bridge
+// will. Verifies initialize, tools/list, a typed tool, the raw query escape
+// hatch, and that writes are rejected.
+
+import { _electron as electron, test, expect, type ElectronApplication } from '@playwright/test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { connect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from './_helpers.js';
+
+// Minimal newline-delimited JSON-RPC client over the unix socket.
+class RpcClient {
+  private buf = '';
+  private nextId = 1;
+  private pending = new Map<number, (msg: { result?: unknown; error?: unknown }) => void>();
+  constructor(private sock: Socket) {
+    sock.setEncoding('utf8');
+    sock.on('data', (chunk: string) => {
+      this.buf += chunk;
+      let nl: number;
+      while ((nl = this.buf.indexOf('\n')) >= 0) {
+        const line = this.buf.slice(0, nl).trim();
+        this.buf = this.buf.slice(nl + 1);
+        if (!line) continue;
+        const msg = JSON.parse(line) as { id?: number; result?: unknown; error?: unknown };
+        if (typeof msg.id === 'number' && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        }
+      }
+    });
+  }
+  call(method: string, params?: unknown): Promise<{ result?: unknown; error?: unknown }> {
+    const id = this.nextId++;
+    return new Promise((resolve) => {
+      this.pending.set(id, resolve);
+      this.sock.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    });
+  }
+  close(): void {
+    this.sock.destroy();
+  }
+}
+
+async function connectWithRetry(sockPath: string, deadlineMs = 8_000): Promise<Socket> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      return await new Promise<Socket>((resolve, reject) => {
+        const s = connect(sockPath);
+        s.once('connect', () => resolve(s));
+        s.once('error', reject);
+      });
+    } catch (err) {
+      if (Date.now() - start > deadlineMs) throw err;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }
+}
+
+/** Pull the JSON text out of an MCP tools/call result envelope. */
+function toolText(res: { result?: unknown }): unknown {
+  const content = (res.result as { content?: Array<{ text?: string }> })?.content;
+  return content?.[0]?.text ? JSON.parse(content[0].text) : undefined;
+}
+
+test('MCP server: initialize, tools, query escape hatch, write rejection', async () => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'claude-fleet-mcp-'));
+  const id = '01MCPTESTWS0000000000000WS';
+  const stateDir = path.join(userDataDir, 'state', id);
+  const projectsDir = path.join(stateDir, '.claude', 'projects', '-workspace');
+  mkdirSync(projectsDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, 'workspace.json'),
+    JSON.stringify({
+      id,
+      name: 'mcp-test-ws',
+      labels: [],
+      workspaceRoot: '/tmp/fleet-mcp',
+      workspaceSubdir: '',
+      kind: 'container',
+      image: 'mock',
+      authMode: 'oauth',
+      env: { plain: {}, secretKeys: [] },
+      createdAt: Date.now(),
+      lastUsedAt: Date.now()
+    })
+  );
+
+  const app: ElectronApplication = await electron.launch({
+    args: [REPO_ROOT, `--user-data-dir=${userDataDir}`],
+    cwd: REPO_ROOT,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([k]) => k !== 'CLAUDE_FLEET_MOCK')
+    ) as Record<string, string>
+  });
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  let client: RpcClient | null = null;
+  try {
+    // Seed an assistant event for the watcher to ingest into the DB.
+    await new Promise((r) => setTimeout(r, 500));
+    const sessionId = randomUUID();
+    const event = {
+      type: 'assistant',
+      uuid: randomUUID(),
+      timestamp: new Date().toISOString(),
+      message: {
+        model: 'claude-opus-4-7',
+        content: [],
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          service_tier: 'standard'
+        }
+      }
+    };
+    writeFileSync(path.join(projectsDir, `${sessionId}.jsonl`), JSON.stringify(event) + '\n');
+
+    const sock = await connectWithRetry(path.join(userDataDir, 'mcp.sock'));
+    client = new RpcClient(sock);
+
+    // initialize
+    const init = await client.call('initialize', { protocolVersion: '2024-11-05' });
+    expect((init.result as { serverInfo?: { name?: string } }).serverInfo?.name).toBe('claude-fleet-state');
+
+    // tools/list exposes the typed tools + the raw query escape hatch
+    const tools = await client.call('tools/list');
+    const names = ((tools.result as { tools: Array<{ name: string }> }).tools).map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['list_sessions', 'get_session', 'get_cost', 'list_events', 'query'])
+    );
+
+    // The watcher ingest is async — poll the raw query until the event lands.
+    await expect
+      .poll(
+        async () => {
+          const res = await client!.call('tools/call', {
+            name: 'query',
+            arguments: { sql: 'SELECT COUNT(*) AS c FROM events' }
+          });
+          const out = toolText(res) as { rows?: Array<{ c: number }> };
+          return out?.rows?.[0]?.c ?? 0;
+        },
+        { timeout: 8_000, intervals: [200, 500, 1000] }
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    // Typed tool: the seeded session shows up.
+    const sessions = await client.call('tools/call', { name: 'list_sessions', arguments: {} });
+    const rows = toolText(sessions) as Array<{ id: string }>;
+    expect(rows.some((s) => s.id === sessionId)).toBe(true);
+
+    // Write rejection through the escape hatch (guard fires before the engine).
+    const del = await client.call('tools/call', {
+      name: 'query',
+      arguments: { sql: 'DELETE FROM events' }
+    });
+    expect((del.result as { isError?: boolean }).isError).toBe(true);
+  } finally {
+    client?.close();
+    await app.close();
+  }
+});


### PR DESCRIPTION
**Slice 1 of #12** — the host-side half. (Issue stays open for slice 2.)

A hand-rolled MCP server (newline-delimited JSON-RPC 2.0, no SDK dep — matches the broker) listening on `<userData>/mcp.sock`, backed by its **own read-only** `better-sqlite3` connection (`{ readonly: true }`), separate from the app's writers.

### Tools (over the state DB)
- `list_sessions({ workspace_id?, since?, until?, limit? })`
- `get_session({ id })`
- `get_cost({ session_id })` — token totals + USD **derived** via `pricing.ts` (there is no `cost` table)
- `list_events({ session_id, type?, since?, limit? })` — curated columns, omits `raw_jsonl`
- `query({ sql })` — raw read-only SQL, gated by a pure `isReadOnlySql` guard (rejects writes + multi-statement injection) + a 1000-row cap; table schemas embedded in the tool description
- *(`list_prompts` omitted — #11 is blocked, no `prompts` table.)*

Decisions: transport is stdio-style JSON-RPC over a Unix socket (not HTTP — avoids a network port); visibility is **fleet-global** (matches "sessions are global"); read-only connection is the hard write-guard.

### Tests
- `mcpReadonlySql.test.ts` — pure guard (allow SELECT/WITH/EXPLAIN/PRAGMA-read, reject writes + `;` injection + leading-comment masking).
- `mcp-server.spec.ts` — e2e drives the **real socket**: initialize → tools/list → `list_sessions` → `query` count → write-rejection.
- 98 unit + 74 e2e green; typecheck clean. SPEC §11 updated.

### Slice 2 (pending — needs live-container verification)
Bind `mcp.sock → /fleet/mcp.sock`, add `socat` to the runner image, seed `mcpServers` into the per-workspace `~/.claude.json` so claude auto-connects via `socat - UNIX-CONNECT:/fleet/mcp.sock`. Unknown to verify on a real container: whether claude auto-connects without an approval gate.

> Note: this branch also relied on the just-merged #95 (mockMainIpc `mirror` default) — without it the suite was red from a #93 regression, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)