### PR TITLE
feat(mcp): MCP over loopback TCP on Windows (Phase 2)

### DIFF
--- a/docs/design/windows-broker-tcp.md
+++ b/docs/design/windows-broker-tcp.md
@@ -1,6 +1,9 @@
 # Windows support: broker (and MCP) over loopback TCP
 
-**Status:** plan / handoff. Not yet implemented.
+**Status:** **implemented** (Phase 1 broker-over-TCP — PR #141, on `main`;
+Phase 2 MCP-over-TCP — this change). Verified on native Windows: `pty:attach`
+succeeds over loopback TCP, and claude's in-container `claude-fleet-state` MCP
+server connects over loopback TCP with per-workspace token auth.
 **Why this doc:** the work must be done and verified on **native Windows** (Docker
 Desktop, native Electron, Windows-ABI native modules). This captures the full
 plan so a Windows-native Claude Code session can execute it without re-deriving
@@ -142,25 +145,35 @@ constructor(endpoint: string | { host: string; port: number }) {
 Everything downstream (FrameReader, waiters, events) is transport-agnostic and
 needs no change. Update the three call sites to pass the resolved endpoint.
 
-### Phase 2 — MCP over TCP (#12), do after Phase 1 verifies
+### Phase 2 — MCP over TCP (#12) — **implemented**
 
-Same root cause, same fix, lower priority (the terminal works without it). The
-in-container MCP path: host MCP server on a unix socket (`mcpServer.ts`,
-`<userData>/mcp/<id>/mcp.sock`), bind-mounted per-id, reached from the container
-by a reconnecting `socat - UNIX-CONNECT:/fleet/mcp/mcp.sock` stdio bridge seeded
-into `~/.claude.json` (see `claudeJsonSeed.ts` / `ensureWorkspaceClaudeJson`,
-`mcpSocket.ts`, and the bind in `docker.ts` ~407–420). On Windows the bind-mount
-unix socket is unreachable the same way. Options:
-- Have the host MCP server also listen on `127.0.0.1:<port>` (Windows), publish a
-  second container port, and seed the in-container bridge as
-  `socat - TCP:host.docker.internal:<port>` (or `npx -y …` TCP client) instead of
-  the unix `socat`. `host.docker.internal` resolves to the host from inside
-  Docker Desktop containers.
-- Keep the per-id caller-identity model (#117): with TCP you lose the
-  "which unix listener accepted" identity signal, so derive caller id another way
-  (per-workspace token in the seeded bridge command, validated host-side). **Call
-  this out and design it before implementing** — don't regress the #117 security
-  property.
+Same root cause as Phase 1, reversed direction: here the **host** is the server
+and the **container** is the client. The host MCP server (`mcpServer.ts`) can't
+`listen()` on a unix socket at a Windows path (EACCES), so the per-id
+unix-socket transport (`<userData>/mcp/<id>/mcp.sock`, bind-mounted per-id,
+reached by a reconnecting `socat - UNIX-CONNECT:/fleet/mcp/mcp.sock` bridge in
+`~/.claude.json`) can't work on Windows.
+
+**As implemented (win32-gated; Linux/macOS unchanged):**
+- **Transport:** the host runs **one** loopback-TCP listener on
+  `127.0.0.1:7071` (`MCP_TCP_PORT`, override via `CLAUDE_FLEET_MCP_TCP_PORT`) —
+  bound to `127.0.0.1` only (verified reachable from containers via
+  `host.docker.internal`, which Docker Desktop NATs through the host loopback, so
+  it's **not** LAN-exposed). The in-container bridge dials
+  `socat - TCP:host.docker.internal:7071`.
+- **Caller identity (#117 preserved):** the TCP source address is always
+  `127.0.0.1` (NAT'd) and carries no identity, so "which listener accepted" is
+  replaced by a **per-workspace token**. Each workspace gets a random 256-bit
+  token written to `<userData>/mcp/<id>/token` — the **same per-id leaf dir** the
+  socket used, bind-mounted into only that container, so a container only ever
+  sees its own token and can't read a sibling's or guess one. The bridge sends
+  the token as the **first line**; the host maps token→workspace id = `callerId`
+  and drops any connection presenting an unknown token. The reconnecting bridge
+  re-sends the token on every reconnect (so socat is single-shot per connection,
+  not `forever`).
+- Bridge command (seeded by `managedMcpServerEntry` in `docker.ts`):
+  `TOK=$(cat /fleet/mcp/token); { printf '%s\n' "$TOK"; exec cat; } | socat - TCP:host.docker.internal:7071`
+  inside the existing reconnect `while` loop.
 
 ## Building / verifying (native Windows)
 

--- a/src/main/docker.ts
+++ b/src/main/docker.ts
@@ -29,7 +29,13 @@ import {
 import type { AuthMode, Workspace, WorkspaceEnv, WorkspaceResources, WorkspaceKind } from './workspaces.js';
 import { FACTORY_MIRROR } from './workspaces.js';
 import { fleetPrivateDir, fleetSharedDir } from './config.js';
-import { mcpWorkspaceSocketDir, mcpWorkspaceBind, CONTAINER_MCP_SOCKET } from './mcpSocket.js';
+import {
+  mcpWorkspaceSocketDir,
+  mcpWorkspaceBind,
+  CONTAINER_MCP_SOCKET,
+  CONTAINER_MCP_TOKEN,
+  MCP_TCP_PORT
+} from './mcpSocket.js';
 import { BrokerClient, brokerPtyStream } from './broker.js';
 import { recordPendingAttach } from './pendingAttaches.js';
 import { learnBrokerSessionMapping } from './db.js';
@@ -350,13 +356,26 @@ function managedMcpServerEntry(): {
   command: string;
   args: string[];
 } {
+  // Windows: the host MCP server listens on loopback TCP (it can't bind a unix
+  // socket on a Windows path), so the bridge dials host.docker.internal and
+  // authenticates with the per-workspace token bind-mounted at /fleet/mcp/token.
+  // The token is sent as the first line, then claude's stdio is spliced to the
+  // socket: `{ printf token; exec cat; }` feeds the token then claude's input
+  // into socat's stdin (→ TCP), while socat's stdout (← TCP) returns to claude.
+  // The outer `while` re-handshakes on every reconnect (each new TCP connection
+  // needs the token again), so — unlike the unix entry — socat is single-shot,
+  // not `forever`. The token is re-read each iteration so a regenerated one is
+  // picked up. (#117 identity is preserved: the token dir is leaf-bind-mounted
+  // into only this container.)
+  const command = isWindows
+    ? `while :; do TOK=$(cat "${CONTAINER_MCP_TOKEN}" 2>/dev/null); ` +
+      `if [ -n "$TOK" ]; then { printf '%s\\n' "$TOK"; exec cat; } | ` +
+      `socat - "TCP:host.docker.internal:${MCP_TCP_PORT}"; fi; sleep 1; done`
+    : `while :; do socat - "UNIX-CONNECT:${CONTAINER_MCP_SOCKET},forever,interval=1"; sleep 1; done`;
   return {
     type: 'stdio',
     command: 'sh',
-    args: [
-      '-c',
-      `while :; do socat - "UNIX-CONNECT:${CONTAINER_MCP_SOCKET},forever,interval=1"; sleep 1; done`
-    ]
+    args: ['-c', command]
   };
 }
 

--- a/src/main/mcpServer.ts
+++ b/src/main/mcpServer.ts
@@ -23,12 +23,26 @@
 // #122, gated behind a flag.
 
 import { createServer, type Server, type Socket } from 'node:net';
-import { existsSync, mkdirSync, rmSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
 import { costFor } from './pricing.js';
 import { isReadOnlySql } from './mcpReadonlySql.js';
-import { mcpWorkspaceSocketDir, mcpWorkspaceSocketPath } from './mcpSocket.js';
+import {
+  mcpWorkspaceSocketDir,
+  mcpWorkspaceSocketPath,
+  mcpWorkspaceTokenPath,
+  MCP_TCP_PORT
+} from './mcpSocket.js';
+
+// A Windows host can't listen() on a unix-domain socket at a Windows path
+// (EACCES), so the per-workspace-socket transport (#117) can't work there. On
+// win32 the server instead runs ONE loopback-TCP listener for all workspaces
+// and authenticates each connection by a per-workspace token (see mcpSocket.ts
+// mcpWorkspaceTokenPath). Linux/macOS keep the per-workspace unix sockets
+// unchanged. See docs/design/windows-broker-tcp.md (Phase 2).
+const isWindows = process.platform === 'win32';
 
 const PROTOCOL_VERSION = '2024-11-05';
 const SERVER_INFO = { name: 'claude-fleet-state', version: '1.0.0' };
@@ -81,23 +95,56 @@ let userDataDir: string | null = null;
 let rodb: Database.Database | null = null;
 // One listening socket per workspace, keyed by workspace id. The id is captured
 // in each listener's accept callback and becomes the connection's caller id.
+// (Unix transport — Linux/macOS.)
 const listeners = new Map<string, Server>();
 
+// Windows TCP transport: a single shared loopback listener plus a token→id map.
+// A connection's caller id is resolved from the token it presents on its first
+// line, since the TCP source address (always 127.0.0.1 via host.docker.internal)
+// carries no identity. tokenToId is the authority; idToToken makes token
+// issuance idempotent and lets removeWorkspaceSocket revoke.
+let tcpListener: Server | null = null;
+const tokenToId = new Map<string, string>();
+const idToToken = new Map<string, string>();
+
 /** Open the shared read-only DB connection. Per-workspace listeners are created
- *  lazily via {@link ensureWorkspaceSocket}. No-op if already started. */
+ *  lazily via {@link ensureWorkspaceSocket}. No-op if already started. On
+ *  Windows this also binds the single loopback-TCP listener that fronts every
+ *  workspace (identity comes from the per-connection token, not the socket). */
 export function startMcpServer(dir: string): void {
   if (rodb) return;
   const dbPath = join(dir, 'state.db');
   rodb = new Database(dbPath, { readonly: true, fileMustExist: true });
   userDataDir = dir;
+
+  if (isWindows && !tcpListener) {
+    // 127.0.0.1 only — never 0.0.0.0. Docker Desktop NATs host.docker.internal
+    // through the host loopback, so containers still reach it while the LAN
+    // cannot. callerId is resolved from the first-line token in handleTcp.
+    const srv = createServer((sock) => handleTcpConnection(sock));
+    srv.on('error', (err) => console.warn('[mcp] tcp listener error:', err));
+    srv.listen(MCP_TCP_PORT, '127.0.0.1', () =>
+      console.log(`[mcp] tcp listening on 127.0.0.1:${MCP_TCP_PORT}`)
+    );
+    tcpListener = srv;
+  }
 }
 
-/** Ensure a listener exists for `id` at `<userData>/mcp/<id>/mcp.sock`.
- *  Idempotent; safe to call before the workspace's container starts (the
- *  in-container socat bridge reconnects until the listener is up). No-op if the
- *  server hasn't been started (e.g. mock mode / tests without a DB). */
+/** Ensure `id` is reachable from its container. Idempotent; safe to call before
+ *  the workspace's container starts (the in-container bridge reconnects until
+ *  the server is up). No-op if the server hasn't been started (e.g. mock mode /
+ *  tests without a DB).
+ *
+ *  Unix (Linux/macOS): a per-workspace listener at `<userData>/mcp/<id>/mcp.sock`.
+ *  Windows: ensure a per-workspace token exists on disk (in the same per-id
+ *  leaf dir, bind-mounted into only that container) and is registered, so the
+ *  shared TCP listener can map an incoming token to this id. */
 export function ensureWorkspaceSocket(id: string): void {
   if (!rodb || !userDataDir) return;
+  if (isWindows) {
+    ensureWorkspaceToken(id);
+    return;
+  }
   if (listeners.has(id)) return;
   const dir = mcpWorkspaceSocketDir(userDataDir, id);
   const sockPath = mcpWorkspaceSocketPath(userDataDir, id);
@@ -116,6 +163,35 @@ export function ensureWorkspaceSocket(id: string): void {
   listeners.set(id, server);
 }
 
+/** Windows: ensure a stable per-workspace token exists and is registered.
+ *  Reuses the token already on disk (so it survives app restarts and matches a
+ *  paused container's baked-in bridge) — otherwise mints a fresh 256-bit one.
+ *  Writing it into the per-id leaf dir is what bounds its visibility to the one
+ *  container that dir is bind-mounted into. */
+function ensureWorkspaceToken(id: string): void {
+  if (!userDataDir) return;
+  if (idToToken.has(id)) return;
+  const dir = mcpWorkspaceSocketDir(userDataDir, id);
+  const tokenPath = mcpWorkspaceTokenPath(userDataDir, id);
+  let token: string | null = null;
+  try {
+    mkdirSync(dir, { recursive: true });
+    if (existsSync(tokenPath)) {
+      const existing = readFileSync(tokenPath, 'utf8').trim();
+      if (existing) token = existing;
+    }
+    if (!token) {
+      token = randomBytes(32).toString('hex');
+      writeFileSync(tokenPath, token, { encoding: 'utf8', mode: 0o600 });
+    }
+  } catch (err) {
+    console.warn(`[mcp] token setup failed (${id}):`, err);
+    return;
+  }
+  tokenToId.set(token, id);
+  idToToken.set(id, token);
+}
+
 /** Tear down a workspace's listener + remove its socket dir. Best-effort
  *  cleanup on workspace removal; surviving listeners are harmless and get
  *  rebuilt from the manifest list on next launch. */
@@ -128,6 +204,12 @@ export function removeWorkspaceSocket(id: string): void {
       /* ignore */
     }
     listeners.delete(id);
+  }
+  // Windows: revoke the token so the shared listener stops honoring it.
+  const token = idToToken.get(id);
+  if (token) {
+    tokenToId.delete(token);
+    idToToken.delete(id);
   }
   if (userDataDir) {
     try {
@@ -147,6 +229,16 @@ export function stopMcpServer(): void {
     }
   }
   listeners.clear();
+  if (tcpListener) {
+    try {
+      tcpListener.close();
+    } catch {
+      /* ignore */
+    }
+    tcpListener = null;
+  }
+  tokenToId.clear();
+  idToToken.clear();
   try {
     rodb?.close();
   } catch {
@@ -169,6 +261,39 @@ function handleConnection(sock: Socket, callerId: string): void {
     }
   });
   sock.on('error', () => sock.destroy());
+}
+
+/** Windows TCP connection handler. The first non-empty line authenticates the
+ *  connection: it must be a registered per-workspace token, which resolves the
+ *  caller id. The source address is always 127.0.0.1 (NAT'd through the host
+ *  loopback) so it proves nothing — the token is the sole identity. Subsequent
+ *  lines are the normal newline-delimited JSON-RPC stream. An unknown token
+ *  drops the connection before any tool can run. */
+function handleTcpConnection(sock: Socket): void {
+  let buf = '';
+  let callerId: string | null = null;
+  sock.setEncoding('utf8');
+  sock.on('error', () => sock.destroy());
+  sock.on('data', (chunk: string) => {
+    buf += chunk;
+    let nl: number;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (callerId === null) {
+        if (!line) continue; // tolerate leading blank lines before the token
+        const id = tokenToId.get(line);
+        if (!id) {
+          console.warn('[mcp] tcp connection presented an unknown token; closing');
+          sock.destroy();
+          return;
+        }
+        callerId = id;
+        continue;
+      }
+      if (line) dispatchLine(line, sock, callerId);
+    }
+  });
 }
 
 function dispatchLine(line: string, sock: Socket, callerId: string): void {

--- a/src/main/mcpSocket.ts
+++ b/src/main/mcpSocket.ts
@@ -38,6 +38,19 @@ export function mcpWorkspaceSocketPath(userDataDir: string, id: string): string 
   return join(mcpWorkspaceSocketDir(userDataDir, id), 'mcp.sock');
 }
 
+/** `<userData>/mcp/<id>/token` — the per-workspace MCP auth token (Windows
+ *  only). A Windows host can't `listen()` on a unix socket, so the MCP server
+ *  there runs one loopback-TCP listener for all workspaces; caller identity can
+ *  no longer come from *which* per-workspace socket accepted (#117). Instead
+ *  each workspace gets a random token, written here and bind-mounted leaf-only
+ *  into that one container (so a container only ever sees its own). The
+ *  in-container bridge sends it as the first line; the host maps token→id. This
+ *  file lives in the SAME per-id leaf dir the socket used, so the existing
+ *  bind-mount isolation carries the secrecy. */
+export function mcpWorkspaceTokenPath(userDataDir: string, id: string): string {
+  return join(mcpWorkspaceSocketDir(userDataDir, id), 'token');
+}
+
 /** The Docker bind string for a workspace's MCP socket dir: the per-id **leaf**
  *  dir → `/fleet/mcp` (`:rw` because connecting to a Unix socket needs write
  *  access; the read-only guarantee is the DB connection, not the mount). This
@@ -55,3 +68,15 @@ export const CONTAINER_MCP_DIR = '/fleet/mcp';
  *  across workspaces — only the *host* side of the bind differs per workspace,
  *  so the in-container socat bridge command never changes. */
 export const CONTAINER_MCP_SOCKET = '/fleet/mcp/mcp.sock';
+
+/** In-container path of the per-workspace MCP token (Windows transport). Lives
+ *  in the same bound `/fleet/mcp` dir as the socket would; the bridge reads it
+ *  and sends it as the first line to authenticate over loopback TCP. */
+export const CONTAINER_MCP_TOKEN = '/fleet/mcp/token';
+
+/** Fixed loopback-TCP port the Windows MCP server listens on (127.0.0.1) and
+ *  the in-container bridge dials via host.docker.internal. Fixed (not
+ *  ephemeral) because the bridge command is baked into ~/.claude.json at
+ *  create-time and a paused container must keep reconnecting to the same port
+ *  across host/app restarts. Override with CLAUDE_FLEET_MCP_TCP_PORT. */
+export const MCP_TCP_PORT = Number(process.env.CLAUDE_FLEET_MCP_TCP_PORT) || 7071;


### PR DESCRIPTION
The host MCP server can't listen() on a unix socket at a Windows path
(EACCES), so the per-workspace unix-socket transport (#117) can't work on
Windows. On win32 the server now runs one loopback-TCP listener on
127.0.0.1:7071 and authenticates each connection by a per-workspace token,
preserving the #117 caller-identity invariant. Linux/macOS keep the
per-workspace unix sockets unchanged.

- mcpSocket.ts: per-workspace token path + CONTAINER_MCP_TOKEN + MCP_TCP_PORT
- mcpServer.ts: single 127.0.0.1 TCP listener; per-workspace token registry
  persisted to the per-id leaf dir; the first line of each connection is the
  token and resolves callerId; unknown tokens are dropped
- docker.ts: Windows MCP bridge reads /fleet/mcp/token, sends it as the first
  line, then socat to host.docker.internal:7071, re-handshaking per reconnect
- docs/design: mark Phase 1 + Phase 2 implemented

The token is written to the same per-id leaf dir the socket used and
bind-mounted into only that container, so a container sees only its own token
and can neither read a sibling's nor guess a 256-bit secret. Bound to
127.0.0.1 only (reachable from containers via host.docker.internal, which
Docker Desktop NATs through the host loopback; not LAN-exposed).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
