### PR TITLE
fix(docker): authenticate GitHub API in devops build (rate-limit)

### DIFF
--- a/.github/workflows/publish-runner.yml
+++ b/.github/workflows/publish-runner.yml
@@ -83,6 +83,12 @@ jobs:
           # images are always in lockstep.
           build-args: |
             BASE_IMAGE=ghcr.io/${{ steps.owner.outputs.value }}/claude-fleet/runner@${{ steps.base.outputs.digest }}
+          # Authenticated GitHub API access for the install scripts (tenv, the
+          # kustomize tag lookup, tflint/trivy) — anonymous builds hit the
+          # 60 req/hr/IP limit. Passed as a BuildKit secret so it never lands
+          # in the image. GITHUB_TOKEN is auto-provided to the workflow.
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.meta_devops.outputs.tags }}
           labels: ${{ steps.meta_devops.outputs.labels }}
           cache-from: type=gha

--- a/docker/devops/Dockerfile
+++ b/docker/devops/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # DevOps runner image — the base claude-fleet runner + the SumerSports
 # platform-engineering toolset (GitHub CLI, OpenTofu/Terramate, OPA, tflint/
 # trivy, kubectl/helm/kustomize, dnsutils, AWS CLI; Azure CLI opt-in). The
@@ -38,7 +39,18 @@ ENV TENV_ROOT=/opt/tenv
 
 USER root
 COPY docker/scripts/ /opt/install-scripts/
-RUN set -eux; cd /opt/install-scripts; \
+# The installers hit api.github.com (tenv resolving tofu/terramate, the
+# kustomize tag lookup, the tflint/trivy installers). Unauthenticated CI builds
+# get 60 req/hr/IP and fail with "rate-limited by GitHub". Mount CI's token as a
+# BuildKit secret (NOT a build-arg — keeps it out of the image history/layers)
+# and export the env vars those tools read; the build still works without it
+# (the secret mount is optional), just risks the anonymous rate limit.
+RUN --mount=type=secret,id=github_token set -eux; \
+    if [ -f /run/secrets/github_token ]; then \
+      GITHUB_TOKEN="$(cat /run/secrets/github_token)"; \
+      export GITHUB_TOKEN TENV_GITHUB_TOKEN="$GITHUB_TOKEN"; \
+    fi; \
+    cd /opt/install-scripts; \
     bash apt-tools.sh; \
     bash gh.sh; \
     bash yq.sh; \

--- a/docker/scripts/kubectl.sh
+++ b/docker/scripts/kubectl.sh
@@ -20,7 +20,11 @@ kubectl version --client | head -1
 # modules' tags (api/, kyaml/, cmd/config/).
 KV="${KUSTOMIZE_VERSION:-latest}"
 if [ "$KV" = "latest" ]; then
-  KV="$(curl -fsSL 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' \
+  # Authenticate the API call when a token is present (CI exports GITHUB_TOKEN)
+  # — api.github.com allows only 60 req/hr/IP unauthenticated, which CI hits.
+  gh_auth=()
+  [ -n "${GITHUB_TOKEN:-}" ] && gh_auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  KV="$(curl -fsSL "${gh_auth[@]}" 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' \
         | grep -oE 'kustomize/v[0-9]+\.[0-9]+\.[0-9]+' \
         | sed 's#kustomize/##' \
         | sort -V | tail -n1)"


### PR DESCRIPTION
Follow-up to #133. With the SIGPIPE gone, the devops install layer hit a **real** failure:

```
Error: you are rate-limited by GitHub. Consider using a token by setting
the TENV_GITHUB_TOKEN env variable to increase the rate limit
```

`tenv` resolves the tofu/terramate releases via `api.github.com`, which allows only **60 req/hr/IP unauthenticated** — CI hits that. The kustomize tag lookup and the tflint/trivy installers share the risk.

## Fix

Thread CI's `GITHUB_TOKEN` into the build as a **BuildKit secret** (not a build-arg — keeps it out of the image history/layers) and export the env vars each tool reads:
- `TENV_GITHUB_TOKEN` → `tenv`
- `GITHUB_TOKEN` → the `tflint`/`trivy` installers (they honor it)
- `Authorization: Bearer` header on the kustomize `api.github.com` curl

The secret mount is **optional** — local builds without a token still work (just subject to the anonymous limit). Verified the unauthenticated `kubectl.sh` path locally: resolves `v5.8.1`, exit 0, empty-array safe under `set -u`.

## Files
- `docker/devops/Dockerfile` — `# syntax=docker/dockerfile:1` + `RUN --mount=type=secret,id=github_token …` exporting the tokens.
- `docker/scripts/kubectl.sh` — optional auth header on the kustomize API call.
- `.github/workflows/publish-runner.yml` — pass `secrets: github_token=${{ secrets.GITHUB_TOKEN }}` to the devops build.

Merging re-triggers the publish workflow; this should be the one that finally pushes `ghcr.io/imioimi/claude-fleet/runner-devops:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)