### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ playwright-report/
 
 # Superpowers brainstorm/designsync scratch
 .superpowers/
+
+# Claude Code worktrees (EnterWorktree nests linked worktrees here)
+.claude/worktrees/


### PR DESCRIPTION
`EnterWorktree` nests linked worktrees under `.claude/worktrees/`, which lives inside the tracked `.claude/` dir. Ignoring it keeps worktree contents out of `git status` and prevents accidental `git add -A` staging.

Docs/config-only (.gitignore); no code paths touched, so build-app CI doesn't trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)