### PR TITLE
fix(docker): devops runner build SIGPIPE on kustomize tag resolution

### DIFF
--- a/docker/scripts/kubectl.sh
+++ b/docker/scripts/kubectl.sh
@@ -11,10 +11,20 @@ kubectl version --client | head -1
 # kustomize — download the release tarball directly (the upstream install
 # script's glob is flaky). Resolve the latest `kustomize/vX.Y.Z` tag unless
 # pinned, then fetch the matching asset (tag slash is %2F-encoded in the URL).
+#
+# The selector must DRAIN the whole curl body: a `| head -1` mid-stream closes
+# the pipe early and SIGPIPEs curl (exit 141), which `set -o pipefail` turns
+# into a build failure (this is what broke the devops image publish). `sort -V
+# | tail -n1` reads to EOF (no early close) and picks the highest version —
+# more robust than API order, since the kustomize repo interleaves other
+# modules' tags (api/, kyaml/, cmd/config/).
 KV="${KUSTOMIZE_VERSION:-latest}"
 if [ "$KV" = "latest" ]; then
-  KV="$(curl -fsSL 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=30' \
-        | grep '"tag_name"' | grep 'kustomize/' | head -1 | sed -E 's#.*"kustomize/(v[0-9.]+)".*#\1#')"
+  KV="$(curl -fsSL 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' \
+        | grep -oE 'kustomize/v[0-9]+\.[0-9]+\.[0-9]+' \
+        | sed 's#kustomize/##' \
+        | sort -V | tail -n1)"
+  [ -n "$KV" ] || { echo "kustomize: could not resolve latest release tag" >&2; exit 1; }
 fi
 tmp="$(mktemp -d)"
 curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KV}/kustomize_${KV}_linux_${ARCH_DEB}.tar.gz" \


### PR DESCRIPTION
## Problem

The `runner-devops` image has **never published** — the publish-runner CI run for #131 ([run 28028289208](https://github.com/ImIOImI/claude-fleet/actions/runs/28028289208)) failed building the tooling layer:

```
#12 ERROR: process "... bash kubectl.sh; ..." did not complete successfully: exit code: 141
```

Exit **141 = SIGPIPE**. `docker/scripts/kubectl.sh` resolved the latest kustomize tag with:

```sh
curl -fsSL '.../releases?per_page=30' | grep '"tag_name"' | grep 'kustomize/' | head -1 | sed ...
```

`head -1` closes the pipe after the first match while `curl` is still streaming the (large) releases JSON, so `curl`/`grep` are killed with SIGPIPE and `set -o pipefail` surfaces it as a build failure. (The `… --version | head -1` smoke lines elsewhere are safe — their output is tiny and fully buffered before `head` closes.)

## Fix

Drain the whole response instead of truncating it mid-stream:

```sh
curl -fsSL '.../releases?per_page=100' \
  | grep -oE 'kustomize/v[0-9]+\.[0-9]+\.[0-9]+' \
  | sed 's#kustomize/##' \
  | sort -V | tail -n1
```

`sort -V | tail -n1` reads to EOF (no early close → no SIGPIPE) and picks the **highest** version, which is also more robust than relying on API order since the kustomize repo interleaves other modules' tags (`api/`, `kyaml/`, `cmd/config/`). Plus an explicit guard if nothing resolves.

## Verification

Ran the new pipeline locally: resolves `v5.8.1`, exit 0, no SIGPIPE. Merging this re-triggers the publish workflow (it watches `docker/**`), which should push **`ghcr.io/imioimi/claude-fleet/runner-devops:latest`** for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)