### PR TITLE
Backend interface + per-workspace router (no behavior change) (#16 PR1)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -323,8 +323,11 @@ interface Workspace extends WorkspaceSpec {
 - **stopped** — the container exists but its main process has exited (or it's in any other non-live state like `created` / `dead`).
 - **deleted** — there is no live container, but a manifest is on disk. Recoverable by recreating via the create flow.
 
+### Backend dispatch (per-workspace, by `kind`)
+Workspace operations are routed to a backend **per workspace**, not chosen globally. Both backends implement a single `Backend` contract (`src/main/backend.ts`: `ping`, `ensureImage`, `listLiveWorkspaces`, `createWorkspace`, `inspectImage`, `start/pause/stop/removeWorkspace`, `attachPty`, `getBrokerLogs`) — the Docker backend (`docker.ts`), the local host-process backend (`local.ts`, #16), and the mock backend (`mock.ts`, behind `CLAUDE_FLEET_MOCK=1`). `ipc.ts` dispatches each call: `workspace:create` routes on the payload's `kind`; every other channel resolves the workspace's `kind` from its manifest via `backendRouter.ts:resolveKind(idOrContainerId)` (a Docker container id never matches a manifest path → defaults to `'container'`; a local workspace's containerId surrogate equals its id → resolves to `'local'`). `workspace:list` merges live results from both backends. Docker-daemon-specific channels (`ping`, `ensureImage`, `inspectImage`) always target the Docker backend. In mock mode every workspace routes to the mock backend. (As of PR1 the `local.ts` mutations are stubs and `kind:'local'` is still blocked at create; PR2 implements it.)
+
 ### Docker container labels (backend implementation)
-Today the only workspace backend is a Docker container. The container name is `cf-<id>` (must be unique on the host); lookup is always by the `com.claude-fleet.id` label, which means renaming a workspace does not require touching the container at all. Each managed container carries:
+Today the primary workspace backend is a Docker container. The container name is `cf-<id>` (must be unique on the host); lookup is always by the `com.claude-fleet.id` label, which means renaming a workspace does not require touching the container at all. Each managed container carries:
 - `com.claude-fleet.managed` = `"true"` — discovery filter. `dockerode listContainers` filters on this label exclusively, so unmanaged containers never appear in the UI.
 - `com.claude-fleet.id` — the workspace's ULID. **Stable identity lookup key**; survives renames.
 - `com.claude-fleet.name` — the workspace's user-facing label at create time. Snapshot only; the source of truth for current name is the manifest.
@@ -560,7 +563,10 @@ claude-fleet/
     ├── main/
     │   ├── index.ts                   # app lifecycle, BrowserWindow
     │   ├── ipc.ts                     # registerIpc() — workspace:* / pty:* / etc. live here
+    │   ├── backend.ts                 # Backend contract (shared by docker/local/mock)
+    │   ├── backendRouter.ts           # resolveKind() — per-workspace backend routing (#16)
     │   ├── docker.ts                  # Docker backend (dockerode + broker-aware PTY attach)
+    │   ├── local.ts                   # local host-process backend (#16; stub until PR2)
     │   ├── broker.ts                  # host-side BrokerClient + frame codec
     │   ├── mock.ts                    # mock backend behind CLAUDE_FLEET_MOCK=1
     │   ├── workspaces.ts              # WorkspaceSpec types + manifest read/write/list

--- a/src/main/backend.ts
+++ b/src/main/backend.ts
@@ -1,0 +1,42 @@
+// The workspace-backend contract. Both the Docker backend (`docker.ts`) and
+// the mock backend (`mock.ts`) already implement this surface, and the local
+// host-process backend (`local.ts`, #16) implements it too. `ipc.ts` dispatches
+// each operation to the right backend per-workspace by `kind` (see
+// `resolveKind`/`backendFor` there) instead of choosing one backend globally.
+//
+// Type-only module: it just names the shared shape, importing the concrete
+// payload/result types from `docker.ts` (the original home of these types) so
+// there's a single source of truth and no duplication.
+
+import type { Workspace } from './workspaces.js';
+import type {
+  CreateWorkspaceInput,
+  ImageInspectResult,
+  PullProgress,
+  RemoveWorkspaceOpts,
+  PtyHandle
+} from './docker.js';
+
+export interface Backend {
+  /** Backend reachable? (Docker daemon up / `claude` on PATH.) */
+  ping(): Promise<boolean>;
+  /** Ensure the runtime is present (pull the image / no-op for local). */
+  ensureImage(onProgress: (p: PullProgress) => void): Promise<void>;
+  /** Live workspaces this backend owns, with their current state. */
+  listLiveWorkspaces(): Promise<Workspace[]>;
+  createWorkspace(spec: CreateWorkspaceInput): Promise<Workspace>;
+  inspectImage(ref: string): Promise<ImageInspectResult>;
+  /** Bring an existing workspace up; returns its containerId surrogate or null. */
+  startWorkspace(id: string): Promise<string | null>;
+  pauseWorkspace(containerId: string): Promise<void>;
+  stopWorkspace(containerId: string): Promise<void>;
+  removeWorkspace(containerId: string, opts?: RemoveWorkspaceOpts): Promise<void>;
+  attachPty(
+    containerId: string,
+    sessionId: string,
+    cols: number,
+    rows: number,
+    resumeOf?: string
+  ): Promise<PtyHandle>;
+  getBrokerLogs(containerId: string, tailLines?: number): Promise<string>;
+}

--- a/src/main/backendRouter.test.ts
+++ b/src/main/backendRouter.test.ts
@@ -1,0 +1,69 @@
+// Unit tests for resolveKind — the per-workspace backend routing decision (#16).
+// Mocks `electron` so `app.getPath('userData')` resolves to a temp dir (same
+// pattern as claudeJsonSeed.test.ts / migration.test.ts).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let userDataDir = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (which: string) => {
+      if (which === 'userData') return userDataDir;
+      throw new Error(`unexpected getPath: ${which}`);
+    }
+  }
+}));
+
+const { resolveKind } = await import('./backendRouter.js');
+const { workspaceManifestPath } = await import('./paths.js');
+
+async function writeManifest(id: string, kind: 'container' | 'local'): Promise<void> {
+  await mkdir(join(userDataDir, 'state', id), { recursive: true });
+  await writeFile(
+    workspaceManifestPath(id),
+    JSON.stringify({
+      id,
+      name: id,
+      workspaceRoot: '/tmp/' + id,
+      workspaceSubdir: '',
+      kind,
+      authMode: 'oauth',
+      env: { plain: {}, secretKeys: [] },
+      mirror: { default: 'on', cleanup: 'delete' },
+      createdAt: 1,
+      lastUsedAt: 1
+    }),
+    'utf8'
+  );
+}
+
+beforeEach(async () => {
+  userDataDir = await mkdtemp(join(tmpdir(), 'claude-fleet-router-'));
+});
+
+afterEach(async () => {
+  await rm(userDataDir, { recursive: true, force: true });
+});
+
+describe('resolveKind', () => {
+  it("returns 'local' for a workspace whose manifest is kind:'local'", async () => {
+    await writeManifest('01LOCAL00000000000000000WS', 'local');
+    expect(await resolveKind('01LOCAL00000000000000000WS')).toBe('local');
+  });
+
+  it("returns 'container' for a workspace whose manifest is kind:'container'", async () => {
+    await writeManifest('01CONT000000000000000000WS', 'container');
+    expect(await resolveKind('01CONT000000000000000000WS')).toBe('container');
+  });
+
+  it("defaults to 'container' for an unknown id (e.g. a real Docker container id)", async () => {
+    // A 64-hex docker container id has no manifest at its path → must fall
+    // through to the Docker backend, never the local one.
+    const dockerId = 'a'.repeat(64);
+    expect(await resolveKind(dockerId)).toBe('container');
+  });
+});

--- a/src/main/backendRouter.ts
+++ b/src/main/backendRouter.ts
@@ -1,0 +1,20 @@
+// Per-workspace backend routing (#16). Kept separate from `ipc.ts` so the
+// disk-reading routing decision is unit-testable without importing the heavy
+// ipc graph (dockerode, better-sqlite3) that can't load under vitest.
+
+import { readWorkspaceManifest, type WorkspaceKind } from './workspaces.js';
+
+/**
+ * Resolve a workspace's kind from its on-disk manifest.
+ *
+ * Safe for every channel's identifier:
+ *  - id-keyed ops (start/create) pass the ULID directly → manifest found.
+ *  - containerId-keyed ops (stop/pause/remove/attach) work because a *local*
+ *    workspace's containerId surrogate equals its id, so the manifest is found;
+ *    a real Docker container id (64-hex) has no manifest at that path, so this
+ *    returns the `'container'` default — exactly the right backend.
+ */
+export async function resolveKind(idOrContainerId: string): Promise<WorkspaceKind> {
+  const m = await readWorkspaceManifest(idOrContainerId);
+  return m?.kind ?? 'container';
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -19,7 +19,10 @@ import {
   setHardwareAccelDisabled
 } from './config.js';
 import * as realDocker from './docker.js';
+import * as realLocal from './local.js';
 import * as mockDocker from './mock.js';
+import type { Backend } from './backend.js';
+import { resolveKind } from './backendRouter.js';
 import * as vault from './vault.js';
 import * as fs from './fs.js';
 import * as imageLibrary from './imageLibrary.js';
@@ -37,6 +40,7 @@ import {
   type WorkspaceColor,
   type AuthMode,
   type WorkspaceMirror,
+  type WorkspaceKind,
   FACTORY_MIRROR
 } from './workspaces.js';
 import type { PtyHandle, RemoveWorkspaceOpts } from './docker.js';
@@ -58,7 +62,22 @@ import { broadcastObservabilitySummary } from './observabilityBroadcast.js';
 import { consumeForWorkspace, recordPendingAttach } from './pendingAttaches.js';
 
 export const MOCK_MODE = process.env.CLAUDE_FLEET_MOCK === '1';
-const backend = MOCK_MODE ? mockDocker : realDocker;
+
+// Per-workspace backend dispatch (#16). A workspace's `kind` decides whether
+// it's a Docker container or a host process; the two backends share the
+// `Backend` contract. In mock mode everything routes to the mock backend.
+const dockerBackend: Backend = MOCK_MODE ? mockDocker : realDocker;
+const localBackend: Backend = MOCK_MODE ? mockDocker : realLocal;
+
+function backendForKind(kind: WorkspaceKind): Backend {
+  if (MOCK_MODE) return mockDocker;
+  return kind === 'local' ? localBackend : dockerBackend;
+}
+
+async function backendFor(idOrContainerId: string): Promise<Backend> {
+  if (MOCK_MODE) return mockDocker;
+  return backendForKind(await resolveKind(idOrContainerId));
+}
 
 const ptySessions = new Map<string, PtyHandle>();
 
@@ -136,10 +155,12 @@ interface WorkspaceCreatePayload {
  * (description/labels/color/env/etc.) that don't live on the container.
  */
 async function listAllWorkspaces(): Promise<Workspace[]> {
-  const [live, manifests] = await Promise.all([
-    backend.listLiveWorkspaces(),
+  const [dockerLive, localLive, manifests] = await Promise.all([
+    dockerBackend.listLiveWorkspaces(),
+    localBackend.listLiveWorkspaces(),
     listWorkspaceManifests()
   ]);
+  const live = [...dockerLive, ...localLive];
   const manifestById = new Map(manifests.map((m) => [m.id, m]));
   const result: Workspace[] = [];
 
@@ -153,10 +174,15 @@ async function listAllWorkspaces(): Promise<Workspace[]> {
       description: m?.description,
       labels: m?.labels ?? w.labels,
       color: m?.color,
-      // workspaceRoot is always the canonical private folder derived from the
-      // fleet root + id — never trust stale labels/manifests (a container
-      // created before the fleet-root migration still carries the old path).
-      workspaceRoot: await fleetPrivateDir(w.id),
+      // Container: workspaceRoot is always the canonical private folder derived
+      // from the fleet root + id — never trust stale labels/manifests (a
+      // container created before the fleet-root migration still carries the old
+      // path). Local: the user picked an existing host dir, so honor the
+      // manifest's workspaceRoot (#16).
+      workspaceRoot:
+        w.kind === 'local'
+          ? m?.workspaceRoot ?? w.workspaceRoot
+          : await fleetPrivateDir(w.id),
       workspaceSubdir: w.workspaceSubdir || m?.workspaceSubdir || '',
       authMode: m?.authMode ?? w.authMode,
       env: m?.env ?? w.env,
@@ -209,10 +235,12 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     });
   }
 
-  ipcMain.handle('workspace:ping', () => backend.ping());
+  // Docker-daemon reachability (drives the #23 indicator) and image pulls are
+  // Docker-specific; local workspaces need neither.
+  ipcMain.handle('workspace:ping', () => dockerBackend.ping());
   ipcMain.handle('workspace:ensureImage', async (event, channelId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
-    await backend.ensureImage((p) => {
+    await dockerBackend.ensureImage((p) => {
       win?.webContents.send(`workspace:ensureImage:progress:${channelId}`, p);
     });
   });
@@ -240,7 +268,7 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
         throw new Error(`A workspace named "${input.name}" already exists.`);
       }
 
-      const ws = await backend.createWorkspace({
+      const ws = await backendForKind(input.kind ?? 'container').createWorkspace({
         id: input.id,
         name: input.name,
         workspaceSubdir: input.workspaceSubdir,
@@ -278,7 +306,7 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
       // fail the workspace create.
       if (ws.image) {
         try {
-          const inspected = await backend.inspectImage(ws.image);
+          const inspected = await dockerBackend.inspectImage(ws.image);
           await imageLibrary.recordImage(inspected);
         } catch (err) {
           // eslint-disable-next-line no-console
@@ -371,7 +399,7 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   ipcMain.handle(
     'sessions:resume',
     async (_e, workspaceId: string): Promise<{ containerId: string } | null> => {
-      const containerId = await backend.startWorkspace(workspaceId);
+      const containerId = await (await backendFor(workspaceId)).startWorkspace(workspaceId);
       if (!containerId) return null;
       await touchWorkspaceUsed(workspaceId);
       return { containerId };
@@ -385,7 +413,7 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
    * normal create flow (which resolves vault credentials).
    */
   ipcMain.handle('workspace:start', async (_e, id: string): Promise<Workspace | null> => {
-    const containerId = await backend.startWorkspace(id);
+    const containerId = await (await backendFor(id)).startWorkspace(id);
     if (!containerId) return null;
     await touchWorkspaceUsed(id);
     // Find the freshly-running workspace in the merged list so the
@@ -419,11 +447,16 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     setWorkspaceDefault(spec.id, spec.mirror?.default ?? FACTORY_MIRROR.default);
   });
 
-  ipcMain.handle('workspace:stop', (_e, containerId: string) => backend.stopWorkspace(containerId));
-  ipcMain.handle('workspace:pause', (_e, containerId: string) => backend.pauseWorkspace(containerId));
-  ipcMain.handle(
-    'workspace:remove',
-    (_e, containerId: string, opts?: RemoveWorkspaceOpts) => backend.removeWorkspace(containerId, opts)
+  ipcMain.handle('workspace:stop', async (_e, containerId: string) =>
+    (await backendFor(containerId)).stopWorkspace(containerId)
+  );
+  ipcMain.handle('workspace:pause', async (_e, containerId: string) =>
+    (await backendFor(containerId)).pauseWorkspace(containerId)
+  );
+  ipcMain.handle('workspace:remove', async (_e, containerId: string, opts?: RemoveWorkspaceOpts) =>
+    // A saved (no-live) workspace passes its ULID in opts.id; prefer it so the
+    // kind resolves even when there's no live containerId.
+    (await backendFor(opts?.id ?? containerId)).removeWorkspace(containerId, opts)
   );
 
   ipcMain.handle('app:mockMode', () => MOCK_MODE);
@@ -532,9 +565,10 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
       // is the workspace-persistent id the broker keys its session map
       // by). The renderer doesn't need to learn the broker id.
       const ptyHandleId = randomUUID();
+      const b = await backendFor(containerId);
       let handle: PtyHandle;
       try {
-        handle = await backend.attachPty(containerId, brokerSessionId, cols, rows, resumeOf);
+        handle = await b.attachPty(containerId, brokerSessionId, cols, rows, resumeOf);
       } catch (err) {
         // Capture the broker's recent stdout/stderr so the user has
         // something to diagnose with. The classic symptom we're chasing
@@ -544,7 +578,7 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
         // doing on the other side of the socket. Best-effort: if the
         // logs call itself fails (container gone, dockerode flaked),
         // getBrokerLogs returns '' and we just rethrow the original.
-        const brokerLog = await backend.getBrokerLogs(containerId, 100);
+        const brokerLog = await b.getBrokerLogs(containerId, 100);
         logError({
           source: 'main',
           type: 'pty-attach-failed',

--- a/src/main/local.ts
+++ b/src/main/local.ts
@@ -1,0 +1,93 @@
+// Local (non-container) workspace backend (#16): runs `claude` as a host child
+// process (node-pty) against a host directory, no Docker layer.
+//
+// PR1 (backend interface + router) ships this as a STUB: `listLiveWorkspaces`
+// returns nothing and every mutation throws. The renderer + `workspace:create`
+// still block `kind:'local'`, so the router never actually reaches these
+// mutations yet — this exists so `ipc.ts` can wire the dispatcher against a
+// real module. PR2 implements the session manager, spawn/attach, and lifecycle.
+
+import type { Backend } from './backend.js';
+import type { Workspace } from './workspaces.js';
+import type {
+  CreateWorkspaceInput,
+  ImageInspectResult,
+  PullProgress,
+  PtyHandle,
+  RemoveWorkspaceOpts
+} from './docker.js';
+
+const NOT_IMPLEMENTED = 'local backend not implemented yet (#16, PR2)';
+
+export async function ping(): Promise<boolean> {
+  // Real readiness (`which claude`) lands in PR2; the daemon indicator (#23)
+  // still probes the Docker backend, so this isn't consulted yet.
+  return false;
+}
+
+export async function ensureImage(_onProgress: (p: PullProgress) => void): Promise<void> {
+  // No image to pull for a host process.
+}
+
+export async function listLiveWorkspaces(): Promise<Workspace[]> {
+  return [];
+}
+
+export async function createWorkspace(_spec: CreateWorkspaceInput): Promise<Workspace> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function inspectImage(_ref: string): Promise<ImageInspectResult> {
+  throw new Error('local workspaces have no image to inspect');
+}
+
+export async function startWorkspace(_id: string): Promise<string | null> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function pauseWorkspace(_containerId: string): Promise<void> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function stopWorkspace(_containerId: string): Promise<void> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function removeWorkspace(
+  _containerId: string,
+  _opts?: RemoveWorkspaceOpts
+): Promise<void> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function attachPty(
+  _containerId: string,
+  _sessionId: string,
+  _cols: number,
+  _rows: number,
+  _resumeOf?: string
+): Promise<PtyHandle> {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+export async function getBrokerLogs(_containerId: string, _tailLines?: number): Promise<string> {
+  return '';
+}
+
+// Compile-time assertion that this module satisfies the Backend contract.
+// (A namespace import of this file is assigned to `Backend` in ipc.ts; this
+// makes a mismatch fail here, at the source, with a clearer error.)
+const _assertBackend: Backend = {
+  ping,
+  ensureImage,
+  listLiveWorkspaces,
+  createWorkspace,
+  inspectImage,
+  startWorkspace,
+  pauseWorkspace,
+  stopWorkspace,
+  removeWorkspace,
+  attachPty,
+  getBrokerLogs
+};
+void _assertBackend;


### PR DESCRIPTION
First of 3 PRs implementing the **local (non-container) workspace backend** (#16). This one is a **pure refactor with no behavior change** — it lays the dispatch foundation so a local backend can coexist with Docker workspaces.

## What changed
- **`src/main/backend.ts`** — the `Backend` contract both `docker.ts` and `mock.ts` already satisfy (`ping`, `ensureImage`, `listLiveWorkspaces`, `createWorkspace`, `inspectImage`, `start/pause/stop/removeWorkspace`, `attachPty`, `getBrokerLogs`).
- **`src/main/backendRouter.ts`** — `resolveKind(idOrContainerId)`: reads the manifest's `kind`. A real Docker container id (64-hex) never matches a manifest path → defaults to `'container'`; a local workspace's containerId surrogate equals its id → resolves to `'local'`. Kept separate from `ipc.ts` so it's unit-testable without the heavy ipc graph (dockerode / better-sqlite3 can't load under vitest).
- **`src/main/local.ts`** — STUB backend conforming to `Backend` (`listLiveWorkspaces → []`; mutations throw). PR2 implements the real session manager + spawn/attach.
- **`ipc.ts`** — replaces the single `MOCK_MODE ? mock : docker` const with `dockerBackend`/`localBackend` + `backendFor()`/`backendForKind()`. Every backend call site now dispatches per-workspace. Docker-daemon-specific channels (`ping`, `ensureImage`, `inspectImage`) stay on the Docker backend. `workspace:list` merges live results from both backends; `workspaceRoot` branches on `kind` (local will honor the manifest path). `kind:'local'` is still blocked at create — **no behavior change**.

## Why no behavior change
All workspaces are `kind:'container'` today and local creation is still guarded, so everything routes exactly as before. The full suite proves it.

## Verification
- New `backendRouter` unit test (3 cases incl. the unknown-id → `'container'` fallback that makes the router safe).
- Full suite green: **vitest 102** (99 prior + 3 new), **playwright 54** (unchanged). `typecheck` + `build` clean.

SPEC: new "Backend dispatch (per-workspace, by kind)" section + file tree.

Part of #16. Next: PR2 (`local.ts` core + node-pty session manager + UI), PR3 (MCP for local). Windows is split into its own follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)