### PR TITLE
feat: drag-and-drop file ingestion, revived on native Windows (#87)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -757,29 +757,28 @@ The goal: **expert workspaces** that load a domain context once (an organization
 ### Drag-and-drop file ingestion
 Drop OS files, pasted images, web content, or text fragments onto the window; the app saves them into the selected container's workspace so the agent can read them.
 
-**Status: BUILT then SHELVED — blocked (PR #87, closed unmerged 2026-06-17).** The full feature was implemented (`src/main/files.ts` + `dropNaming.ts`: all four sources, 100 MB/file + 1 GB/dropbox caps with reject-on-overflow, magic-byte MIME sniffing, collision suffixing, a URL fetch with a 20s abort + streaming size guard, a `*` `.gitignore` in the dropbox; a `useDropIngestion` renderer hook + full-window overlay + toasts; unit + e2e). It was **not merged** because drag-and-drop can't function on the current **WSLg dev** setup: OS drag events aren't forwarded Windows→Linux into the Electron window and clipboard image bytes don't reliably cross (a real OS drag event also can't be synthesized in Electron for e2e). The right-rail **Private / Shared folder-reveal** links cover getting files into a workspace meanwhile. **Unblock when claude-fleet ships as a native binary install.** Code preserved on branch `feat/drag-drop-ingestion`; it predates the fleet-root model, so the dropbox path below moves from `<workspaceRoot>/_dropped/` to the per-workspace private folder `<fleetRoot>/<id>/_dropped/`. The design below is the target for that revival.
+**Status: SHIPPED (#87, revived on native Windows).** Originally built then shelved (PR #87, closed unmerged 2026-06-17) because drag-and-drop can't be exercised on the **WSLg dev** setup — OS drag events aren't forwarded Windows→Linux into the Electron window and clipboard image bytes don't reliably cross (a real OS drag event also can't be synthesized in Electron for e2e). It is now revived against a **native Windows build**, where the OS integrations work. Implementation: `src/main/files.ts` + `dropNaming.ts` (all four sources, 100 MB/file + 1 GB/dropbox caps with reject-on-overflow, magic-byte MIME sniffing, collision suffixing, a URL fetch with a 20s abort + streaming size guard, a `*` `.gitignore` in the dropbox); a `useDropIngestion` renderer hook + full-window overlay; results surface through the existing bottom-center toast stack (`pushToast`, with `ok`/`error` variants added alongside the loadout-reload `progress` toast). Unit (`dropNaming.test.ts`) + e2e (`drag-drop.spec.ts`, which drives the `files:*` IPC directly since a real OS drag can't be synthesized). **WSLg caveat retained:** under WSLg dev the overlay still won't receive OS drops; the right-rail Private/Shared folder-reveal links remain the fallback there.
 
 **Decisions made:**
-- **Drop target**: anywhere on the window. The file is routed to whichever container is currently selected in the sidebar. If no container is selected, the drop is rejected with a hint ("select a container first").
-- **Save location**: `<workspaceRoot>/_dropped/` for the selected container. Filename collisions resolved by suffix (`foo.png`, `foo-2.png`, `foo-3.png`). Inside the container the agent reads from `/workspace/_dropped/<name>`.
-- **Post-save behavior**: toast confirmation showing the saved path, plus the path is copied to the system clipboard (via `clipboard.writeText`). User pastes it into their prompt manually — no auto-typing into the PTY.
+- **Drop target**: anywhere on the window. The file is routed to whichever workspace is currently selected. If none is selected, the drop is rejected with a hint ("Select a workspace first, then drop.").
+- **Save location**: `<fleetRoot>/<id>/_dropped/` — the selected workspace's private folder (via `config.ts:fleetPrivateDir`, the same dir mounted at `/workspace`). Filename collisions resolved by suffix (`foo.png`, `foo-2.png`, `foo-3.png`). Inside the container the agent reads from `/workspace/_dropped/<name>`.
+- **Post-save behavior**: toast confirmation showing the saved container path, plus the path is copied to the system clipboard (via `clipboard.writeText`). User pastes it into their prompt manually — no auto-typing into the PTY.
 - **Sources accepted**:
   - **OS file drag** — drop from Explorer/Finder/Nautilus. Renderer reads the path via `webUtils.getPathForFile(file)`; main copies from source to destination.
   - **Clipboard paste** (Cmd/Ctrl+V) anywhere on the window — image bytes from the clipboard saved as `paste-<ISO-timestamp>.<ext>` (extension derived from clipboard format).
   - **Web drag** — content dragged out of a browser. If a URL, the main process fetches it and writes the body; if inline bytes, written directly. Filename derived from the source URL or Content-Disposition; falls back to `web-<ISO-timestamp>.<ext>`.
   - **Text / HTML drag** — selected text dragged in. Written as `dropped-<ISO-timestamp>.txt` (plain text) or `.html` (when the drag carries HTML).
 
-**IPC surface (sketch):**
-- `files:dropOsFiles(containerId, sourcePaths: string[])` → `string[]` (saved paths)
-- `files:dropBytes(containerId, payload: { suggestedName, mime, bytes })` → `string`
-- `files:dropUrl(containerId, url: string)` → `string`
-- `files:dropText(containerId, payload: { mime: 'text/plain' | 'text/html', text: string })` → `string`
+**IPC surface (as built).** Each takes the selected `workspaceId` and returns the container-visible saved path(s):
+- `files:dropOsFiles(workspaceId, sourcePaths: string[])` → `string[]` (saved paths) — caps validated across the whole batch before any copy, so a partial over-limit drop writes nothing.
+- `files:dropBytes(workspaceId, payload: { suggestedName?, mime?, bytes })` → `string`
+- `files:dropUrl(workspaceId, url: string)` → `string`
+- `files:dropText(workspaceId, payload: { mime: 'text/plain' | 'text/html', text: string })` → `string`
+- `clipboard:readImage()` → `{ bytes, mime } | null` — supports Ctrl+V image ingestion. The renderer can't read clipboard image bytes under contextIsolation, and xterm swallows the native `paste` event while the terminal is focused, so `TerminalSession`'s Ctrl+V handler calls this and, when an image is present, dispatches a `cf:drop-image` window event that `useDropIngestion` routes to `files:dropBytes`.
+
+**Resolved (were open):** per-file (100 MB) + per-dropbox (1 GB) caps with reject-on-overflow (no eviction); magic-byte MIME sniffing with clipboard/MIME-type fallback (unknown ⇒ saved extensionless); URL fetch with a 20s abort + streaming size guard; the dropbox carries its own `*` `.gitignore` so drops are never committed regardless of the consumer repo's rules.
 
 **Open:**
-- **Max file size / total dropbox size.** A single drop could fill the host disk. Cap per file (e.g., 100 MB) and per container dropbox (e.g., 1 GB) with eviction or rejection on overflow.
-- **MIME / format detection.** For clipboard and web sources where filename isn't given, sniff bytes (magic numbers) before falling back to the clipboard-format extension. Decide whether unknown formats are saved with no extension or rejected.
-- **Web-drag CORS / large downloads.** Need a timeout, a progress indicator if the fetch takes more than a beat, and a sensible error if the URL is unreachable from the main process.
-- **`.gitignore` interaction.** `_dropped/` should be added to the runner image's default `.gitignore` (or the spec should require users to add it). Otherwise drops get committed by accident.
 - **Whether to expose drops in the sessions table.** A row showing "5 files dropped" alongside the session might be useful. Out of scope for v1 but worth recording.
 
 ### Durable transcript mirror

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",

--- a/src/main/dropNaming.test.ts
+++ b/src/main/dropNaming.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  candidateName,
+  extFromMime,
+  fileStamp,
+  filenameFromDisposition,
+  sniffExtension,
+  splitName
+} from './dropNaming.js';
+
+describe('sniffExtension', () => {
+  const bytes = (...b: number[]): Uint8Array => new Uint8Array(b);
+  it('recognizes PNG / JPEG / GIF / PDF magic numbers', () => {
+    expect(sniffExtension(bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a))).toBe('.png');
+    expect(sniffExtension(bytes(0xff, 0xd8, 0xff, 0xe0))).toBe('.jpg');
+    expect(sniffExtension(bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61))).toBe('.gif');
+    expect(sniffExtension(bytes(0x25, 0x50, 0x44, 0x46, 0x2d))).toBe('.pdf');
+  });
+  it('recognizes WEBP (RIFF…WEBP)', () => {
+    const b = bytes(0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50);
+    expect(sniffExtension(b)).toBe('.webp');
+  });
+  it('returns null for unrecognized / too-short input', () => {
+    expect(sniffExtension(bytes(0x00, 0x01, 0x02))).toBeNull();
+    expect(sniffExtension(bytes())).toBeNull();
+  });
+});
+
+describe('extFromMime', () => {
+  it('maps known types and tolerates parameters/casing', () => {
+    expect(extFromMime('image/png')).toBe('.png');
+    expect(extFromMime('image/jpeg')).toBe('.jpg');
+    expect(extFromMime('TEXT/HTML; charset=utf-8')).toBe('.html');
+  });
+  it('returns null for unknown or missing types', () => {
+    expect(extFromMime('application/octet-stream')).toBeNull();
+    expect(extFromMime(undefined)).toBeNull();
+  });
+});
+
+describe('splitName / candidateName', () => {
+  it('splits stem and extension', () => {
+    expect(splitName('foo.png')).toEqual({ stem: 'foo', ext: '.png' });
+    expect(splitName('archive.tar.gz')).toEqual({ stem: 'archive.tar', ext: '.gz' });
+    expect(splitName('noext')).toEqual({ stem: 'noext', ext: '' });
+  });
+  it('suffixes collisions: n=1 bare, n>=2 -N', () => {
+    expect(candidateName('foo', '.png', 1)).toBe('foo.png');
+    expect(candidateName('foo', '.png', 2)).toBe('foo-2.png');
+    expect(candidateName('foo', '', 3)).toBe('foo-3');
+  });
+});
+
+describe('fileStamp', () => {
+  it('produces a filesystem-safe stamp (no colons or dots)', () => {
+    const s = fileStamp(new Date('2026-06-16T18:50:00.123Z'));
+    expect(s).toBe('2026-06-16T18-50-00-123Z');
+    expect(s).not.toMatch(/[:.]/);
+  });
+});
+
+describe('filenameFromDisposition', () => {
+  it('parses plain and extended (filename*) forms, stripping paths', () => {
+    expect(filenameFromDisposition('attachment; filename="report.pdf"')).toBe('report.pdf');
+    expect(filenameFromDisposition("attachment; filename*=UTF-8''na%C3%AFve%20file.png")).toBe(
+      'naïve file.png'
+    );
+    expect(filenameFromDisposition('inline; filename=/etc/passwd')).toBe('passwd');
+  });
+  it('returns null when absent', () => {
+    expect(filenameFromDisposition(null)).toBeNull();
+    expect(filenameFromDisposition('inline')).toBeNull();
+  });
+});

--- a/src/main/dropNaming.ts
+++ b/src/main/dropNaming.ts
@@ -1,0 +1,73 @@
+// Pure naming/sniffing helpers for drag-and-drop ingestion (files.ts).
+// Kept electron-free so they're unit-testable under vitest — files.ts pulls
+// in config.ts → electron, which can't load in the test runner.
+
+import { basename, extname } from 'node:path';
+
+/**
+ * Magic-number sniff for the formats a drop realistically carries when the
+ * source gave us no filename (clipboard images, web bytes). Returns the
+ * dotted extension or null when unrecognized (caller saves extensionless).
+ */
+export function sniffExtension(bytes: Uint8Array): string | null {
+  const b = bytes;
+  if (b.length >= 8 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) return '.png';
+  if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return '.jpg';
+  if (b.length >= 6 && b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) return '.gif';
+  if (
+    b.length >= 12 &&
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 && // "RIFF"
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50 // "WEBP"
+  )
+    return '.webp';
+  if (b.length >= 4 && b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46) return '.pdf'; // "%PDF"
+  return null;
+}
+
+/** Fallback extension from a MIME type when bytes don't sniff. */
+export function extFromMime(mime?: string): string | null {
+  if (!mime) return null;
+  const map: Record<string, string> = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'image/svg+xml': '.svg',
+    'application/pdf': '.pdf',
+    'text/plain': '.txt',
+    'text/html': '.html'
+  };
+  return map[mime.split(';')[0].trim().toLowerCase()] ?? null;
+}
+
+/** `foo.png` → {stem:'foo', ext:'.png'}; `foo` → {stem:'foo', ext:''}. */
+export function splitName(name: string): { stem: string; ext: string } {
+  const ext = extname(name);
+  return { stem: ext ? name.slice(0, -ext.length) : name, ext };
+}
+
+/** Collision suffixing: n=1 → `foo.png`, n=2 → `foo-2.png`, … */
+export function candidateName(stem: string, ext: string, n: number): string {
+  return n <= 1 ? `${stem}${ext}` : `${stem}-${n}${ext}`;
+}
+
+/** Filesystem-safe ISO-ish timestamp for generated names (no colons/dots). */
+export function fileStamp(d: Date): string {
+  return d.toISOString().replace(/[:.]/g, '-');
+}
+
+/** Parse `filename="…"` / `filename*=UTF-8''…` from Content-Disposition. */
+export function filenameFromDisposition(header: string | null): string | null {
+  if (!header) return null;
+  const star = /filename\*\s*=\s*(?:UTF-8'')?["']?([^"';]+)["']?/i.exec(header);
+  if (star) {
+    try {
+      return basename(decodeURIComponent(star[1]));
+    } catch {
+      return basename(star[1]);
+    }
+  }
+  const plain = /filename\s*=\s*["']?([^"';]+)["']?/i.exec(header);
+  return plain ? basename(plain[1]) : null;
+}

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -1,0 +1,261 @@
+// Drag-and-drop file ingestion.
+//
+// Drops (OS files, pasted images, dragged web content, dragged text) are
+// saved into the selected workspace's private folder under `_dropped/`, so
+// the in-container agent can read them at `/workspace/_dropped/<name>`. The
+// renderer routes every drop to the currently-selected workspace and shows
+// the returned container path in a toast (and on the clipboard) for the user
+// to paste into their prompt.
+//
+// Host layout: `<fleetRoot>/<id>/_dropped/`. The dir gets a `.gitignore`
+// containing `*` so drops never get committed regardless of the repo's root
+// ignore rules. These functions touch only the host filesystem (+ a network
+// fetch for URL drops) — no Docker — so they run identically in mock mode.
+//
+// Caps: a single file is capped at MAX_FILE_BYTES and the whole dropbox at
+// MAX_DROPBOX_BYTES. Overflow is REJECTED with a clear message (no eviction)
+// so a drop never silently destroys earlier drops the agent may still need.
+
+import { access, copyFile, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+import { fleetPrivateDir } from './config.js';
+import {
+  candidateName,
+  extFromMime,
+  fileStamp,
+  filenameFromDisposition,
+  sniffExtension,
+  splitName
+} from './dropNaming.js';
+
+// Re-export the pure helpers so existing importers (and tests via dropNaming)
+// have one surface; the implementations live in the electron-free module.
+export { sniffExtension, extFromMime, splitName, candidateName, fileStamp, filenameFromDisposition };
+
+export const MAX_FILE_BYTES = 100 * 1024 * 1024; // 100 MB per file
+export const MAX_DROPBOX_BYTES = 1024 * 1024 * 1024; // 1 GB per workspace dropbox
+
+const DROPBOX_DIRNAME = '_dropped';
+const CONTAINER_DROPBOX = '/workspace/_dropped';
+// Hard ceiling on a URL fetch before we give up (separate from a stalled
+// connection — that's handled by the no-progress idle timeout in fetchUrl).
+const URL_FETCH_TIMEOUT_MS = 20_000;
+
+export interface DropBytesPayload {
+  suggestedName?: string;
+  mime?: string;
+  bytes: Uint8Array;
+}
+export interface DropTextPayload {
+  mime: 'text/plain' | 'text/html';
+  text: string;
+}
+
+function containerPath(name: string): string {
+  return `${CONTAINER_DROPBOX}/${name}`;
+}
+
+// ── Filesystem-backed helpers ───────────────────────────────────────────
+
+async function ensureDropbox(workspaceId: string): Promise<string> {
+  const dir = join(await fleetPrivateDir(workspaceId), DROPBOX_DIRNAME);
+  await mkdir(dir, { recursive: true });
+  // Keep the dropbox out of git regardless of the consumer repo's rules.
+  const gitignore = join(dir, '.gitignore');
+  try {
+    await access(gitignore);
+  } catch {
+    await writeFile(gitignore, '*\n', 'utf8');
+  }
+  return dir;
+}
+
+/** Total bytes of dropped files (excludes the .gitignore + any subdirs). */
+async function dropboxUsage(dir: string): Promise<number> {
+  let total = 0;
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    if (!e.isFile() || e.name === '.gitignore') continue;
+    total += (await stat(join(dir, e.name))).size;
+  }
+  return total;
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** First non-colliding name in `dir` derived from `desired`. */
+async function uniqueName(dir: string, desired: string): Promise<string> {
+  const { stem, ext } = splitName(desired);
+  for (let n = 1; ; n++) {
+    const candidate = candidateName(stem, ext, n);
+    if (!(await exists(join(dir, candidate)))) return candidate;
+  }
+}
+
+function tooLargeError(label: string): Error {
+  return new Error(`${label} is larger than the ${fmtMb(MAX_FILE_BYTES)} per-file limit.`);
+}
+function dropboxFullError(): Error {
+  return new Error(`Dropbox is full (${fmtMb(MAX_DROPBOX_BYTES)} max). Remove some files in _dropped/ and retry.`);
+}
+function fmtMb(bytes: number): string {
+  return bytes >= 1024 * 1024 * 1024 ? `${bytes / 1024 / 1024 / 1024} GB` : `${Math.round(bytes / 1024 / 1024)} MB`;
+}
+
+/** Save raw bytes under `desiredName` (collision-suffixed), enforcing caps. */
+async function saveBytes(
+  workspaceId: string,
+  desiredName: string,
+  bytes: Uint8Array
+): Promise<string> {
+  if (bytes.length > MAX_FILE_BYTES) throw tooLargeError(desiredName);
+  const dir = await ensureDropbox(workspaceId);
+  if ((await dropboxUsage(dir)) + bytes.length > MAX_DROPBOX_BYTES) throw dropboxFullError();
+  const name = await uniqueName(dir, desiredName);
+  await writeFile(join(dir, name), bytes);
+  return containerPath(name);
+}
+
+// ── Drop entry points (one per source) ──────────────────────────────────
+
+/** OS file drag (Explorer/Finder/Nautilus). Caps validated across the whole
+ *  drop before any copy, so a partial over-limit batch writes nothing. */
+export async function dropOsFiles(workspaceId: string, sourcePaths: string[]): Promise<string[]> {
+  if (sourcePaths.length === 0) return [];
+  const dir = await ensureDropbox(workspaceId);
+  const stats = await Promise.all(sourcePaths.map((p) => stat(p)));
+  let incoming = 0;
+  for (let i = 0; i < stats.length; i++) {
+    if (!stats[i].isFile()) throw new Error(`${basename(sourcePaths[i])} is not a file.`);
+    if (stats[i].size > MAX_FILE_BYTES) throw tooLargeError(basename(sourcePaths[i]));
+    incoming += stats[i].size;
+  }
+  if ((await dropboxUsage(dir)) + incoming > MAX_DROPBOX_BYTES) throw dropboxFullError();
+
+  const saved: string[] = [];
+  for (const src of sourcePaths) {
+    const name = await uniqueName(dir, basename(src));
+    await copyFile(src, join(dir, name));
+    saved.push(containerPath(name));
+  }
+  return saved;
+}
+
+/** Clipboard image paste / inline web bytes. */
+export async function dropBytes(workspaceId: string, payload: DropBytesPayload): Promise<string> {
+  const bytes = payload.bytes instanceof Uint8Array ? payload.bytes : new Uint8Array(payload.bytes);
+  let name = payload.suggestedName?.trim();
+  if (!name || !extname(name)) {
+    const ext = sniffExtension(bytes) ?? extFromMime(payload.mime) ?? '';
+    name = name ? `${name}${ext}` : `paste-${fileStamp(new Date())}${ext}`;
+  }
+  return saveBytes(workspaceId, name, bytes);
+}
+
+/** Dragged-in selected text / HTML. */
+export async function dropText(workspaceId: string, payload: DropTextPayload): Promise<string> {
+  const ext = payload.mime === 'text/html' ? '.html' : '.txt';
+  return saveBytes(workspaceId, `dropped-${fileStamp(new Date())}${ext}`, Buffer.from(payload.text, 'utf8'));
+}
+
+/** Web-content drag: fetch the URL in main and save the body. */
+export async function dropUrl(workspaceId: string, url: string): Promise<string> {
+  const { bytes, filename, contentType } = await fetchUrl(url);
+  let name = filename?.trim();
+  if (!name || !extname(name)) {
+    const ext = sniffExtension(bytes) ?? extFromMime(contentType ?? undefined) ?? '';
+    name = name ? `${name}${ext}` : `web-${fileStamp(new Date())}${ext}`;
+  }
+  return saveBytes(workspaceId, name, bytes);
+}
+
+async function fetchUrl(
+  url: string
+): Promise<{ bytes: Uint8Array; filename: string | null; contentType: string | null }> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Not a valid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), URL_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect: 'follow' });
+    if (!res.ok) throw new Error(`Couldn't fetch ${url} (HTTP ${res.status}).`);
+
+    const contentType = res.headers.get('content-type');
+    // Reject early when the server declares an over-limit size.
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_FILE_BYTES) throw tooLargeError(url);
+
+    // Stream so we can abort a body that exceeds the cap even when the server
+    // didn't declare content-length.
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    if (res.body) {
+      const reader = res.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          total += value.length;
+          if (total > MAX_FILE_BYTES) {
+            await reader.cancel();
+            throw tooLargeError(url);
+          }
+          chunks.push(value);
+        }
+      }
+    } else {
+      const buf = new Uint8Array(await res.arrayBuffer());
+      total = buf.length;
+      if (total > MAX_FILE_BYTES) throw tooLargeError(url);
+      chunks.push(buf);
+    }
+
+    const bytes = concat(chunks, total);
+    return {
+      bytes,
+      filename: filenameFromDisposition(res.headers.get('content-disposition')) ?? urlBasename(parsed),
+      contentType
+    };
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') {
+      throw new Error(`Fetching ${url} timed out after ${URL_FETCH_TIMEOUT_MS / 1000}s.`);
+    }
+    if (err instanceof TypeError) {
+      // fetch throws TypeError for network/DNS/CORS-ish failures.
+      throw new Error(`Couldn't reach ${url}: ${err.message}`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function concat(chunks: Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+function urlBasename(parsed: URL): string | null {
+  const base = basename(parsed.pathname);
+  return base && base !== '/' ? decodeURIComponent(base) : null;
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -41,6 +41,7 @@ import {
 import * as vault from './vault.js';
 import * as fs from './fs.js';
 import * as imageLibrary from './imageLibrary.js';
+import * as files from './files.js';
 import * as loadouts from './loadouts.js';
 import { loadoutDir } from './paths.js';
 import * as sessions from './sessions.js';
@@ -895,6 +896,33 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     if (typeof text === 'string' && text.length > 0) clipboard.writeText(text);
   });
   ipcMain.handle('clipboard:read', () => clipboard.readText());
+  // Image on the clipboard, as PNG bytes — drives Ctrl+V image ingestion
+  // (the renderer can't read clipboard image bytes directly under
+  // contextIsolation). Null when the clipboard holds no image.
+  ipcMain.handle('clipboard:readImage', () => {
+    const img = clipboard.readImage();
+    if (img.isEmpty()) return null;
+    return { bytes: new Uint8Array(img.toPNG()), mime: 'image/png' };
+  });
+
+  // Drag-and-drop ingestion. Routed to the selected workspace by the
+  // renderer; each saves into `<fleetRoot>/<id>/_dropped/` and returns the
+  // container-visible path (`/workspace/_dropped/<name>`). Not backend-gated
+  // — these touch only the host filesystem (+ a fetch for URL drops), so the
+  // real module works in mock mode too. Errors (over-limit, unreachable URL)
+  // propagate to the renderer, which toasts them.
+  ipcMain.handle('files:dropOsFiles', (_e, workspaceId: string, sourcePaths: string[]) =>
+    files.dropOsFiles(workspaceId, sourcePaths)
+  );
+  ipcMain.handle('files:dropBytes', (_e, workspaceId: string, payload: files.DropBytesPayload) =>
+    files.dropBytes(workspaceId, payload)
+  );
+  ipcMain.handle('files:dropUrl', (_e, workspaceId: string, url: string) =>
+    files.dropUrl(workspaceId, url)
+  );
+  ipcMain.handle('files:dropText', (_e, workspaceId: string, payload: files.DropTextPayload) =>
+    files.dropText(workspaceId, payload)
+  );
 
   ipcMain.handle(
     'menu:showTerminalContextMenu',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
+import { contextBridge, ipcRenderer, IpcRendererEvent, webUtils } from 'electron';
 
 // Mirrored from src/main/sessions.ts. Kept here as a type-only declaration so
 // the preload doesn't reach into main-process code (and so the renderer can
@@ -263,6 +263,37 @@ const api = {
     /** Reveal a host path in the OS file manager. Resolves '' on success, else an error string. */
     openPath: (path: string): Promise<string> => ipcRenderer.invoke('fs:openPath', path)
   },
+  files: {
+    /**
+     * Resolve the host path of a dragged OS File. `webUtils.getPathForFile`
+     * replaces the removed `File.path` property and must be called in the
+     * preload (the renderer has no access to webUtils). Returns '' for
+     * non-OS-file drops (synthetic File objects from web/text drags).
+     */
+    getPathForFile: (file: File): string => {
+      try {
+        return webUtils.getPathForFile(file);
+      } catch {
+        return '';
+      }
+    },
+    /** OS file drag → saved container paths (`/workspace/_dropped/<name>`). */
+    dropOsFiles: (workspaceId: string, sourcePaths: string[]): Promise<string[]> =>
+      ipcRenderer.invoke('files:dropOsFiles', workspaceId, sourcePaths),
+    /** Clipboard image / inline bytes → saved container path. */
+    dropBytes: (
+      workspaceId: string,
+      payload: { suggestedName?: string; mime?: string; bytes: Uint8Array }
+    ): Promise<string> => ipcRenderer.invoke('files:dropBytes', workspaceId, payload),
+    /** Dragged web URL (fetched in main) → saved container path. */
+    dropUrl: (workspaceId: string, url: string): Promise<string> =>
+      ipcRenderer.invoke('files:dropUrl', workspaceId, url),
+    /** Dragged text/HTML → saved container path. */
+    dropText: (
+      workspaceId: string,
+      payload: { mime: 'text/plain' | 'text/html'; text: string }
+    ): Promise<string> => ipcRenderer.invoke('files:dropText', workspaceId, payload)
+  },
   loadouts: {
     /** Loadout library (#16-followup): browse, inspect, install/uninstall. */
     list: (): Promise<unknown[]> => ipcRenderer.invoke('loadouts:list'),
@@ -309,7 +340,10 @@ const api = {
   },
   clipboard: {
     write: (text: string): Promise<void> => ipcRenderer.invoke('clipboard:write', text),
-    read: (): Promise<string> => ipcRenderer.invoke('clipboard:read')
+    read: (): Promise<string> => ipcRenderer.invoke('clipboard:read'),
+    /** Image on the clipboard as PNG bytes, or null. For Ctrl+V image drops. */
+    readImage: (): Promise<{ bytes: Uint8Array; mime: string } | null> =>
+      ipcRenderer.invoke('clipboard:readImage')
   },
   menu: {
     showTerminalContextMenu: (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { CloseWorkspaceModal } from './components/CloseWorkspaceModal';
 import { DeleteWorkspaceModal } from './components/DeleteWorkspaceModal';
 import { EditWorkspaceModal, containerLevelChanged } from './components/EditWorkspaceModal';
 import { SettingsModal } from './components/SettingsModal';
+import { useDropIngestion } from './dropIngestion';
 import type { WorkspaceObservabilitySummary, SessionListItem, UsageBudget } from '../../preload';
 
 export type WorkspaceState = 'running' | 'paused' | 'stopped' | 'deleted';
@@ -287,15 +288,32 @@ export function App() {
   } | null>(null);
   const reloadRequestTokenRef = useRef(0);
 
-  // Transient toasts (bottom-center, auto-dismissing). Used so far for the
-  // loadout reload, whose close+resume briefly flickers the terminal (#16).
-  const [toasts, setToasts] = useState<{ id: number; eyebrow?: string; message: string }[]>([]);
+  // Transient toasts (bottom-center, auto-dismissing). Used for the loadout
+  // reload (#16) and drag-and-drop results (#87). `kind` styles the toast:
+  // 'progress' shows the spinner (the default), 'ok'/'error' show a static
+  // status glyph and (for error) danger coloring.
+  type ToastKind = 'progress' | 'ok' | 'error';
+  const [toasts, setToasts] = useState<
+    { id: number; eyebrow?: string; message: string; kind: ToastKind }[]
+  >([]);
   const toastIdRef = useRef(0);
-  const pushToast = useCallback((message: string, eyebrow?: string, ttlMs = 4000): void => {
-    const id = ++toastIdRef.current;
-    setToasts((prev) => [...prev, { id, eyebrow, message }]);
-    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), ttlMs);
-  }, []);
+  const pushToast = useCallback(
+    (message: string, eyebrow?: string, ttlMs = 4000, kind: ToastKind = 'progress'): void => {
+      const id = ++toastIdRef.current;
+      setToasts((prev) => [...prev, { id, eyebrow, message, kind }]);
+      setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), ttlMs);
+    },
+    []
+  );
+  // Drag-and-drop / clipboard-image ingestion → selected workspace's _dropped/.
+  // Results surface through the existing toast stack; errors linger longer.
+  const notify = useCallback(
+    (kind: 'ok' | 'error', message: string): void => {
+      pushToast(message, kind === 'error' ? 'Drop failed' : 'Saved', kind === 'error' ? 6000 : 4000, kind);
+    },
+    [pushToast]
+  );
+  const { dragging } = useDropIngestion({ workspaceId: selectedId, notify });
   const handleReloadStarted = useCallback(
     (workspaceId: string): void => {
       const name = workspacesRef.current.find((w) => w.id === workspaceId)?.name ?? 'workspace';
@@ -803,7 +821,7 @@ export function App() {
   };
 
   return (
-    <div className="app">
+    <div className={`app${dragging ? ' dragging' : ''}`}>
       <WorkspaceTabStrip
         workspaces={workspaces}
         summaries={summaries}
@@ -991,11 +1009,27 @@ export function App() {
           />
         );
       })()}
+      {dragging && (
+        <div className="drop-overlay" aria-hidden="true">
+          <div className="drop-overlay-card">
+            <div className="drop-overlay-title">Drop to add to this workspace</div>
+            <div className="drop-overlay-sub">
+              {selected ? `→ ${selected.name} · /workspace/_dropped/` : 'Select a workspace first'}
+            </div>
+          </div>
+        </div>
+      )}
       {toasts.length > 0 && (
         <div className="toast-stack" role="status" aria-live="polite">
           {toasts.map((t) => (
-            <div key={t.id} className="toast">
-              <span className="toast-spinner" aria-hidden="true" />
+            <div key={t.id} className={`toast${t.kind !== 'progress' ? ` ${t.kind}` : ''}`}>
+              {t.kind === 'progress' ? (
+                <span className="toast-spinner" aria-hidden="true" />
+              ) : (
+                <span className="toast-glyph" aria-hidden="true">
+                  {t.kind === 'ok' ? '✓' : '✕'}
+                </span>
+              )}
               <span className="toast-body">
                 {t.eyebrow && <span className="toast-eyebrow">{t.eyebrow}</span>}
                 <span className="toast-text">{t.message}</span>

--- a/src/renderer/src/components/TerminalSession.tsx
+++ b/src/renderer/src/components/TerminalSession.tsx
@@ -318,8 +318,19 @@ export function TerminalSession({
     };
 
     const doPaste = (): void => {
-      void window.api.clipboard.read().then((text) => {
-        if (text && ptyHandleId) window.api.pty.input(ptyHandleId, text);
+      // Image on the clipboard → ingest as a drop instead of pasting text.
+      // xterm intercepts Ctrl+V on keydown (preventDefault), so the
+      // window-level `paste` listener never fires while the terminal is
+      // focused — we route through the terminal's own paste path and hand
+      // off via a window CustomEvent that useDropIngestion handles.
+      void window.api.clipboard.readImage().then((img) => {
+        if (img) {
+          window.dispatchEvent(new CustomEvent('cf:drop-image', { detail: img }));
+          return;
+        }
+        return window.api.clipboard.read().then((text) => {
+          if (text && ptyHandleId) window.api.pty.input(ptyHandleId, text);
+        });
       });
     };
 

--- a/src/renderer/src/dropIngestion.ts
+++ b/src/renderer/src/dropIngestion.ts
@@ -1,0 +1,183 @@
+// Window-level drag-and-drop + clipboard-image ingestion.
+//
+// Wires the four drop sources (OS files, web URL, text/HTML, clipboard image)
+// to the main-process `files:*` handlers, routing every drop to the
+// currently-selected workspace. On success the saved container path is copied
+// to the clipboard and surfaced via `notify` so the user can paste it into
+// their prompt; failures (no workspace selected, over-limit, unreachable URL)
+// surface the same way.
+//
+// Precedence on drop: real OS files first; then a dragged http(s) URL
+// (fetched in main); then dragged HTML; then plain text. A browser image
+// drag carries a synthetic File whose `getPathForFile` is empty, so it falls
+// through to the URL branch — which is what we want (main fetches it).
+
+import { useEffect, useState } from 'react';
+
+export type NotifyKind = 'ok' | 'error';
+
+interface Options {
+  workspaceId: string | null;
+  notify: (kind: NotifyKind, message: string) => void;
+}
+
+function looksLikeHttpUrl(s: string): boolean {
+  const t = s.trim().split('\n')[0]?.trim() ?? '';
+  return /^https?:\/\/\S+$/i.test(t);
+}
+
+export function useDropIngestion({ workspaceId, notify }: Options): { dragging: boolean } {
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    // Depth counter so nested dragenter/leave (crossing child elements)
+    // doesn't flicker the overlay off mid-drag.
+    let depth = 0;
+
+    const announce = (paths: string[]): void => {
+      const joined = paths.join('\n');
+      void window.api.clipboard.write(joined);
+      notify(
+        'ok',
+        paths.length === 1
+          ? `Saved ${paths[0]} (path copied)`
+          : `Saved ${paths.length} files to /workspace/_dropped/ (paths copied)`
+      );
+    };
+    const fail = (err: unknown): void => {
+      notify('error', err instanceof Error ? err.message : String(err));
+    };
+    const requireWorkspace = (): string | null => {
+      if (!workspaceId) {
+        notify('error', 'Select a workspace first, then drop.');
+        return null;
+      }
+      return workspaceId;
+    };
+
+    const onDragOver = (e: DragEvent): void => {
+      // preventDefault on dragover is what marks the window as a valid drop
+      // target — without it the OS shows the "not-allowed" cursor. Call it
+      // UNCONDITIONALLY and first: during a drag the dataTransfer is in
+      // "protected mode" and can read as null/empty in some Chromium/Electron
+      // builds, and guarding preventDefault behind it silently rejects the
+      // drop. dropEffect is best-effort on top.
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    };
+    const onDragEnter = (e: DragEvent): void => {
+      e.preventDefault();
+      depth++;
+      setDragging(true);
+    };
+    const onDragLeave = (): void => {
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) setDragging(false);
+    };
+
+    const onDrop = (e: DragEvent): void => {
+      e.preventDefault();
+      depth = 0;
+      setDragging(false);
+      const dt = e.dataTransfer;
+      if (!dt) return;
+      const ws = requireWorkspace();
+      if (!ws) return;
+
+      // 1. OS files (Explorer/Finder/Nautilus) — getPathForFile yields a real
+      //    host path; synthetic files (browser drags) yield ''.
+      const osPaths = Array.from(dt.files)
+        .map((f) => window.api.files.getPathForFile(f))
+        .filter((p) => p.length > 0);
+      if (osPaths.length > 0) {
+        window.api.files.dropOsFiles(ws, osPaths).then(announce).catch(fail);
+        return;
+      }
+
+      // 2. Dragged http(s) URL — main fetches it.
+      const uri = dt.getData('text/uri-list') || dt.getData('text/plain');
+      if (uri && looksLikeHttpUrl(uri)) {
+        const url = uri.trim().split('\n')[0]!.trim();
+        window.api.files
+          .dropUrl(ws, url)
+          .then((p) => announce([p]))
+          .catch(fail);
+        return;
+      }
+
+      // 3. Dragged HTML, else plain text.
+      const html = dt.getData('text/html');
+      const text = dt.getData('text/plain');
+      if (html) {
+        window.api.files
+          .dropText(ws, { mime: 'text/html', text: html })
+          .then((p) => announce([p]))
+          .catch(fail);
+      } else if (text) {
+        window.api.files
+          .dropText(ws, { mime: 'text/plain', text })
+          .then((p) => announce([p]))
+          .catch(fail);
+      }
+      // Nothing recognizable → silently ignore (e.g. an empty drag).
+    };
+
+    const onPaste = (e: ClipboardEvent): void => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      // Only act on an image on the clipboard. Text paste falls through to
+      // xterm's own Ctrl+V handler (which reads clipboard text).
+      const imageItem = Array.from(items).find(
+        (it) => it.kind === 'file' && it.type.startsWith('image/')
+      );
+      if (!imageItem) return;
+      // We're handling this paste — keep it from also reaching the terminal.
+      e.preventDefault();
+      e.stopPropagation();
+      const ws = requireWorkspace();
+      if (!ws) return;
+      const file = imageItem.getAsFile();
+      if (!file) return;
+      file
+        .arrayBuffer()
+        .then((buf) =>
+          window.api.files.dropBytes(ws, { mime: file.type, bytes: new Uint8Array(buf) })
+        )
+        .then((p) => announce([p]))
+        .catch(fail);
+    };
+
+    // Image paste routed from the terminal's Ctrl+V handler (xterm
+    // suppresses the native `paste` event while focused — see TerminalSession).
+    const onDropImage = (e: Event): void => {
+      const detail = (e as CustomEvent).detail as { bytes: Uint8Array; mime: string } | undefined;
+      if (!detail) return;
+      const ws = requireWorkspace();
+      if (!ws) return;
+      window.api.files
+        .dropBytes(ws, { mime: detail.mime, bytes: detail.bytes })
+        .then((p) => announce([p]))
+        .catch(fail);
+    };
+
+    window.addEventListener('dragover', onDragOver);
+    window.addEventListener('dragenter', onDragEnter);
+    window.addEventListener('dragleave', onDragLeave);
+    window.addEventListener('drop', onDrop);
+    // Capture phase so we see the paste before xterm's textarea consumes it
+    // (covers the case where focus is OUTSIDE the terminal; the in-terminal
+    // case comes through 'cf:drop-image' above).
+    window.addEventListener('paste', onPaste, true);
+    window.addEventListener('cf:drop-image', onDropImage);
+    return () => {
+      window.removeEventListener('dragover', onDragOver);
+      window.removeEventListener('dragenter', onDragEnter);
+      window.removeEventListener('dragleave', onDragLeave);
+      window.removeEventListener('drop', onDrop);
+      window.removeEventListener('paste', onPaste, true);
+      window.removeEventListener('cf:drop-image', onDropImage);
+    };
+  }, [workspaceId, notify]);
+
+  return { dragging };
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2494,6 +2494,48 @@ button.obs-ws-row:hover .obs-ws-icon { opacity: 1; color: var(--ink); }
   .toast-spinner { animation: none; }
   .toast { animation: none; }
 }
+/* Drag-and-drop result toasts (#87): static glyph instead of the spinner. */
+.toast-glyph {
+  width: 13px;
+  height: 13px;
+  flex: none;
+  margin-top: 1px;
+  font-size: 12px;
+  line-height: 13px;
+  text-align: center;
+}
+.toast.ok { border-color: color-mix(in oklab, var(--ok) 45%, var(--rule)); }
+.toast.ok .toast-glyph { color: var(--ok); }
+.toast.error { border-color: color-mix(in oklab, var(--danger) 45%, var(--rule)); }
+.toast.error .toast-glyph,
+.toast.error .toast-text { color: var(--danger); }
+
+/* ----- drag-and-drop overlay (#87) ----------------------------------- */
+.drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--info) 12%, rgba(0, 0, 0, 0.45));
+  pointer-events: none;
+}
+.drop-overlay-card {
+  padding: 28px 40px;
+  border: 2px dashed var(--info);
+  border-radius: var(--r-lg);
+  background: var(--bg-card);
+  text-align: center;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+}
+.drop-overlay-title { font-size: 16px; font-weight: 600; color: var(--ink); }
+.drop-overlay-sub {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+}
 
 /* ── PR-C: Advanced image search modal ───────────────────────────── */
 

--- a/tests/drag-drop.spec.ts
+++ b/tests/drag-drop.spec.ts
@@ -1,0 +1,108 @@
+// Drag-and-drop ingestion against the real files module. We can't synthesize
+// a real OS drag event in Electron, so we drive the IPC the renderer calls
+// (window.api.files.*) and assert the saved files + returned container paths
+// + collision suffixing + .gitignore. A fresh CLAUDE_FLEET_ROOT isolates the
+// dropbox so paths are deterministic.
+
+import { _electron as electron, test, expect, type Page } from '@playwright/test';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from './_helpers.js';
+
+const WS_ID = 'dropws01';
+
+function dropText(window: Page, mime: 'text/plain' | 'text/html', text: string): Promise<string> {
+  return window.evaluate(
+    ([m, t]) =>
+      (window as unknown as {
+        api: { files: { dropText: (w: string, p: { mime: string; text: string }) => Promise<string> } };
+      }).api.files.dropText('dropws01', { mime: m as 'text/plain', text: t }),
+    [mime, text] as const
+  );
+}
+function dropBytes(window: Page, suggestedName: string | undefined, mime: string, bytes: number[]): Promise<string> {
+  return window.evaluate(
+    ([name, m, arr]) =>
+      (window as unknown as {
+        api: {
+          files: {
+            dropBytes: (
+              w: string,
+              p: { suggestedName?: string; mime?: string; bytes: Uint8Array }
+            ) => Promise<string>;
+          };
+        };
+      }).api.files.dropBytes('dropws01', {
+        suggestedName: name as string | undefined,
+        mime: m as string,
+        bytes: new Uint8Array(arr as number[])
+      }),
+    [suggestedName, mime, bytes] as const
+  );
+}
+
+test('Drag-and-drop: text + bytes land in the dropbox with container paths, collisions suffixed', async () => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'claude-fleet-drop-'));
+  const fleetRoot = mkdtempSync(path.join(tmpdir(), 'claude-fleet-root-'));
+  const app = await electron.launch({
+    args: [REPO_ROOT, `--user-data-dir=${userDataDir}`],
+    cwd: REPO_ROOT,
+    env: { ...process.env, CLAUDE_FLEET_ROOT: fleetRoot } as Record<string, string>
+  });
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  const dropboxDir = path.join(fleetRoot, WS_ID, '_dropped');
+
+  try {
+    // Regression: a `dragover` must be preventDefault'd so the window is a
+    // valid drop target (otherwise the OS shows the "not-allowed" cursor and
+    // the drop never fires). A bare Event has no dataTransfer — the exact
+    // case that previously short-circuited before preventDefault.
+    const prevented = await window.evaluate(() => {
+      const ev = new Event('dragover', { bubbles: true, cancelable: true });
+      window.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    });
+    expect(prevented).toBe(true);
+
+    // Text drop → /workspace/_dropped/dropped-<stamp>.txt, content preserved.
+    const textPath = await dropText(window, 'text/plain', 'hello from a drag');
+    expect(textPath).toMatch(/^\/workspace\/_dropped\/dropped-.*\.txt$/);
+    const hostTextPath = path.join(dropboxDir, path.basename(textPath));
+    expect(readFileSync(hostTextPath, 'utf8')).toBe('hello from a drag');
+
+    // The dropbox is git-ignored regardless of the consumer repo's rules.
+    expect(readFileSync(path.join(dropboxDir, '.gitignore'), 'utf8')).toContain('*');
+
+    // Bytes with no suggested name + PNG magic → sniffed .png extension.
+    const pngMagic = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3];
+    const p1 = await dropBytes(window, undefined, '', pngMagic);
+    expect(p1).toMatch(/^\/workspace\/_dropped\/paste-.*\.png$/);
+
+    // Explicit name twice → collision suffixing (foo.bin, foo-2.bin).
+    const a = await dropBytes(window, 'foo.bin', 'application/octet-stream', [1, 2, 3]);
+    const b = await dropBytes(window, 'foo.bin', 'application/octet-stream', [4, 5, 6]);
+    expect(path.basename(a)).toBe('foo.bin');
+    expect(path.basename(b)).toBe('foo-2.bin');
+    expect(existsSync(path.join(dropboxDir, 'foo.bin'))).toBe(true);
+    expect(existsSync(path.join(dropboxDir, 'foo-2.bin'))).toBe(true);
+
+    // clipboard:readImage — the new IPC the terminal's Ctrl+V handler uses to
+    // decide image-vs-text paste. With a text-only clipboard it must return
+    // null so text paste falls through. (A real image round-trip can't be
+    // exercised in headless Linux Electron — nativeImage/clipboard image
+    // support isn't available here — so we verify the null branch, which is
+    // what gates the fix, and trust the dropBytes path tested above.)
+    await app.evaluate(({ clipboard }) => clipboard.writeText('just text'));
+    const img = await window.evaluate(() =>
+      (window as unknown as {
+        api: { clipboard: { readImage: () => Promise<unknown | null> } };
+      }).api.clipboard.readImage()
+    );
+    expect(img).toBeNull();
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Revives the shelved PR #87 against current `main`. Drop OS files, paste clipboard images, or drag web/text content onto the window → saved into the selected workspace's `<fleetRoot>/<id>/_dropped/` (mounted at `/workspace/_dropped/`); the container path is toasted and copied to the clipboard for pasting into a prompt.

#87 was shelved because drag-and-drop can't be exercised under WSLg (OS drag events don't cross Windows→Linux). It is now verified on a **native Windows build**.

### What's included
- **Four sources:** OS file drag (`webUtils.getPathForFile`), clipboard image paste (routed via `clipboard:readImage` + a `cf:drop-image` window event so xterm's Ctrl+V interception doesn't swallow it), web URL (fetched in main, 20s abort + streaming size guard), text/HTML drag.
- **Caps:** 100 MB/file + 1 GB/dropbox, reject-on-overflow; magic-byte MIME sniffing; collision suffixing; a `*` `.gitignore` in the dropbox.
- Wired into the **existing toast stack** (added `ok`/`error` variants alongside the loadout-reload spinner) rather than duplicating it.
- New files: `src/main/files.ts`, `dropNaming.ts` (+ `dropNaming.test.ts`), `src/renderer/src/dropIngestion.ts`, `tests/drag-drop.spec.ts` (drives the `files:*` IPC since a real OS drag can't be synthesized in Electron).
- SPEC drag-drop section updated **BLOCKED → SHIPPED**; version **0.1.0 → 0.2.0**.

### Test plan
- `npm run typecheck` ✅ · `npm run build` ✅
- `dropNaming.test.ts` 10/10 ✅
- `drag-drop.spec.ts` + `preload.spec.ts` pass in real Electron on Windows ✅
- Native binary built (`electron-builder --dir`) and manually verified: all four drop sources work, files land in `_dropped/` with correct names/bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
