### PR TITLE
fix(docker): SIGPIPE on `--version | head` smokes under QEMU

### DIFF
--- a/docker/scripts/apt-tools.sh
+++ b/docker/scripts/apt-tools.sh
@@ -18,6 +18,10 @@ apt-get install -y --no-install-recommends \
 pip3 install --no-cache-dir --break-system-packages pre-commit
 rm -rf /var/lib/apt/lists/*
 
-make --version | head -1
-dig -v 2>&1 | head -1 || true
+# Smoke the tools. Use `sed -n '1p'` (NOT `| head -1`) to print the first line:
+# head closes the pipe after line 1, and under QEMU emulation (the arm64 leg of
+# the multi-arch build) the slow emulated producer is still writing → SIGPIPE →
+# exit 141, which `set -o pipefail` turns into a build failure. sed drains to EOF.
+make --version | sed -n '1p'
+dig -v 2>&1 | sed -n '1p' || true
 pre-commit --version

--- a/docker/scripts/azure-cli.sh
+++ b/docker/scripts/azure-cli.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 V="${AZURE_CLI_VERSION:-2.83.0}"
 pip3 install --no-cache-dir --break-system-packages "azure-cli==${V}"
-az version --output table | head -3
+az version --output table | sed -n '1,3p'  # sed, not head — head SIGPIPEs the producer under QEMU (see apt-tools.sh)

--- a/docker/scripts/gh.sh
+++ b/docker/scripts/gh.sh
@@ -8,4 +8,4 @@ curl -fsSL "https://github.com/cli/cli/releases/download/v${V}/gh_${V}_linux_${A
   | tar -xz -C "$tmp"
 install -m 0755 "$tmp/gh_${V}_linux_${ARCH_DEB}/bin/gh" /usr/local/bin/gh
 rm -rf "$tmp"
-gh --version | head -1
+gh --version | sed -n '1p'  # sed, not head — head SIGPIPEs the producer under QEMU (see apt-tools.sh)

--- a/docker/scripts/iac-lint.sh
+++ b/docker/scripts/iac-lint.sh
@@ -11,4 +11,4 @@ curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/ins
   | sh -s -- -b /usr/local/bin
 
 tflint --version
-trivy --version | head -1
+trivy --version | sed -n '1p'  # sed, not head — head SIGPIPEs the producer under QEMU (see apt-tools.sh)

--- a/docker/scripts/kubectl.sh
+++ b/docker/scripts/kubectl.sh
@@ -6,7 +6,7 @@ V="${KUBECTL_VERSION:-latest}"
 [ "$V" = "latest" ] && V="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"
 curl -fsSL "https://dl.k8s.io/release/${V}/bin/linux/${ARCH_DEB}/kubectl" -o /usr/local/bin/kubectl
 chmod 0755 /usr/local/bin/kubectl
-kubectl version --client | head -1
+kubectl version --client | sed -n '1p'  # sed, not head — head SIGPIPEs the producer under QEMU (see apt-tools.sh)
 
 # kustomize — download the release tarball directly (the upstream install
 # script's glob is flaky). Resolve the latest `kustomize/vX.Y.Z` tag unless

--- a/docker/scripts/tenv.sh
+++ b/docker/scripts/tenv.sh
@@ -32,7 +32,7 @@ tenv tm install "$TERRAMATE_VERSION"
 tenv tm use "$TERRAMATE_VERSION"
 
 # Smoke the shims (this also creates the per-version last-use.txt files as root)…
-tofu version | head -1
+tofu version | sed -n '1p'  # sed, not head — head SIGPIPEs the producer under QEMU (see apt-tools.sh)
 terramate --version
 
 # …THEN make everything world-RWX, so any container UID (docker run --user) can


### PR DESCRIPTION
Follow-up to #133/#134. With auth fixed, the devops build got further but failed again with **exit 141 (SIGPIPE)** — this time on the **arm64** leg at `apt-tools.sh`'s `make --version | head -1`.

`head -1` closes the pipe after the first line. On native amd64 the tiny `--version` output is fully buffered before `head` closes, so the producer exits cleanly — but under **QEMU emulation** (the arm64 multi-arch leg) the emulated producer is slow enough to still be writing when `head` closes the pipe → SIGPIPE → 141, which `set -o pipefail` turns into a build failure.

## Fix

Replace every `… | head -N` smoke line with `sed -n '1[,N]p'`, which reads the stream to EOF (never closes early, so the producer never gets SIGPIPE):

- `apt-tools.sh` — `make`, `dig`
- `gh.sh`, `tenv.sh`, `kubectl.sh`, `iac-lint.sh` (trivy), `azure-cli.sh`

The kustomize tag lookup already drains via `sort -V | tail -n1`. Verified locally: `make --version | sed -n '1p'` → exit 0, no SIGPIPE; no live `| head` smokes remain in `docker/scripts/`.

This should be the last blocker — merging re-triggers the publish and should finally push `ghcr.io/imioimi/claude-fleet/runner-devops:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)