### PR TITLE
Committee 3/7: pause/unpause control plane (closes #119)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -876,7 +876,7 @@ The main process's writers use the read-write `state.db` connection; the MCP ser
 ### Cross-workspace committee control (#116)
 Give one workspace permission to talk to and control others, so a **manager** session can convene a **committee of expert workspaces** — unpause a panel, have them review/argue over a PR, synthesize a verdict. Built in phases (#117–#123); this section is amended each phase.
 
-**Status: in progress.** Phase 1 (#117, per-workspace MCP socket + caller identity — the security spine) shipped. Phase 2 (#118, the permission model + opt-in/grant UI) is described below; the cross-workspace *effects* (pause/post/collect/status, #119–#121) and the console + loadouts (#123) are not built yet.
+**Status: in progress.** Phase 1 (#117, per-workspace MCP socket + caller identity — the security spine) and Phase 2 (#118, permission model + opt-in/grant UI) shipped. Phase 3 (#119, the pause/unpause control plane — first real cross-workspace effect) is described below. The remaining effects (post/collect/status, #120–#121) and the console + loadouts (#123) are not built yet.
 
 **Architecture (recommended, from the design pass).** The existing host MCP server (above) is the cross-workspace control plane — every container already reaches it, it runs in `main` where it can call `pauseWorkspace`/`sendInput`, and it's already in the §9 security model. The **manager is an ordinary Claude session** that gains `committee.*` MCP tools via a loadout — not a privileged broker peer. The **host is the sole authority**.
 
@@ -888,7 +888,7 @@ type CommitteeVerb = 'read' | 'post' | 'pause';
 control?:       { canControl?: Array<{ id: string; verbs: CommitteeVerb[] }> };  // outbound (makes this a "manager")
 accessibility?: { reachable: boolean; acceptFrom?: string[]; roleHint?: string }; // inbound opt-in (makes this a reachable "expert")
 ```
-- **`read`** = query the target's sessions/events/cost; **`post`** = inject input into its live session; **`pause`** = pause/unpause (and cold-start) it. (Only `read`/`post`/`pause` *effects* land in later phases; #118 ships only the data + gate + UI.)
+- **`read`** = query the target's sessions/events/cost; **`post`** = inject input into its live session; **`pause`** = pause/unpause (and cold-start) it. (#118 shipped the data + gate + UI; the `pause` *effect* shipped in #119 below; `read`/`post` effects land in #120/#122.)
 - A workspace holding ≥1 grant is a **manager**; one with `reachable: true` is a reachable **expert**.
 
 **Enforcement — `src/main/control.ts`.** A single `assertControl(callerId, targetId, verb)` is the gate every committee effect must pass. It re-reads **both manifests fresh on every call** (instant revocation — no cached authority) and delegates to a pure `decideControl(caller, target, …)` (unit-tested truth table). Permit **iff** all hold; otherwise default-deny with a reason:
@@ -905,7 +905,14 @@ accessibility?: { reachable: boolean; acceptFrom?: string[]; roleHint?: string }
 - **Grant matrix** (`CommitteePane.tsx`): keyed off the *selected* workspace as manager; rows are the other reachable container peers (managers + opted-out shown excluded with a reason), columns are the three verbs. Toggling a checkbox does an optimistic local update then `getManifest`→`writeManifest` on the manager's manifest. A local selected workspace shows "can't act as a manager — container-only."
 - **Manifest write merge (`workspace:writeManifest`):** the handler now **merges over the existing manifest** (`{ ...existing, ...spec, workspaceRoot }`) so renderer-unmanaged fields survive an edit — the edit form omits `control` (edited in the rail) and `installedLoadouts` (written by the loadouts engine), and a wholesale overwrite would silently wipe them. A key present in the incoming spec (even `undefined`, e.g. clearing `accessibility`) is authoritative. (This also fixes a latent pre-#118 `installedLoadouts`-on-edit drop.) `listAllWorkspaces` carries `control`/`accessibility` through to the renderer so chips + matrix reflect current state.
 
-**Phased delivery.** #117 socket/identity ✓ → #118 model + UI (this) → #119 pause/unpause → #120 post/collect → #121 busy-idle + status + runaway guards → #122 narrow legacy fleet-global reads (behind a flag) → #123 console UI + manager/expert loadouts.
+**Pause/unpause control plane (#119) — first real effect.** A granted manager can pause/unpause a reachable expert.
+- **MCP tools** `committee_pause(id)` / `committee_unpause(id)` (`mcpServer.ts`) — the manager's Claude calls these over its per-workspace socket; `callerId` is the accepting listener's id. They **do not** touch the read-only DB connection; they proxy to host effect functions injected via `setCommitteeHandlers` (so `mcpServer.ts` needn't import the docker/backend graph). Tool dispatch is now async (`callTool` awaits `tool.run`; `dispatchLine` funnels sync + async results through one promise chain).
+- **IPC** `committee:pause` / `committee:unpause` (`ipc.ts`, `committeePause`/`committeeUnpause`) — the same effect functions, with `callerId` supplied by the host UI (the human operator — the ultimate authority, who can edit manifests directly anyway). Exposed to the renderer as `window.api.committee.pause/unpause` for the future console (#123).
+- Both paths call `assertControl(callerId, targetId, 'pause')` first, then: **pause** resolves the target's live `containerId` from `listAllWorkspaces` (pause is keyed by containerId) and calls `backend.pauseWorkspace`; **unpause** calls `backend.startWorkspace(id)` (unpauses a paused container, cold-starts a stopped one) then **waits for the broker** (`docker.ts:waitForBrokerReady`) before returning.
+- **Frozen-broker correctness:** a paused container's broker (PID 1) is frozen — a socket *connect* still succeeds (kernel backlog) but it never answers. So `waitForBrokerReady` polls a fresh `LIST` (not just connect) on the `REATTACH_RETRIES`×`REATTACH_RETRY_MS` backoff, each attempt bounded by a short timeout, until the thawed broker replies. This guarantees a later `post` (#120) never lands in a still-frozen broker. Skipped for mock/local (no broker).
+- `pause` is a **combined verb** (pause + unpause + cold-start) — it grants lifecycle, not just resume. The **manager is never paused**, and experts hold no grants so they can't pause each other.
+
+**Phased delivery.** #117 socket/identity ✓ → #118 model + UI ✓ → #119 pause/unpause ✓ → #120 post/collect → #121 busy-idle + status + runaway guards → #122 narrow legacy fleet-global reads (behind a flag) → #123 console UI + manager/expert loadouts.
 
 ### Dev-mode mock fleet
 When `CLAUDE_FLEET_MOCK=1` is set in the main process's environment, `ipc.ts` swaps the real `docker.ts` implementation for `src/main/mock.ts`. The mock:

--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -623,6 +623,46 @@ const REATTACH_RETRIES = 12;
 const REATTACH_RETRY_MS = 250;
 
 /**
+ * Resolve only once the workspace's broker answers a `LIST` (#119). Committee
+ * unpause uses this so a later `post` (#120) never lands in a *frozen* broker:
+ * `docker unpause` (startWorkspace) has thawed the container by the time we
+ * poll, but the broker (PID 1) may take a moment to resume servicing RPCs.
+ * We retry on the same backoff the reattach race uses.
+ *
+ * A frozen broker still *accepts* a socket connect (the kernel parks it in the
+ * listen backlog) but never answers — so `ready()` succeeding is not enough;
+ * the authoritative signal is a `LIST` reply. Each attempt is bounded by a
+ * short timeout so a genuinely-stuck broker can't burn the full 30s RPC budget
+ * per try (the late reply is swallowed to avoid an unhandled rejection).
+ */
+export async function waitForBrokerReady(workspaceId: string): Promise<void> {
+  const sockPath = workspaceBrokerSocket(workspaceId);
+  const PER_ATTEMPT_MS = 1500;
+  let lastErr: unknown;
+  for (let i = 0; i < REATTACH_RETRIES; i++) {
+    const client = new BrokerClient(sockPath);
+    try {
+      await client.ready();
+      const listed = client.listSessions();
+      listed.catch(() => {}); // swallow a late rejection if we time out first
+      await Promise.race([
+        listed,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('broker LIST timed out')), PER_ATTEMPT_MS))
+      ]);
+      return; // broker is servicing RPCs again
+    } catch (err) {
+      lastErr = err;
+      await new Promise((r) => setTimeout(r, REATTACH_RETRY_MS));
+    } finally {
+      client.close();
+    }
+  }
+  throw new Error(
+    `broker for ${workspaceId} did not become ready after unpause: ${(lastErr as Error)?.message ?? String(lastErr)}`
+  );
+}
+
+/**
  * Open a terminal session against the in-container broker.
  *
  * Broker socket lives in the host state dir keyed by workspace id. We

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -25,7 +25,8 @@ import * as realLocal from './local.js';
 import * as mockDocker from './mock.js';
 import type { Backend } from './backend.js';
 import { resolveKind } from './backendRouter.js';
-import { ensureWorkspaceSocket, removeWorkspaceSocket } from './mcpServer.js';
+import { assertControl } from './control.js';
+import { ensureWorkspaceSocket, removeWorkspaceSocket, setCommitteeHandlers } from './mcpServer.js';
 import * as vault from './vault.js';
 import * as fs from './fs.js';
 import * as imageLibrary from './imageLibrary.js';
@@ -220,6 +221,41 @@ async function listAllWorkspaces(): Promise<Workspace[]> {
   }
 
   return result;
+}
+
+// ── Cross-workspace committee control (#119) ───────────────────────────────
+// The single place pause/unpause effects are performed, shared by the MCP
+// tools (caller id from the per-workspace socket) and the committee IPC
+// channels (caller id supplied by the host UI — the human operator, who is the
+// ultimate authority and can already edit manifests directly). Both go through
+// `assertControl` first, so authorization is identical on either path.
+
+/** Pause a reachable, granted expert. Resolves its live containerId from the
+ *  merged list (pauseWorkspace is keyed by containerId, not workspace id). */
+async function committeePause(callerId: string, targetId: string): Promise<{ id: string; paused: true }> {
+  await assertControl(callerId, targetId, 'pause');
+  const target = (await listAllWorkspaces()).find((w) => w.id === targetId);
+  if (!target?.containerId) {
+    throw new Error(`target ${targetId} has no live container to pause`);
+  }
+  await backendForKind(target.kind).pauseWorkspace(target.containerId);
+  return { id: targetId, paused: true };
+}
+
+/** Unpause (or cold-start) a granted expert, returning only once its broker is
+ *  servicing RPCs again so a later `post` (#120) can't land in a frozen broker. */
+async function committeeUnpause(callerId: string, targetId: string): Promise<{ id: string; running: true }> {
+  await assertControl(callerId, targetId, 'pause');
+  const kind = await resolveKind(targetId);
+  const containerId = await backendForKind(kind).startWorkspace(targetId);
+  if (!containerId) {
+    throw new Error(`target ${targetId} has no container to unpause (it may need recreation)`);
+  }
+  // Real docker only — mock/local have no in-container broker to wait on.
+  if (!MOCK_MODE && kind === 'container') {
+    await realDocker.waitForBrokerReady(targetId);
+  }
+  return { id: targetId, running: true };
 }
 
 export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): void {
@@ -506,6 +542,19 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   ipcMain.handle('workspace:pause', async (_e, containerId: string) =>
     (await backendFor(containerId)).pauseWorkspace(containerId)
   );
+  // Committee pause/unpause (#119). `callerId` is the workspace acting as
+  // manager; assertControl gates the effect. Exposed for the committee console
+  // (#123); the manager's Claude reaches the same effects via the MCP tools.
+  ipcMain.handle('committee:pause', (_e, callerId: string, targetId: string) =>
+    committeePause(callerId, targetId)
+  );
+  ipcMain.handle('committee:unpause', (_e, callerId: string, targetId: string) =>
+    committeeUnpause(callerId, targetId)
+  );
+  // Let the MCP committee_* tools reach the same effects (caller id from the
+  // per-workspace socket instead of an IPC arg).
+  setCommitteeHandlers({ pause: committeePause, unpause: committeeUnpause });
+
   ipcMain.handle('workspace:remove', async (_e, containerId: string, opts?: RemoveWorkspaceOpts) => {
     // A saved (no-live) workspace passes its ULID in opts.id; prefer it so the
     // kind resolves even when there's no live containerId.

--- a/src/main/mcpServer.ts
+++ b/src/main/mcpServer.ts
@@ -41,6 +41,22 @@ interface ToolCtx {
   callerId: string;
 }
 
+/**
+ * Cross-workspace committee effects (#119+). Injected by `ipc.ts` at startup so
+ * the `committee_*` tools can drive pause/unpause (and later post/collect)
+ * without mcpServer importing the docker/backend module graph. Each takes the
+ * host-assigned `callerId` (never a wire value) and the target workspace id;
+ * the implementation enforces `assertControl` before any effect.
+ */
+export interface CommitteeHandlers {
+  pause(callerId: string, targetId: string): Promise<unknown>;
+  unpause(callerId: string, targetId: string): Promise<unknown>;
+}
+let committeeHandlers: CommitteeHandlers | null = null;
+export function setCommitteeHandlers(h: CommitteeHandlers): void {
+  committeeHandlers = h;
+}
+
 let userDataDir: string | null = null;
 let rodb: Database.Database | null = null;
 // One listening socket per workspace, keyed by workspace id. The id is captured
@@ -147,18 +163,23 @@ function dispatchLine(line: string, sock: Socket, callerId: string): void {
   // Notifications (no id) get no reply — e.g. notifications/initialized.
   const isNotification = id === undefined || id === null;
 
-  try {
-    const result = handleMethod(method ?? '', params ?? {}, callerId);
-    if (!isNotification && result !== NO_REPLY) {
-      send(sock, { jsonrpc: '2.0', id, result });
-    }
-  } catch (err) {
-    if (!isNotification) {
-      const message = err instanceof Error ? err.message : String(err);
-      const code = err instanceof RpcError ? err.code : -32603;
-      send(sock, { jsonrpc: '2.0', id, error: { code, message } });
-    }
-  }
+  // handleMethod may return a Promise (the committee_* tools call async backend
+  // effects); Promise.resolve() funnels both sync throws and async rejections
+  // through the single .catch below.
+  Promise.resolve()
+    .then(() => handleMethod(method ?? '', params ?? {}, callerId))
+    .then((result) => {
+      if (!isNotification && result !== NO_REPLY) {
+        send(sock, { jsonrpc: '2.0', id, result });
+      }
+    })
+    .catch((err) => {
+      if (!isNotification) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code = err instanceof RpcError ? err.code : -32603;
+        send(sock, { jsonrpc: '2.0', id, error: { code, message } });
+      }
+    });
 }
 
 const NO_REPLY = Symbol('no-reply');
@@ -185,14 +206,14 @@ function handleMethod(method: string, params: Record<string, unknown>, callerId:
     case 'tools/list':
       return { tools: TOOLS.map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })) };
     case 'tools/call':
-      return callTool(params, callerId);
+      return callTool(params, callerId); // may be a Promise (committee_* tools)
     default:
       if (method.startsWith('notifications/')) return NO_REPLY;
       throw new RpcError(-32601, `Method not found: ${method}`);
   }
 }
 
-function callTool(params: Record<string, unknown>, callerId: string): unknown {
+async function callTool(params: Record<string, unknown>, callerId: string): Promise<unknown> {
   const name = params.name as string;
   const args = (params.arguments as Record<string, unknown>) ?? {};
   const tool = TOOLS.find((t) => t.name === name);
@@ -200,8 +221,10 @@ function callTool(params: Record<string, unknown>, callerId: string): unknown {
   if (!rodb) throw new RpcError(-32603, 'Database not open');
   try {
     // callerId is host-assigned (the accepting listener's workspace id), so it
-    // is trustworthy here. Tools that scope by caller read it from ctx (#122).
-    const result = tool.run(rodb, args, { callerId });
+    // is trustworthy here. Tools that scope by caller read it from ctx (#122);
+    // the committee_* tools enforce assertControl before any effect. `await`
+    // covers both sync DB tools and async committee effects.
+    const result = await tool.run(rodb, args, { callerId });
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   } catch (err) {
     // Tool-level failures surface to the model as an error result (MCP
@@ -385,6 +408,34 @@ const TOOLS: Tool[] = [
         return { truncated: true, returned: MAX_LIMIT, rows: rows.slice(0, MAX_LIMIT) };
       }
       return { truncated: false, returned: rows.length, rows };
+    }
+  },
+  // Cross-workspace committee control (#119). These do NOT touch the read-only
+  // DB connection — they proxy to the injected host handlers, which enforce
+  // `assertControl(callerId, id, 'pause')` before any effect. `callerId` is the
+  // host-assigned id of the accepting per-workspace socket, never a wire value.
+  {
+    name: 'committee_pause',
+    description:
+      'Pause a reachable expert workspace you hold a "pause" grant for. Freezes its container; ' +
+      'the conversation is preserved. Arg: id (the target workspace id).',
+    inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+    run: (_db, a, ctx) => {
+      if (!committeeHandlers) throw new Error('committee control is unavailable');
+      if (typeof a.id !== 'string') throw new Error('id is required');
+      return committeeHandlers.pause(ctx.callerId, a.id);
+    }
+  },
+  {
+    name: 'committee_unpause',
+    description:
+      'Unpause (or cold-start) an expert workspace you hold a "pause" grant for, and wait until ' +
+      'its in-container session manager is responsive before returning. Arg: id (the target workspace id).',
+    inputSchema: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+    run: (_db, a, ctx) => {
+      if (!committeeHandlers) throw new Error('committee control is unavailable');
+      if (typeof a.id !== 'string') throw new Error('id is required');
+      return committeeHandlers.unpause(ctx.callerId, a.id);
     }
   }
 ];

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -174,6 +174,14 @@ const api = {
     list: () => ipcRenderer.invoke('images:list'),
     remove: (ref: string) => ipcRenderer.invoke('images:remove', ref)
   },
+  /** Cross-workspace committee control (#119). `callerId` is the workspace
+   *  acting as manager; the host gates every call via assertControl. */
+  committee: {
+    pause: (callerId: string, targetId: string): Promise<{ id: string; paused: true }> =>
+      ipcRenderer.invoke('committee:pause', callerId, targetId),
+    unpause: (callerId: string, targetId: string): Promise<{ id: string; running: true }> =>
+      ipcRenderer.invoke('committee:unpause', callerId, targetId)
+  },
   sessions: {
     read: (workspaceId: string): Promise<SessionInventory> =>
       ipcRenderer.invoke('sessions:read', workspaceId),

--- a/tests/committee-pause.spec.ts
+++ b/tests/committee-pause.spec.ts
@@ -1,0 +1,90 @@
+// Committee pause/unpause control plane (#119), mock backend. Drives the
+// committee:pause / committee:unpause IPC (the channel the future console uses,
+// and the same effect the manager's MCP tools reach) and asserts the
+// authorization gate: a granted manager flips a reachable expert paused ⇄
+// running, while an ungranted caller is refused.
+
+import { test, expect, type Page } from '@playwright/test';
+import { launch } from './_helpers.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function createWorkspace(window: Page, name: string): Promise<void> {
+  await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
+  await window.getByLabel('Workspace name').fill(name);
+  await window.getByRole('button', { name: 'Create & start' }).click();
+  await expect(window.getByRole('tab', { name: 'New' })).toBeHidden();
+}
+
+async function openChipMenu(window: Page, name: string) {
+  await window.locator('.ws-chip-group', { hasText: name }).locator('.ws-chip-menu-trigger').click();
+  return window.locator('.ws-chip-menu');
+}
+
+/** Current state of a workspace by id, read live from the IPC list. */
+function stateOf(window: Page, id: string): Promise<string | undefined> {
+  return window.evaluate(async (wid) => {
+    const list = (await (window as any).api.workspace.list()) as Array<{ id: string; state: string }>;
+    return list.find((w) => w.id === wid)?.state;
+  }, id);
+}
+
+test('Committee: granted manager pauses/unpauses a reachable expert; ungranted is refused (#119)', async () => {
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  try {
+    await createWorkspace(window, 'expert-p');
+    await createWorkspace(window, 'mgr-p');
+
+    // expert-p opts in.
+    const menu = await openChipMenu(window, 'expert-p');
+    await menu.getByRole('menuitem', { name: 'Edit…' }).click();
+    await window.getByText('Committee access').click();
+    await window.getByLabel('Reachable by managers').check();
+    await window.getByRole('button', { name: 'Save' }).click();
+    await expect(window.locator('.modal-tab', { hasText: 'Edit expert-p' })).toBeHidden();
+
+    // mgr-p is granted `pause` over expert-p via the matrix.
+    await window.locator('.ws-chip', { hasText: 'mgr-p' }).click();
+    await window.getByLabel('pause expert-p').check();
+    await expect(
+      window.locator('.ws-chip-group', { hasText: 'mgr-p' }).locator('.committee-glyph.mgr')
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Resolve workspace ids from the live list.
+    const ids = await window.evaluate(async () => {
+      const list = (await (window as any).api.workspace.list()) as Array<{ id: string; name: string }>;
+      return Object.fromEntries(list.map((w) => [w.name, w.id])) as Record<string, string>;
+    });
+
+    // Granted pause → expert flips to paused.
+    const res = await window.evaluate(
+      ([c, t]) => (window as any).api.committee.pause(c, t),
+      [ids['mgr-p'], ids['expert-p']]
+    );
+    expect(res).toMatchObject({ id: ids['expert-p'], paused: true });
+    await expect.poll(() => stateOf(window, ids['expert-p'])).toBe('paused');
+
+    // Unpause → back to running.
+    await window.evaluate(
+      ([c, t]) => (window as any).api.committee.unpause(c, t),
+      [ids['mgr-p'], ids['expert-p']]
+    );
+    await expect.poll(() => stateOf(window, ids['expert-p'])).toBe('running');
+
+    // Ungranted caller (expert acting on the manager) is refused by assertControl.
+    const denied = await window.evaluate(
+      async ([c, t]) => {
+        try {
+          await (window as any).api.committee.pause(c, t);
+          return 'NOT-REFUSED';
+        } catch (e) {
+          return String(e);
+        }
+      },
+      [ids['expert-p'], ids['mgr-p']]
+    );
+    expect(denied).toContain('control denied');
+  } finally {
+    await app.close();
+  }
+});

--- a/tests/mcp-server.spec.ts
+++ b/tests/mcp-server.spec.ts
@@ -147,7 +147,15 @@ test('MCP server: initialize, tools, query escape hatch, write rejection', async
     const tools = await client.call('tools/list');
     const names = ((tools.result as { tools: Array<{ name: string }> }).tools).map((t) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(['list_sessions', 'get_session', 'get_cost', 'list_events', 'query'])
+      expect.arrayContaining([
+        'list_sessions',
+        'get_session',
+        'get_cost',
+        'list_events',
+        'query',
+        'committee_pause',
+        'committee_unpause'
+      ])
     );
 
     // The watcher ingest is async — poll the raw query until the event lands.
@@ -176,6 +184,15 @@ test('MCP server: initialize, tools, query escape hatch, write rejection', async
       arguments: { sql: 'DELETE FROM events' }
     });
     expect((del.result as { isError?: boolean }).isError).toBe(true);
+
+    // committee_pause (#119) is wired through the async dispatch + injected
+    // handler, and enforces assertControl: this connection's caller id is `id`
+    // (the listener that accepted it), and `id2` never opted in (not reachable),
+    // so the call is refused before any backend effect is reached.
+    const cp = await client.call('tools/call', { name: 'committee_pause', arguments: { id: id2 } });
+    const cpRes = cp.result as { isError?: boolean; content?: Array<{ text?: string }> };
+    expect(cpRes.isError).toBe(true);
+    expect(cpRes.content?.[0]?.text ?? '').toContain('control denied');
 
     // Per-workspace fan-out (#117): the second workspace has its OWN listener
     // at its OWN per-id socket path — a separate connection that initializes


### PR DESCRIPTION
**Part of #116. Depends on #118 (`assertControl`, merged).** The first real cross-workspace effect: a granted manager can **pause and unpause** a reachable expert.

## How it works
- **MCP tools** `committee_pause(id)` / `committee_unpause(id)` (`mcpServer.ts`) — the manager's Claude calls these over its per-workspace socket, so `callerId` is the accepting listener's id (#117). They **never touch the read-only DB connection**; they proxy to host effect functions injected via `setCommitteeHandlers`, so `mcpServer.ts` doesn't import the docker/backend graph. Tool dispatch is now **async** (`callTool` awaits `tool.run`; `dispatchLine` funnels sync + async through one promise chain).
- **IPC** `committee:pause` / `committee:unpause` (`ipc.ts`) — the same effect functions, with `callerId` supplied by the host UI (the human operator, the ultimate authority). Exposed as `window.api.committee.pause/unpause` for the future console (#123).
- Both paths call **`assertControl(callerId, targetId, 'pause')` first**, then: pause resolves the target's live `containerId` from `listAllWorkspaces` and calls `pauseWorkspace`; unpause calls `startWorkspace(id)` (unpause / cold-start) then **waits for the broker**.

## Frozen-broker correctness (the subtle part)
A paused container's broker (PID 1) is frozen — a socket *connect* still succeeds (kernel backlog) but it never answers. So `docker.ts:waitForBrokerReady` polls a fresh **`LIST`** (not just connect) on the `REATTACH_RETRIES`×`REATTACH_RETRY_MS` backoff, each attempt bounded by a short timeout (late reply swallowed to avoid an unhandled rejection), until the thawed broker replies. This guarantees a later `post` (#120) never lands in a still-frozen broker. Skipped for mock/local (no broker).

## Decisions (from #116)
- `pause` is a **combined verb** (pause + unpause + cold-start) — grants lifecycle, not just resume.
- The **manager is never paused**; experts hold no grants so they can't pause each other.

## Tests
- `tests/committee-pause.spec.ts` (e2e, mock): granted manager pauses ⇄ unpauses a reachable expert (state flips verified); an **ungranted** caller is refused (`control denied`).
- `mcp-server.spec.ts` extended: proves the **MCP tool path** — `committee_pause` against a non-opted-in target returns `control denied` through the async dispatch + injected handler, before any backend effect. (`tools/list` now includes `committee_pause`/`committee_unpause`.)
- `npm run typecheck` ✅ · `npx vitest run` → **146 passed** ✅ · committee/mcp/pause e2e green ✅

## SPEC
Committee section amended with the pause/unpause control plane (MCP tools, IPC, the broker-wait, combined-verb + never-pause-the-manager rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)