### PR TITLE
Session-tab ⋮ menu: rename, auto-rename, close

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -292,9 +292,11 @@ For each workspace, `<userData>/state/<id>/sessions.json` records the renderer's
 ```ts
 interface SessionEntry {
   id: string;        // stable display id = the broker session key; NOT the PTY handle (per-attach)
-  name: string;      // 'main', 'session 2', 'session 3', …
+  name: string;      // 'main', 'session 2', 'session 3', … or an auto-derived title
   createdAt: number;
   resumeOf?: string; // set on a resume tab — first attach runs `claude --resume <resumeOf>`
+  mirror?: 'on'|'off'; // per-session durable-mirror override; absent = workspace default
+  autoName?: boolean;  // when true, `name` tracks Claude's session summary (auto-rename)
 }
 
 interface SessionInventory {
@@ -306,6 +308,8 @@ interface SessionInventory {
 ```
 
 Writes are atomic (write-to-temp + rename). Reads tolerate missing/malformed files by returning `{ version: 1, sessions: [], nextNum: 2 }`. The first attach to a fresh workspace inserts a single `main` tab and persists it immediately. A **resume tab** (created from the Sessions list) carries `resumeOf` so that even after the broker dies (host reboot) the re-attach re-resumes the same Claude session rather than starting a fresh one.
+
+**Session-tab actions (⋮ menu).** Each tab has a `⋮` trigger (a portaled dropdown, like the workspace chips; replaces the old bare `×`) with **Rename**, **Auto rename**, and **Close**. *Rename* is an inline edit in the tab; committing sets `name` and clears `autoName` (a manual name takes ownership). *Auto rename* toggles `autoName` — when on, `TerminalPane` subscribes to `observability:summary` and mirrors the tab's resolved Claude session title (`summaryForBrokerSession(...).title`, capped 40 chars) into `name`, refreshed on each push; an auto-named tab shows a `✦` marker. The toggle is **opt-in (default off)** so the conventional `main`/`session N` naming is unchanged unless the user asks for it. *Close* routes through the same `requestClose` path as before (mirror-delete confirm when a transcript mirror exists). Drag-reorder is disabled while a tab's name is being edited.
 
 ### Workspace shape (returned over IPC)
 The `Workspace` type joins the manifest with live backend state:

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -38,6 +38,10 @@ export interface SessionEntry {
   // Per-session durable-mirror override. Absent = use the workspace default.
   // Persisted so the choice survives reattach.
   mirror?: 'on' | 'off';
+  // When true, the tab's `name` tracks Claude's session summary (the observed
+  // AI title) and is refreshed as the conversation evolves. A manual rename
+  // turns this off. Absent = off (the default "main"/"session N" naming).
+  autoName?: boolean;
 }
 
 export interface SessionInventory {
@@ -79,7 +83,8 @@ export async function readInventory(workspaceId: string): Promise<SessionInvento
       .map((s) => ({
         ...s,
         resumeOf: typeof s.resumeOf === 'string' ? s.resumeOf : undefined,
-        mirror: s.mirror === 'on' || s.mirror === 'off' ? s.mirror : undefined
+        mirror: s.mirror === 'on' || s.mirror === 'off' ? s.mirror : undefined,
+        autoName: s.autoName === true ? true : undefined
       }));
     return {
       version: 1,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,10 @@ export interface SessionEntry {
    * (host reboot) re-resumes the same session.
    */
   resumeOf?: string;
+  /** Per-session durable-mirror override; absent = use the workspace default. */
+  mirror?: 'on' | 'off';
+  /** When true, the tab name tracks Claude's session summary (auto-rename). */
+  autoName?: boolean;
 }
 export interface SessionInventory {
   version: 1;

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -14,6 +14,7 @@
 // context is lost; PR2's in-container broker is what preserves that.
 
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import type { WorkspaceObservabilitySummary } from '../../../preload';
 import type { MirrorSetting, CleanupSetting } from '../App';
 import { TerminalSession } from './TerminalSession';
@@ -129,10 +130,38 @@ interface Session {
   resumeOf?: string;
   /** Per-session durable-mirror override; absent = use the workspace default. */
   mirror?: MirrorSetting;
+  /** When true, `name` tracks Claude's session summary; a manual rename clears it. */
+  autoName?: boolean;
 }
 
 function uid(): string {
   return globalThis.crypto?.randomUUID?.() ?? `s-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// Session-tab menu icons — 12×12 viewBox so they sit on the menu text baseline.
+function IconRename(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
+    </svg>
+  );
+}
+function IconAuto(): JSX.Element {
+  // A sparkle — "let Claude name it".
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M6 1 L7 4.5 L10.5 6 L7 7.5 L6 11 L5 7.5 L1.5 6 L5 4.5 Z" />
+    </svg>
+  );
+}
+function IconClose(): JSX.Element {
+  // Eject — matches the workspace chip menu's "Close" affordance.
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M6 2 L10 8 L2 8 Z" />
+      <rect x="2" y="9" width="8" height="1.6" rx="0.4" />
+    </svg>
+  );
 }
 
 export function TerminalPane({
@@ -278,6 +307,96 @@ export function TerminalPane({
     setActiveId(id);
     setNextNum((n) => n + 1);
   }
+
+  // ── Session-tab ⋮ menu: rename / auto-rename / close ──────────────────────
+  // Single open menu at a time; viewport coords for the portaled dropdown.
+  const [tabMenu, setTabMenu] = useState<{ id: string; top: number; left: number } | null>(null);
+  // Inline rename: the tab whose name is being edited, plus the draft text.
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
+
+  // Close the menu on any outside click / Escape / layout shift (the portal is
+  // positioned in viewport coords, so we can't follow the trigger when it moves).
+  useEffect(() => {
+    if (!tabMenu) return;
+    const close = (): void => setTabMenu(null);
+    const esc = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setTabMenu(null);
+    };
+    document.addEventListener('click', close);
+    document.addEventListener('keydown', esc);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('click', close);
+      document.removeEventListener('keydown', esc);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [tabMenu]);
+
+  function openTabMenu(trigger: HTMLElement, id: string): void {
+    const r = trigger.getBoundingClientRect();
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - 188));
+    setTabMenu({ id, top: r.bottom + 4, left });
+  }
+  function startRename(id: string): void {
+    const s = sessions.find((x) => x.id === id);
+    setDraftName(s?.name ?? '');
+    setRenamingId(id);
+  }
+  function commitRename(id: string): void {
+    const name = draftName.trim();
+    setRenamingId(null);
+    if (!name) return;
+    // A manual rename takes ownership: turn auto-rename off so the summary
+    // sync doesn't immediately overwrite it.
+    setSessions((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, name, autoName: false } : s))
+    );
+  }
+  function toggleAutoName(id: string): void {
+    setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, autoName: !s.autoName } : s)));
+  }
+
+  // Auto-rename sync: for every tab with autoName on, mirror Claude's session
+  // summary (the observed AI title) into the tab name, refreshed on each
+  // observability push. Keyed on the *set* of auto-named tabs so flipping the
+  // toggle re-runs immediately; name writes don't re-subscribe (autoKey stable).
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+  const autoKey = sessions
+    .filter((s) => s.autoName)
+    .map((s) => s.id)
+    .sort()
+    .join(',');
+  useEffect(() => {
+    if (!loaded || !autoKey) return;
+    let cancelled = false;
+    const sync = async (): Promise<void> => {
+      for (const s of sessionsRef.current) {
+        if (!s.autoName) continue;
+        try {
+          const sum = await window.api.observability.summaryForBrokerSession(workspaceId, s.id);
+          const title = sum?.title?.trim().slice(0, 40);
+          if (cancelled || !title) continue;
+          setSessions((prev) =>
+            prev.map((p) => (p.id === s.id && p.autoName && p.name !== title ? { ...p, name: title } : p))
+          );
+        } catch {
+          /* best-effort — a tab with no resolvable title keeps its current name */
+        }
+      }
+    };
+    void sync();
+    const unsub = window.api.observability.onSummary((wid) => {
+      if (wid === workspaceId) void sync();
+    });
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, [loaded, workspaceId, autoKey]);
 
   // Drag-reorder of session tabs (#1). Move the dragged tab before the drop
   // target; the existing sessions.json persist effect saves the new order.
@@ -460,7 +579,8 @@ export function TerminalPane({
                 dragSessionId === s.id ? 'dragging' : ''
               }`}
               onClick={() => setActiveId(s.id)}
-              draggable
+              // Don't drag while editing the name (the input owns the pointer).
+              draggable={renamingId !== s.id}
               onDragStart={(e) => {
                 setDragSessionId(s.id);
                 e.dataTransfer.effectAllowed = 'move';
@@ -480,17 +600,42 @@ export function TerminalPane({
                 aria-label={ended ? 'session ended' : 'session live'}
                 title={ended ? 'session ended' : 'session live'}
               />
-              <span className="session-tab-name">{s.name}</span>
+              {renamingId === s.id ? (
+                <input
+                  className="session-tab-rename"
+                  autoFocus
+                  value={draftName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename(s.id);
+                    else if (e.key === 'Escape') setRenamingId(null);
+                  }}
+                  onBlur={() => commitRename(s.id)}
+                  aria-label="Session name"
+                />
+              ) : (
+                <span className="session-tab-name">
+                  {s.autoName && <span className="session-tab-auto" title="Auto-named from Claude's summary" aria-hidden="true">✦</span>}
+                  {s.name}
+                </span>
+              )}
               <button
-                className="session-tab-close"
-                aria-label={`Close ${s.name}`}
-                title="Close session"
+                className="session-tab-menu-trigger"
+                aria-label={`Actions for ${s.name}`}
+                aria-haspopup="menu"
+                aria-expanded={tabMenu?.id === s.id}
+                title="Session actions"
                 onClick={(e) => {
                   e.stopPropagation();
-                  void requestClose(s);
+                  if (tabMenu?.id === s.id) {
+                    setTabMenu(null);
+                    return;
+                  }
+                  openTabMenu(e.currentTarget, s.id);
                 }}
               >
-                ×
+                ⋮
               </button>
             </div>
           );
@@ -520,6 +665,60 @@ export function TerminalPane({
           mirror {activeMirror}
         </button>
       </div>
+      {tabMenu &&
+        (() => {
+          const s = sessions.find((x) => x.id === tabMenu.id);
+          if (!s) return null;
+          return createPortal(
+            <div
+              className="ws-chip-menu"
+              role="menu"
+              style={{ position: 'fixed', top: tabMenu.top, left: tabMenu.left }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                role="menuitem"
+                onClick={() => {
+                  setTabMenu(null);
+                  startRename(s.id);
+                }}
+              >
+                <IconRename />
+                <span>Rename</span>
+              </button>
+              <button
+                role="menuitemcheckbox"
+                aria-checked={!!s.autoName}
+                title="Name this tab from Claude's session summary, kept up to date"
+                onClick={() => {
+                  setTabMenu(null);
+                  toggleAutoName(s.id);
+                }}
+              >
+                <IconAuto />
+                <span>Auto rename</span>
+                {s.autoName && (
+                  <span className="ws-chip-menu-check" aria-hidden="true">
+                    ✓
+                  </span>
+                )}
+              </button>
+              <div className="ws-chip-menu-divider" />
+              <button
+                role="menuitem"
+                className="danger"
+                onClick={() => {
+                  setTabMenu(null);
+                  void requestClose(s);
+                }}
+              >
+                <IconClose />
+                <span>Close</span>
+              </button>
+            </div>,
+            document.body
+          );
+        })()}
       {/* Context bar — workspace's hue track at the top of the terminal,
           filling 0..100% with the latest assistant turn's context-window
           usage (input + cache_read + cache_creation over the session's

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -1688,6 +1688,44 @@ button.obs-ws-row:hover .obs-ws-icon { opacity: 1; color: var(--ink); }
 .session-tab:hover .session-tab-close,
 .session-tab.active .session-tab-close { opacity: 0.7; }
 .session-tab .session-tab-close:hover { background: var(--bg-hover); opacity: 1; color: var(--ink); }
+/* ⋮ actions trigger — replaces the bare close (rename / auto-rename / close). */
+.session-tab .session-tab-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 80ms ease, background 80ms ease;
+}
+.session-tab:hover .session-tab-menu-trigger,
+.session-tab.active .session-tab-menu-trigger { opacity: 0.7; }
+.session-tab .session-tab-menu-trigger:hover { background: var(--bg-hover); opacity: 1; color: var(--ink); }
+/* ✦ marker on an auto-named tab; the inline rename input. */
+.session-tab-auto { color: var(--ok); margin-right: 4px; font-size: 9px; vertical-align: middle; }
+.session-tab-rename {
+  width: 9ch;
+  min-width: 60px;
+  box-sizing: border-box;
+  padding: 1px 4px;
+  background: var(--bg);
+  border: 1px solid var(--ok);
+  border-radius: var(--r-sm);
+  color: var(--ink);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+/* Trailing checkmark on the active "Auto rename" toggle in the tab menu. */
+.ws-chip-menu-check { margin-left: auto; color: var(--ok); padding-left: 12px; }
 .session-tab-new {
   display: inline-flex;
   align-items: center;

--- a/tests/multi-session.spec.ts
+++ b/tests/multi-session.spec.ts
@@ -67,7 +67,8 @@ test('Multi-session: workspace starts with a "main" tab; + adds new tabs; close 
 
     // Close the active "session 3" — focus moves to the tab on its left
     // (session 2), not all the way back to main.
-    await tabs.nth(2).getByRole('button', { name: 'Close session 3' }).click();
+    await tabs.nth(2).getByRole('button', { name: 'Actions for session 3' }).click();
+    await window.getByRole('menuitem', { name: 'Close' }).click();
     await expect(tabs).toHaveCount(2);
     await expect(tabs.nth(1)).toContainText('session 2');
     await expect(tabs.nth(1)).toHaveClass(/active/);
@@ -86,12 +87,45 @@ test('Multi-session: closing the only tab respawns a fresh "main"', async () => 
     const tabs = strip.locator('.session-tab');
     await expect(tabs).toHaveCount(1);
 
-    await tabs.nth(0).getByRole('button', { name: /Close main/ }).click();
+    await tabs.nth(0).getByRole('button', { name: 'Actions for main' }).click();
+    await window.getByRole('menuitem', { name: 'Close' }).click();
 
     // Strip is never empty: a fresh "main" appears in place.
     await expect(tabs).toHaveCount(1);
     await expect(tabs.nth(0)).toContainText('main');
     await expect(tabs.nth(0)).toHaveClass(/active/);
+  } finally {
+    await app.close();
+  }
+});
+
+test('Session tab menu: rename via inline edit; auto-rename toggle marks the tab', async () => {
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  try {
+    await window.locator('.ws-chip', { hasText: 'mock-alpha' }).click();
+    const strip = activePane(window).locator('.session-tab-strip');
+    const tab = strip.locator('.session-tab').nth(0);
+    await expect(tab).toContainText('main');
+
+    // Rename: ⋮ → Rename → inline input → type → Enter.
+    await tab.getByRole('button', { name: 'Actions for main' }).click();
+    await window.getByRole('menuitem', { name: 'Rename' }).click();
+    const input = tab.locator('.session-tab-rename');
+    await expect(input).toBeVisible();
+    await input.fill('backend work');
+    await input.press('Enter');
+    await expect(tab).toContainText('backend work');
+
+    // Auto-rename: ⋮ → Auto rename → the tab gains the ✦ marker, and the
+    // menu item reads back as checked.
+    await tab.getByRole('button', { name: 'Actions for backend work' }).click();
+    await window.getByRole('menuitemcheckbox', { name: 'Auto rename' }).click();
+    await expect(tab.locator('.session-tab-auto')).toBeVisible();
+    await tab.getByRole('button', { name: 'Actions for backend work' }).click();
+    await expect(window.getByRole('menuitemcheckbox', { name: 'Auto rename' })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
   } finally {
     await app.close();
   }


### PR DESCRIPTION
Adds a hamburger (⋮) actions menu to each session tab, replacing the bare `×`.

## Menu options
- **Rename** — inline edit in the tab. Committing sets the name and **clears auto-rename** (a manual name takes ownership).
- **Auto rename** — per-tab toggle (**opt-in, default off**). When on, the tab name tracks Claude's session summary — `TerminalPane` subscribes to `observability:summary` and mirrors the tab's resolved Claude title (`summaryForBrokerSession(...).title`, capped 40 chars) into the name, refreshed on each push. Auto-named tabs show a `✦` marker.
- **Close** — routes through the existing `requestClose` (mirror-delete confirm when a transcript mirror exists).

The menu is a portaled dropdown reusing the workspace-chip menu styling. Drag-reorder is disabled while a tab's name is being edited.

## Data model
- New `SessionEntry.autoName?: boolean` persisted in `sessions.json` (normalized in `readInventory`); preload type updated (and the previously-undocumented `mirror` field added for accuracy).

## Verification
- typecheck · **127** unit · build · **76** e2e — all green. Added a rename + auto-rename e2e; updated the two tests that closed a tab via the old `×`.
- `docs/SPEC.md` updated (SessionEntry fields + the tab-menu user flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)