### PR TITLE
feat: loadout library v2 — Phase 1 (local catalog, favorites, browser modal)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -479,72 +479,23 @@ If no resumable UUID exists (claude never started in that tab), it's a no-op —
 
 Renderer: `LeftRail.tsx` (the accordion shell — Sessions section reuses `SessionsPane` in `embedded` mode + the new Library section), `LibraryPane.tsx` (search/tag-filter + cards + install/uninstall), `LoadoutReviewModal.tsx` (the review). **Card collapse (long-list ergonomics):** each loadout card is independently collapsible via a disclosure **chevron** in its title row (collapsed = title + action only; the body — description + tags — hides). The chevron toggles that one card (stops propagation, so the card-body click still opens the review modal); a header **Collapse all / Expand all** toggle (shown when >1 card is visible) acts on the currently-filtered set, its label following whether most visible cards are open. Cards default **expanded**; the set of collapsed ids persists to `localStorage` under `loadoutLibraryCollapsed` (a pure UI preference, like the rail-collapse state) — a loadout not in the set is expanded, so new loadouts appear open. Still forthcoming: the **Requirements** section in the review (tool preflight, with the merge/run layer), the authoring modal, and the read-only MCP discovery tools.
 
-### Loadout library v2 — remote OCI sources, browser modal, favorites (designed; not yet shipped)
+### Loadout library v2 — Phase 1: local catalog, favorites, browser modal
 
-A designed-but-unbuilt evolution of the library. The pure logic core ships ahead
-of the wiring: `src/main/ociCore.ts` (ref parsing, the security-critical
-artifact-layer path sanitizer, index parsing, version compare, catalog
-assembly) is implemented and unit-tested (`ociCore.test.ts`); the networked and
-electron layers below are enumerated as `it.todo` specs in that test. Design
-doc + hi-fi mocks: [`docs/superpowers/specs/2026-06-28-loadout-library-v2-design.md`](superpowers/specs/2026-06-28-loadout-library-v2-design.md).
+**Phase 1 is implemented.** Design doc + hi-fi mocks: [`docs/superpowers/specs/2026-06-28-loadout-library-v2-design.md`](superpowers/specs/2026-06-28-loadout-library-v2-design.md). The pure OCI logic core (`src/main/ociCore.ts` — ref parsing, artifact-layer path sanitizer, index parsing, version compare) was implemented and unit-tested in an earlier step; Phase 1 wires the user-facing layer on top of the local-only catalog.
 
-- **Remote OCI sources.** The user adds **public GHCR** sources (e.g.
-  `ghcr.io/imioimi/claude-fleet-loadouts`) and downloads loadouts from them.
-  Transport is a **native, zero-dependency OCI client** in the main process
-  (`fetch` against `ghcr.io/v2/` with the anonymous-token flow: 401 → parse
-  `Www-Authenticate` → `GET ghcr.io/token?scope=repository:<repo>:pull` →
-  retry) — no `oras` binary, no host dependency. **Public/anonymous only in v1**
-  (no credentials stored); private/org GHCR (a PAT in the safeStorage vault) is
-  a clean follow-up.
-- **Discovery via an index artifact (cross-repo contract).** OCI exposes no
-  namespace listing on GHCR, so a source publishes a well-known **index
-  artifact** `<source>/index:latest`, artifactType
-  `application/vnd.claude-fleet.loadout-index.v1`, a single `index.json` layer of
-  `[{id,title,description,tags,version}]`. The app derives each loadout's pull
-  ref as `<source>/<id>:<version>`. **Pairs with claude-fleet-loadouts**: its
-  `publish-loadouts.yml` must emit the index, and its docs/skills must document
-  the format — that paired change lands with implementation (see Open
-  decisions), so nothing drifts while only the design is recorded here.
-- **Install pulls transparently — no "download" state.** There is no
-  download-without-install step. **Install** pulls the artifact into the
-  host-private library `<userData>/loadouts/<id>/` if absent or stale (caching
-  the folder byte-identical to the artifact via the layer-title tree), then runs
-  the existing `installLoadout`. Re-pull on a collision with a *locally-authored*
-  id is **confirm-before-overwrite** (never silent). **Update** = re-pull the
-  newer version, then the existing §7 Update/Sync pushes it into installed
-  workspaces.
-- **Sources + provenance** persist in `<userData>/loadouts/sources.json`
-  (`{ sources: string[], provenance: { [id]: {source, version, downloadedAt} } }`);
-  `listLoadouts` ignores it (it filters to directories). Update detection
-  compares the index version against the provenance/installed version.
-- **Favorites (global).** A single user-level favorites set (in `config.json`),
-  shown in **every** workspace's rail; per-entry install/update state is relative
-  to the selected workspace.
-- **IPC (new, all privileged main process):** `loadouts:catalog(workspaceId?)`
-  (assembled local+remote with per-workspace state), `loadouts:listSources` /
-  `addSource(ref)` / `removeSource(ref)` / `refreshSources`,
-  `loadouts:download(ref,id,version)`, `loadouts:setFavorite(id, on)`.
-  `loadouts:install` is revised to pull-if-needed. The MCP server stays
-  read-only — all of this is host-side IPC, consistent with §7's "writes never
-  go through MCP".
-- **Security (§9 preserved).** Downloads land only in the host-private
-  `<userData>/loadouts/` — **never bind-mounted into a container**, like today's
-  library. The only new exposure is outbound main→`ghcr.io`. The
-  `ociCore.safeLayerPath` guard confines every reconstructed layer to the
-  loadout folder (rejects `..`/absolute titles), and `parseIndex` rejects a
-  malformed/hostile index.
-- **UI.** A **browser modal** (the "facet sidebar" layout: source checkboxes +
-  tag cloud + search; results with Install / Installed / Update) is the full
-  catalog browser over local + remote. The **left rail is unchanged** from today
-  (search, tag filter, per-card expand/collapse, install/uninstall, ⋮ menu) plus
-  three minimal additions: an `Update ↑` affordance on a card with a newer
-  remote version, a **favorite toggle that appears only in the expanded card**
-  (no per-row stars), and a **non-intrusive favorites filter** (a small ★ icon
-  toggle beside the Tags dropdown). New primitives this introduces — a `--warn`
-  `.btn.update`, the facet checkbox-list/inset panel, the favorite ★ + favorites
-  filter — are catalogued in the design doc's style guide; the only reconcile is
-  the primary-button drift (design artboard's ink-inverted vs shipped green
-  `.btn.primary`), resolved to **shipped** as canonical.
+**IPC (Phase 1, all privileged main process):**
+- `loadouts:catalog(workspaceId?)` → `CatalogEntry[]` — assembles the local library with per-workspace install state (`installed`, `installedVersion`, `updateAvailable`), `present` (folder exists on disk), and `favorited` (from `config.json`). Returns all entries when `workspaceId` is omitted (used by the browser modal, which shows the full catalog regardless of workspace selection).
+- `loadouts:setFavorite(id, on)` → `string[]` — toggles one loadout's membership in `config.json`'s `favoritedLoadouts` set and returns the updated set. Favorites are global (user-level, not workspace-scoped).
+
+**Favorites (global).** `config.json` gains a `favoritedLoadouts: string[]` field. The field is absent-tolerant (defaults to `[]`) and is written by `loadouts:setFavorite`. The catalog builder reads it and sets `favorited: boolean` per entry. There is one favorites set for the whole app; per-entry `installed`/`updateAvailable` state is relative to the selected workspace.
+
+**Left-rail additions (Phase 1).** The library pane gains two affordances beside the existing Tags dropdown: a **`.fav-filter`** toggle button (☆/★) that, when active (`.on`), filters the card list to `favorited === true` only; and a **`.lib-browse`** "Browse all" button that opens the browser modal. Each expanded card gains a **`.lc-fav`** button (☆ Favorite / ★ Favorited) that calls `loadouts:setFavorite` and triggers a catalog reload.
+
+**Browser modal (`LoadoutBrowserModal`).** Renders as `.modal.loadout-browser` (720 px wide, flex column). Layout: `.lb-head` (title + close); `.lb-body` grid (200 px `.lb-facets` sidebar + `.lb-results` list). The facets sidebar has a `.lb-search` input and a `.lb-tagcloud` of `.lb-tag` pills (each togglable, `.on` when active — tag filter requires *all* active tags). Each result row is `.lb-row` with `.lb-row-main` (title, tags, description) and `.lb-row-actions` (`.lc-fav` toggle + Install / Installed button). Phase 2 will add source checkboxes and the Update ↑ affordance.
+
+**Styles (new classes, `styles.css`).** `.fav-filter`, `.fav-filter.on`, `.lc-fav`, `.lc-fav.on`, `.lib-browse`, `.modal.loadout-browser`, `.lb-head`, `.lb-body`, `.lb-facets`, `.lb-search`, `.lb-tagcloud`, `.lb-tag`, `.lb-tag.on`, `.lb-results`, `.lb-row`, `.lb-row-main`, `.lb-row-title`, `.lb-row-desc`, `.lb-row-actions`, `.lb-empty`. All use the existing token set (`--ok`, `--rule`, `--bg-3`, `--ink`, `--ink-2`, `--r-sm`, `--r-md`).
+
+**Phase 2 (not yet built).** Remote OCI sources: the user adds public GHCR sources (e.g. `ghcr.io/imioimi/claude-fleet-loadouts`); the app fetches them via a native, zero-dependency OCI client (`fetch` + anonymous-token flow). Discovery via a well-known **index artifact** `<source>/index:latest` (artifactType `application/vnd.claude-fleet.loadout-index.v1`, a single `index.json` layer of `[{id,title,description,tags,version}]`). Install pulls the artifact into `<userData>/loadouts/<id>/` if absent or stale, then runs the existing `installLoadout`. Sources + provenance persist in `<userData>/loadouts/sources.json`. Update detection compares index version against provenance/installed version. New IPC: `loadouts:listSources` / `addSource` / `removeSource` / `refreshSources` / `download`. An `Update ↑` affordance on cards with a newer remote version. **Cross-repo dependency (governance):** the paired `claude-fleet-loadouts` change (emitting `<source>/index:latest` from `publish-loadouts.yml` and documenting the format) must land in the same change per the workspace CLAUDE.md cross-repo contract rule.
 
 ## 8. User flows
 
@@ -756,8 +707,8 @@ claude-fleet/
 
 These are decided in spirit but not yet implemented. When you implement one, move it out of this section and into the relevant body section above.
 
-### Loadout library v2 — remote OCI sources, browser modal, favorites
-Designed in §7 ("Loadout library v2"). Pure core (`ociCore.ts`) is implemented + unit-tested; the networked (`ociClient.ts`) and electron-wired (`loadoutSources.ts`) layers, the new IPC, the browser modal, and the rail additions (Update affordance, expanded favorite toggle, favorites filter) are not yet built — enumerated as `it.todo` in `ociCore.test.ts`. **Cross-repo dependency (governance):** discovery relies on an **index artifact** published by `claude-fleet-loadouts`; that repo's `publish-loadouts.yml` must emit `<source>/index:latest` (artifactType `application/vnd.claude-fleet.loadout-index.v1`) and its README/skills must document the format. Per the workspace's CLAUDE.md cross-repo contract rule, that paired change lands **in the same change as the consumer implementation** — recorded here so it isn't re-litigated and so no drift ships before then.
+### Loadout library v2 — remote OCI sources + update detection (Phase 2)
+**Phase 1 (local catalog + favorites + browser modal) is implemented** — see §7 "Loadout library v2 — Phase 1". Phase 2 (remote OCI sources, index artifact, update detection, paired `claude-fleet-loadouts` publish) is not yet built. The pure OCI logic core (`ociCore.ts`) is implemented + unit-tested; the networked (`ociClient.ts`) and electron-wired (`loadoutSources.ts`) layers and the new source-management IPC are enumerated as `it.todo` in `ociCore.test.ts`. **Cross-repo dependency (governance):** discovery relies on an **index artifact** published by `claude-fleet-loadouts`; that repo's `publish-loadouts.yml` must emit `<source>/index:latest` (artifactType `application/vnd.claude-fleet.loadout-index.v1`) and its README/skills must document the format. Per the workspace's CLAUDE.md cross-repo contract rule, that paired change lands **in the same change as the Phase 2 consumer implementation** — recorded here so it isn't re-litigated and so no drift ships before then.
 
 ### Per-container Claude Code state visibility on the host
 Each container gets its own host-side state dir, bind-mounted into the container at `/home/fleet/.claude/`. This is the foundation for the observability watcher, sessions table, durable mirror, and permission-request log — all of which read events from `<state-dir>/projects/-workspace/*.jsonl` directly off the host filesystem.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -485,9 +485,9 @@ Renderer: `LeftRail.tsx` (the accordion shell — Sessions section reuses `Sessi
 
 **IPC (Phase 1, all privileged main process):**
 - `loadouts:catalog(workspaceId?)` → `CatalogEntry[]` — assembles the local library with per-workspace install state (`installed`, `installedVersion`, `updateAvailable`), `present` (folder exists on disk), and `favorited` (from `config.json`). Returns all entries when `workspaceId` is omitted (used by the browser modal, which shows the full catalog regardless of workspace selection).
-- `loadouts:setFavorite(id, on)` → `string[]` — toggles one loadout's membership in `config.json`'s `favoritedLoadouts` set and returns the updated set. Favorites are global (user-level, not workspace-scoped).
+- `loadouts:setFavorite(id, on)` → `string[]` — toggles one loadout's membership in `config.json`'s `favorites` set and returns the updated set. Favorites are global (user-level, not workspace-scoped).
 
-**Favorites (global).** `config.json` gains a `favoritedLoadouts: string[]` field. The field is absent-tolerant (defaults to `[]`) and is written by `loadouts:setFavorite`. The catalog builder reads it and sets `favorited: boolean` per entry. There is one favorites set for the whole app; per-entry `installed`/`updateAvailable` state is relative to the selected workspace.
+**Favorites (global).** `config.json` gains a `favorites: string[]` field. The field is absent-tolerant (defaults to `[]`) and is written by `loadouts:setFavorite`. The catalog builder reads it and sets `favorited: boolean` per entry. There is one favorites set for the whole app; per-entry `installed`/`updateAvailable` state is relative to the selected workspace.
 
 **Left-rail additions (Phase 1).** The library pane gains two affordances beside the existing Tags dropdown: a **`.fav-filter`** toggle button (☆/★) that, when active (`.on`), filters the card list to `favorited === true` only; and a **`.lib-browse`** "Browse all" button that opens the browser modal. Each expanded card gains a **`.lc-fav`** button (☆ Favorite / ★ Favorited) that calls `loadouts:setFavorite` and triggers a catalog reload.
 

--- a/docs/superpowers/plans/2026-06-28-loadout-library-v2-phase1.md
+++ b/docs/superpowers/plans/2026-06-28-loadout-library-v2-phase1.md
@@ -1,0 +1,650 @@
+# Loadout Library v2 — Phase 1 (local catalog + favorites + browser modal) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global favorites set, an assembled-catalog IPC, a facet-sidebar browser modal, and rail favorite toggle + favorites filter — all against the **local** loadout library (no network).
+
+**Architecture:** A pure `toggleFavorite` helper + `assembleCatalog` (already in `ociCore.ts`) carry the logic. A thin main-process `loadoutCatalog.ts` gathers inputs (local list, installed set, favorites) and calls `assembleCatalog`. Two new IPC channels (`loadouts:catalog`, `loadouts:setFavorite`) expose it. The renderer migrates `LibraryPane` onto the catalog and gains a favorite toggle + favorites filter; a new `LoadoutBrowserModal` is the full-catalog browser.
+
+**Tech Stack:** Electron (main IPC), React + TypeScript (renderer), vitest (unit), Playwright (e2e). No new dependencies.
+
+## Global Constraints
+
+- **Phase 1 is local-only** — no network, no `ociClient`, no remote sources. `assembleCatalog` is called with `remote: []`. The `Update ↑` affordance and source checkboxes are **Phase 2** and out of scope here.
+- **MCP server stays read-only** — all new IPC is host-side (`ipc.ts`), never an MCP tool (SPEC §7 invariant).
+- **Favorites are global** — one set in `config.json` (`AppConfig.favorites`), shown in every workspace; install/installed state is per selected workspace.
+- **Reuse the existing install/uninstall path untouched** (`installLoadout`/`uninstallLoadout`).
+- **Catalog entry shape is `CatalogEntry` from `src/main/ociCore.ts`** (already defined + unit-tested) — do not redefine it.
+- **Spec discipline:** update `docs/SPEC.md` §7 in the same change (the loadout library section); the Phase-1 parts move out of §11 Open decisions into the body, Phase 2 stays noted.
+- Run unit tests with `npx vitest run <path>`; the full suite with `npm run test:unit`; typecheck with `npm run typecheck`.
+
+---
+
+### Task 1: Pure `toggleFavorite` helper
+
+**Files:**
+- Modify: `src/main/ociCore.ts` (append helper)
+- Test: `src/main/ociCore.test.ts` (append describe block)
+
+**Interfaces:**
+- Produces: `toggleFavorite(favorites: string[], id: string, on: boolean): string[]` — returns a new de-duplicated array; adding is idempotent, removing absent is a no-op; order stable (existing order preserved, new id appended).
+
+- [ ] **Step 1: Write the failing test** — append to `src/main/ociCore.test.ts`:
+
+```ts
+describe('toggleFavorite', () => {
+  it('adds an id (idempotent) and removes it, de-duplicating', () => {
+    expect(toggleFavorite([], 'a', true)).toEqual(['a']);
+    expect(toggleFavorite(['a'], 'a', true)).toEqual(['a']); // idempotent add
+    expect(toggleFavorite(['a', 'b'], 'a', false)).toEqual(['b']);
+    expect(toggleFavorite(['a'], 'z', false)).toEqual(['a']); // remove absent = no-op
+  });
+
+  it('preserves existing order and appends new ids', () => {
+    expect(toggleFavorite(['b', 'a'], 'c', true)).toEqual(['b', 'a', 'c']);
+  });
+});
+```
+
+Add `toggleFavorite` to the existing import at the top of the test file:
+```ts
+import {
+  parseImageRef,
+  loadoutRefFromSource,
+  safeLayerPath,
+  parseIndex,
+  compareVersions,
+  isUpdateAvailable,
+  assembleCatalog,
+  toggleFavorite
+} from './ociCore';
+```
+(Match the actual existing import list; just add `toggleFavorite`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/main/ociCore.test.ts -t toggleFavorite`
+Expected: FAIL — `toggleFavorite is not a function`.
+
+- [ ] **Step 3: Write minimal implementation** — append to `src/main/ociCore.ts`:
+
+```ts
+/** Add or remove `id` from a favorites list, returning a new de-duplicated array.
+ *  Adding is idempotent; removing an absent id is a no-op. Existing order is
+ *  preserved and a newly-added id is appended. */
+export function toggleFavorite(favorites: string[], id: string, on: boolean): string[] {
+  const set = favorites.filter((f) => f !== id);
+  if (on) set.push(id);
+  return set;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/main/ociCore.test.ts -t toggleFavorite`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ociCore.ts src/main/ociCore.test.ts
+git commit -m "feat(loadouts): pure toggleFavorite helper"
+```
+
+---
+
+### Task 2: Favorites in app config
+
+**Files:**
+- Modify: `src/main/config.ts` (add `favorites` to `AppConfig` + a `setFavorite` helper)
+- Test: `src/main/config.test.ts` (create if absent; otherwise append)
+
+**Interfaces:**
+- Consumes: `toggleFavorite` (Task 1); existing `config.read()`/`config.write()` in `config.ts`.
+- Produces: `AppConfig.favorites?: string[]`; `setFavorite(id: string, on: boolean): Promise<string[]>` (persists via `write`, returns the new list).
+
+- [ ] **Step 1: Write the failing test** — `src/main/config.test.ts`. Mock the read/write so no real fs:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const store: { cfg: Record<string, unknown> } = { cfg: {} };
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp/cf-test' } }));
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(async () => JSON.stringify(store.cfg)),
+  writeFile: vi.fn(async (_p: string, data: string) => {
+    store.cfg = JSON.parse(data);
+  }),
+  mkdir: vi.fn(async () => undefined)
+}));
+
+const config = await import('./config');
+
+describe('setFavorite', () => {
+  beforeEach(() => {
+    store.cfg = {};
+    // reset the module-level cache so each test reads fresh
+    config.__resetCacheForTests?.();
+  });
+
+  it('adds then removes a favorite, persisting to config', async () => {
+    expect(await config.setFavorite('spec-driven', true)).toEqual(['spec-driven']);
+    expect((await config.read()).favorites).toEqual(['spec-driven']);
+    expect(await config.setFavorite('spec-driven', false)).toEqual([]);
+  });
+});
+```
+
+> Note: if `config.ts` already caches, add a tiny test-only `__resetCacheForTests` export (guard it with a comment that it exists only for tests) OR, if a reset hook already exists, use it. Match the file's existing test conventions if a `config.test.ts` already exists.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/main/config.test.ts`
+Expected: FAIL — `setFavorite is not a function` (and/or missing `favorites`).
+
+- [ ] **Step 3: Write minimal implementation** — in `src/main/config.ts`:
+
+Add `favorites` to the `AppConfig` interface:
+```ts
+export interface AppConfig {
+  fleetRoot?: string;
+  disableHardwareAcceleration?: boolean;
+  autoReloadLoadouts?: boolean;
+  usageBudget?: number;
+  /** Global loadout favorites (loadout ids), shown in every workspace's rail. */
+  favorites?: string[];
+}
+```
+
+Append the helper (import `toggleFavorite` from `./ociCore`):
+```ts
+import { toggleFavorite } from './ociCore.js';
+
+/** Toggle a global loadout favorite and persist it. Returns the new list. */
+export async function setFavorite(id: string, on: boolean): Promise<string[]> {
+  const cfg = await read();
+  const favorites = toggleFavorite(cfg.favorites ?? [], id, on);
+  await write({ ...cfg, favorites });
+  return favorites;
+}
+```
+If the module caches config in a module-level variable, add (only if needed for the test):
+```ts
+/** Test-only: drop the in-memory config cache. */
+export function __resetCacheForTests(): void {
+  /* set the cache variable back to null/undefined here */
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/main/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/config.ts src/main/config.test.ts
+git commit -m "feat(loadouts): global favorites in app config"
+```
+
+---
+
+### Task 3: Main-process catalog builder
+
+**Files:**
+- Create: `src/main/loadoutCatalog.ts`
+- Test: covered indirectly by Task 1's `assembleCatalog` tests + Task 7 e2e (this is thin I/O glue — no new logic to unit-test; keep it that way).
+
+**Interfaces:**
+- Consumes: `listLoadouts()` (`./loadouts`), `read()` (`./config`), `readWorkspaceManifest(id)` (`./workspaces`), `assembleCatalog` + `CatalogEntry` + `LocalLoadout` + `InstalledRef` (`./ociCore`).
+- Produces: `buildLoadoutCatalog(workspaceId?: string): Promise<CatalogEntry[]>`.
+
+- [ ] **Step 1: Create the module** — `src/main/loadoutCatalog.ts`:
+
+```ts
+// Assemble the loadout catalog for the renderer (browser modal + rail). Phase 1
+// is local-only: the local library + the target workspace's installed set +
+// global favorites, with no remote sources (assembleCatalog `remote` is []).
+// Pure assembly lives in ociCore.ts:assembleCatalog; this is the I/O glue.
+
+import { listLoadouts } from './loadouts.js';
+import { read as readConfig } from './config.js';
+import { readWorkspaceManifest } from './workspaces.js';
+import { assembleCatalog, type CatalogEntry, type LocalLoadout, type InstalledRef } from './ociCore.js';
+
+export async function buildLoadoutCatalog(workspaceId?: string): Promise<CatalogEntry[]> {
+  const [summaries, cfg] = await Promise.all([listLoadouts(), readConfig()]);
+  const local: LocalLoadout[] = summaries.map((s) => ({
+    id: s.id,
+    title: s.title,
+    description: s.description,
+    tags: s.tags
+    // version omitted — local list carries none; update detection is Phase 2.
+  }));
+  let installed: InstalledRef[] = [];
+  if (workspaceId) {
+    const ws = await readWorkspaceManifest(workspaceId);
+    installed = (ws?.installedLoadouts ?? []).map((l) => ({
+      id: l.id,
+      version: (l as { version?: string }).version
+    }));
+  }
+  return assembleCatalog({ local, installed, favorites: cfg.favorites ?? [] });
+}
+```
+
+> Adjust the `read` import name to match `config.ts`'s actual export (the explore shows `read`/`write`). If `listLoadouts` is a named export under a namespace import elsewhere (e.g. `import * as loadouts`), match the existing convention in `ipc.ts`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck:node`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/loadoutCatalog.ts
+git commit -m "feat(loadouts): main-process catalog builder (local-only)"
+```
+
+---
+
+### Task 4: IPC channels + preload
+
+**Files:**
+- Modify: `src/main/ipc.ts` (register two handlers near the existing `loadouts:*` block, ~line 877)
+- Modify: `src/preload/index.ts` (extend the `loadouts` API, ~line 323)
+
+**Interfaces:**
+- Consumes: `buildLoadoutCatalog` (Task 3), `setFavorite` (Task 2).
+- Produces (preload): `window.api.loadouts.catalog(workspaceId?: string): Promise<CatalogEntry[]>` and `window.api.loadouts.setFavorite(id: string, on: boolean): Promise<string[]>`.
+
+- [ ] **Step 1: Register IPC** — in `src/main/ipc.ts`, add to the loadouts handler block:
+
+```ts
+ipcMain.handle('loadouts:catalog', (_e, workspaceId?: string) => buildLoadoutCatalog(workspaceId));
+ipcMain.handle('loadouts:setFavorite', (_e, id: string, on: boolean) => setFavorite(id, on));
+```
+Add imports at the top of `ipc.ts`:
+```ts
+import { buildLoadoutCatalog } from './loadoutCatalog.js';
+import { setFavorite } from './config.js';
+```
+(If `config` is imported as a namespace, use `config.setFavorite` instead.)
+
+- [ ] **Step 2: Extend preload** — in `src/preload/index.ts`, inside the `loadouts:` object, add a shared catalog-entry type and two methods:
+
+```ts
+catalog: (
+  workspaceId?: string
+): Promise<
+  Array<{
+    id: string;
+    title: string;
+    description: string;
+    tags: string[];
+    version: string;
+    remoteVersion?: string;
+    present: boolean;
+    installed: boolean;
+    installedVersion?: string;
+    updateAvailable: boolean;
+    favorited: boolean;
+    sources: string[];
+  }>
+> => ipcRenderer.invoke('loadouts:catalog', workspaceId),
+setFavorite: (id: string, on: boolean): Promise<string[]> =>
+  ipcRenderer.invoke('loadouts:setFavorite', id, on),
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/ipc.ts src/preload/index.ts
+git commit -m "feat(loadouts): catalog + setFavorite IPC + preload"
+```
+
+---
+
+### Task 5: LibraryPane — catalog data, favorite toggle, favorites filter
+
+**Files:**
+- Modify: `src/renderer/src/components/LibraryPane.tsx`
+
+**Interfaces:**
+- Consumes: `window.api.loadouts.catalog`, `window.api.loadouts.setFavorite`.
+- Produces: a `CatalogEntry`-shaped row type used locally; a `favOnly` filter state; an `onBrowse` prop hook (wired in Task 6) — add `onBrowse?: () => void` to `Props`.
+
+- [ ] **Step 1: Switch the data source to the catalog.** Replace the `loadouts` fetch (currently `window.api.loadouts.list()`, ~line 64) with `window.api.loadouts.catalog(selectedWorkspace?.id)`, storing the result as `entries`. Re-fetch when `selectedWorkspace?.id` changes. Derive `installedIds` from `entries.filter(e => e.installed)` instead of from the prop (the catalog now carries it). Keep a local type:
+
+```ts
+type Entry = Awaited<ReturnType<typeof window.api.loadouts.catalog>>[number];
+const [entries, setEntries] = useState<Entry[]>([]);
+const [favOnly, setFavOnly] = useState(false);
+
+const reload = useCallback(async () => {
+  setEntries(await window.api.loadouts.catalog(selectedWorkspace?.id));
+}, [selectedWorkspace?.id]);
+useEffect(() => { void reload(); }, [reload]);
+```
+Update `doInstall`/`doUninstall`/`onChanged` paths to call `void reload()` after mutating so favorited/installed state refreshes.
+
+- [ ] **Step 2: Add the favorites filter toggle** beside the Tags dropdown (in `.library-filter`):
+
+```tsx
+<button
+  type="button"
+  className={`fav-filter ${favOnly ? 'on' : ''}`}
+  aria-pressed={favOnly}
+  title="Show favorites only"
+  onClick={() => setFavOnly((v) => !v)}
+>
+  {favOnly ? '★' : '☆'}
+</button>
+```
+Fold it into the `filtered` computation:
+```ts
+const filtered = entries.filter((e) => {
+  if (favOnly && !e.favorited) return false;
+  if (activeTags.length && !activeTags.every((t) => e.tags.includes(t))) return false;
+  if (query && !(`${e.title} ${e.description}`.toLowerCase().includes(query.toLowerCase()))) return false;
+  return true;
+});
+```
+(Match the existing query/tag semantics already in the file; just add the `favOnly` clause.)
+
+- [ ] **Step 3: Add the expanded-only favorite toggle** in the card body (render only when `!isCollapsed`, after the tags row). Use the entry `e` in place of `l`:
+
+```tsx
+{!isCollapsed && (
+  <button
+    type="button"
+    className={`lc-fav ${e.favorited ? 'on' : ''}`}
+    onClick={async (ev) => {
+      ev.stopPropagation();
+      await window.api.loadouts.setFavorite(e.id, !e.favorited);
+      void reload();
+    }}
+  >
+    {e.favorited ? '★ Favorited' : '☆ Favorite'}
+  </button>
+)}
+```
+
+- [ ] **Step 4: Add a "Browse all" entry point** in the search row that calls `onBrowse?.()` (wired in Task 6):
+
+```tsx
+<button type="button" className="btn btn-sm lib-browse" onClick={() => onBrowse?.()}>
+  Browse all
+</button>
+```
+
+- [ ] **Step 5: Typecheck + run the existing unit suite**
+
+Run: `npm run typecheck && npm run test:unit`
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/components/LibraryPane.tsx
+git commit -m "feat(loadouts): rail catalog data + favorite toggle + favorites filter"
+```
+
+---
+
+### Task 6: Browser modal (facet sidebar)
+
+**Files:**
+- Create: `src/renderer/src/components/LoadoutBrowserModal.tsx`
+- Modify: `src/renderer/src/App.tsx` (mount the modal + `browseOpen` state; pass `onBrowse` into the rail → LibraryPane)
+- Modify: `src/renderer/src/components/LeftRail.tsx` (thread `onBrowse` to `LibraryPane`)
+
+**Interfaces:**
+- Consumes: `window.api.loadouts.catalog`, `setFavorite`, `install`, `uninstall`; the `CatalogEntry` shape.
+- Produces: `LoadoutBrowserModal` default export with props `{ workspace: WorkspaceSummary | null; onClose: () => void; onChanged: () => void }`.
+
+- [ ] **Step 1: Create the modal** — `src/renderer/src/components/LoadoutBrowserModal.tsx`. Facet sidebar (Phase 1: tag cloud + search; **no source checkboxes** — those are Phase 2) + results list with one action each (`+ Install` / `✓ Installed`) and a favorite ★. Follow the existing `.modal-backdrop`/`.modal` pattern from `LoadoutReviewModal.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { WorkspaceSummary } from '../App';
+
+type Entry = Awaited<ReturnType<typeof window.api.loadouts.catalog>>[number];
+
+interface Props {
+  workspace: WorkspaceSummary | null;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: Props): React.JSX.Element {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [query, setQuery] = useState('');
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const installable = !!workspace && workspace.kind === 'container' && !!workspace.containerId;
+
+  const reload = useCallback(async () => {
+    setEntries(await window.api.loadouts.catalog(workspace?.id));
+  }, [workspace?.id]);
+  useEffect(() => { void reload(); }, [reload]);
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of entries) for (const t of e.tags) set.add(t);
+    return [...set].sort();
+  }, [entries]);
+
+  const filtered = entries.filter((e) => {
+    if (activeTags.length && !activeTags.every((t) => e.tags.includes(t))) return false;
+    if (query && !`${e.title} ${e.description}`.toLowerCase().includes(query.toLowerCase())) return false;
+    return true;
+  });
+
+  const toggleTag = (t: string): void =>
+    setActiveTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
+
+  const onInstall = async (id: string): Promise<void> => {
+    if (workspace) await window.api.loadouts.install(workspace.id, id);
+    onChanged();
+    void reload();
+  };
+  const onFav = async (e: Entry): Promise<void> => {
+    await window.api.loadouts.setFavorite(e.id, !e.favorited);
+    void reload();
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal loadout-browser" onClick={(ev) => ev.stopPropagation()}>
+        <div className="lb-head">
+          <span className="eyebrow">Loadouts · browse</span>
+          <button className="btn btn-sm" onClick={onClose}>Close</button>
+        </div>
+        <div className="lb-body">
+          <aside className="lb-facets">
+            <input
+              className="lb-search"
+              placeholder="Search loadouts…"
+              value={query}
+              onChange={(ev) => setQuery(ev.target.value)}
+            />
+            <div className="lb-tagcloud">
+              {allTags.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  className={`lb-tag ${activeTags.includes(t) ? 'on' : ''}`}
+                  onClick={() => toggleTag(t)}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </aside>
+          <ul className="lb-results">
+            {filtered.map((e) => (
+              <li key={e.id} className="lb-row">
+                <div className="lb-row-main">
+                  <span className="lb-row-title">{e.title}</span>
+                  {e.tags.length > 0 && (
+                    <span className="tags">
+                      {e.tags.map((t) => <span className="tag" key={t}>{t}</span>)}
+                    </span>
+                  )}
+                  {e.description && <span className="lb-row-desc">{e.description}</span>}
+                </div>
+                <div className="lb-row-actions">
+                  <button
+                    type="button"
+                    className={`lc-fav ${e.favorited ? 'on' : ''}`}
+                    title="Favorite"
+                    onClick={() => void onFav(e)}
+                  >
+                    {e.favorited ? '★' : '☆'}
+                  </button>
+                  {e.installed ? (
+                    <button className="btn installed btn-sm" disabled>✓ Installed</button>
+                  ) : (
+                    <button
+                      className="btn primary btn-sm"
+                      disabled={!installable}
+                      onClick={() => void onInstall(e.id)}
+                    >
+                      + Install
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+            {filtered.length === 0 && <li className="lb-empty">No loadouts match.</li>}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Mount in App.tsx.** Add state `const [browseOpen, setBrowseOpen] = useState(false);` (near the other modal state, ~line 157). Mount near the other modals:
+
+```tsx
+{browseOpen && (
+  <LoadoutBrowserModal
+    workspace={selectedWorkspace}
+    onClose={() => setBrowseOpen(false)}
+    onChanged={() => void refreshWorkspaces()}
+  />
+)}
+```
+(Use the app's existing workspace-refresh function in place of `refreshWorkspaces` — match what `onChanged` does elsewhere, e.g. the same callback `LeftRail` already receives.) Add the import:
+```tsx
+import LoadoutBrowserModal from './components/LoadoutBrowserModal';
+```
+Pass an `onBrowse` down to the rail: find where `<LeftRail .../>` is mounted (~line 933) and add `onBrowse={() => setBrowseOpen(true)}`.
+
+- [ ] **Step 3: Thread `onBrowse` through LeftRail.** In `LeftRail.tsx`, add `onBrowse?: () => void` to its props and pass it into `<LibraryPane ... onBrowse={onBrowse} />`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/components/LoadoutBrowserModal.tsx src/renderer/src/components/LeftRail.tsx src/renderer/src/App.tsx
+git commit -m "feat(loadouts): facet-sidebar browser modal (local catalog)"
+```
+
+---
+
+### Task 7: Styles, e2e, SPEC
+
+**Files:**
+- Modify: `src/renderer/src/styles.css`
+- Modify: `tests/workspace-modal.spec.ts` OR create `tests/loadout-library.spec.ts` (favorites + browse flow)
+- Modify: `docs/SPEC.md` (§7 loadout library; move Phase-1 parts out of §11 Open decisions)
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Add styles** — append to `src/renderer/src/styles.css`, reusing existing tokens (`--ok`, `--rule`, `--bg-3`, `--ink-2`, `--r-sm`, `--r-md`):
+
+```css
+/* Loadout favorites + browser (library v2 Phase 1) */
+.fav-filter { padding: 3px 8px; font-size: 13px; border: 1px solid var(--rule); border-radius: var(--r-sm); background: var(--bg-3); color: var(--ink-2); cursor: pointer; }
+.fav-filter.on { color: var(--ok); border-color: var(--ok); }
+.lc-fav { align-self: flex-start; padding: 2px 7px; font-size: 11px; background: none; border: 1px solid var(--rule); border-radius: var(--r-sm); color: var(--ink-2); cursor: pointer; }
+.lc-fav.on { color: var(--ok); border-color: var(--ok); }
+.lib-browse { margin-left: auto; }
+
+.modal.loadout-browser { width: 720px; max-width: 94vw; max-height: 86vh; display: flex; flex-direction: column; }
+.lb-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.lb-body { display: grid; grid-template-columns: 200px 1fr; gap: 14px; min-height: 0; overflow: hidden; }
+.lb-facets { display: flex; flex-direction: column; gap: 10px; }
+.lb-search { width: 100%; }
+.lb-tagcloud { display: flex; flex-wrap: wrap; gap: 5px; }
+.lb-tag { padding: 2px 8px; font-size: 11px; border: 1px solid var(--rule); border-radius: 999px; background: var(--bg-3); color: var(--ink-2); cursor: pointer; }
+.lb-tag.on { color: var(--ok); border-color: var(--ok); }
+.lb-results { list-style: none; margin: 0; padding: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.lb-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; padding: 8px; border: 1px solid var(--rule); border-radius: var(--r-md); background: var(--bg-3); }
+.lb-row-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.lb-row-title { font-weight: 600; color: var(--ink); }
+.lb-row-desc { font-size: 11px; color: var(--ink-2); }
+.lb-row-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.lb-empty { color: var(--ink-2); font-size: 12px; padding: 8px; }
+```
+
+- [ ] **Step 2: Write the e2e** — `tests/loadout-library.spec.ts`. Seed a workspace + at least one built-in loadout is available (the mock `loadouts:list`/`catalog` must return entries — check `_helpers.ts` for a `loadoutList` option; if none exists, add a `loadoutCatalog` mock option mirroring the `workspaceList` pattern). Assert: opening the rail Library shows cards; clicking the expanded favorite toggle calls `setFavorite` and the ★ filter narrows the list; "Browse all" opens the modal and it lists the same loadouts.
+
+```ts
+import { test, expect } from '@playwright/test';
+import { launch, mockMainIpc } from './_helpers.js';
+
+test('Library: favorite toggle + favorites filter + browse modal', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, {
+      workspaceList: [/* one running container workspace */],
+      loadoutCatalog: [
+        { id: 'spec-driven', title: 'Spec-Driven', description: 'x', tags: ['workflow'], version: '', present: true, installed: false, updateAvailable: false, favorited: false, sources: [] }
+      ]
+    });
+    // open the Library rail section, expand the card, click favorite, assert filter, open Browse all.
+    // (Fill in selectors from the rendered classes: .loadout-card, .lc-fav, .fav-filter, .lib-browse, .loadout-browser)
+  } finally {
+    await app.close();
+  }
+});
+```
+
+> If extending `_helpers.ts`: add a `loadoutCatalog?` option and register `ipcMain.handle('loadouts:catalog', () => opts.loadoutCatalog ?? [])` and `ipcMain.handle('loadouts:setFavorite', (_e, _id, _on) => [])`, mirroring the existing `workspaceList`/`writeManifest` handlers. Capture `setFavorite` calls in `g.__calls` for assertion.
+
+- [ ] **Step 3: Run e2e locally if the harness runs; otherwise rely on CI.**
+
+Run: `npm run build && npx playwright test tests/loadout-library.spec.ts` (may be display-blocked in sandbox — then rely on CI).
+
+- [ ] **Step 4: Update SPEC §7.** In `docs/SPEC.md`, document the catalog IPC (`loadouts:catalog`, `loadouts:setFavorite`), the global `config.json` favorites, the rail favorite toggle + favorites filter, and the browser modal (local catalog). Edit the §11 "Loadout library v2" Open-decisions entry to say **Phase 1 (local catalog + favorites + browser modal) is implemented; Phase 2 (remote OCI sources + index + update detection + paired loadouts-repo publish) remains.**
+
+- [ ] **Step 5: Full verify + commit**
+
+```bash
+npm run typecheck && npm run test:unit && npm run build
+git add -A
+git commit -m "feat(loadouts): styles + e2e + SPEC for library v2 phase 1"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage (Phase 1 rows of the design):** favorites global (Tasks 1–2, config), catalog assembly reuse (Task 3), catalog + setFavorite IPC (Task 4), rail favorite toggle + favorites filter (Task 5), facet-sidebar browser modal (Task 6), styles/e2e/SPEC (Task 7). `Update ↑` + source checkboxes + `ociClient` + `loadoutSources` + index artifact are **Phase 2** — deliberately excluded; the catalog already carries `updateAvailable`/`remoteVersion`/`sources` so Phase 2 is additive.
+- **Type consistency:** the renderer's local `Entry` is derived from `window.api.loadouts.catalog`'s return (single source of truth), which mirrors `ociCore.ts:CatalogEntry`. `toggleFavorite` signature is identical in Tasks 1, 2.
+- **No new deps; MCP stays read-only; downloads/network are Phase 2** (no §9 surface change in Phase 1).

--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -31,6 +31,7 @@ const {
   USAGE_BUDGET_WINDOW_HOURS,
   setFleetRoot,
   getFleetRoot,
+  setFavorite,
   _resetConfigCacheForTests
 } = await import('./config.js');
 
@@ -173,5 +174,31 @@ describe('get/setUsageBudget', () => {
     expect(await getFleetRoot()).toBe(root);
     expect(await getAutoReloadLoadouts()).toBe(false);
     expect((await getUsageBudget()).preset).toBe('max5');
+  });
+});
+
+describe('setFavorite', () => {
+  it('adds a favorite and returns the new list', async () => {
+    expect(await setFavorite('spec-driven', true)).toEqual(['spec-driven']);
+  });
+
+  it('persists the favorite so a fresh cache read sees it', async () => {
+    await setFavorite('spec-driven', true);
+    _resetConfigCacheForTests();
+    // After cache reset the on-disk value is authoritative — toggling off
+    // should start from ['spec-driven'] and return [].
+    expect(await setFavorite('spec-driven', false)).toEqual([]);
+  });
+
+  it('removes a favorite and returns the new list', async () => {
+    await setFavorite('spec-driven', true);
+    expect(await setFavorite('spec-driven', false)).toEqual([]);
+  });
+
+  it('does not clobber other settings', async () => {
+    const root = join(userDataDir, 'fleet');
+    await setFleetRoot(root);
+    await setFavorite('spec-driven', true);
+    expect(await getFleetRoot()).toBe(root);
   });
 });

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { assertValidWorkspaceId } from './paths.js';
+import { toggleFavorite } from './ociCore.js';
 
 /** Which plan the usage bar measures spend against. `custom` uses the
  *  user-entered token amount; the rest resolve to USAGE_BUDGET_PRESETS. */
@@ -60,6 +61,8 @@ interface AppConfig {
   autoReloadLoadouts?: boolean;
   /** Plan-usage budget for the observability rail's "tokens left" bar. */
   usageBudget?: UsageBudgetConfig;
+  /** Global loadout favorites (loadout ids), shown in every workspace's rail. */
+  favorites?: string[];
 }
 
 /** Defensively parse the persisted usageBudget (untrusted JSON on disk). */
@@ -219,6 +222,14 @@ export async function fleetPrivateDir(id: string): Promise<string> {
 /** `<fleetRoot>/shared` — mounted into every container at /shared (rw). */
 export async function fleetSharedDir(): Promise<string> {
   return join(await getFleetRoot(), 'shared');
+}
+
+/** Toggle a global loadout favorite and persist it. Returns the new list. */
+export async function setFavorite(id: string, on: boolean): Promise<string[]> {
+  const cfg = await read();
+  const favorites = toggleFavorite(cfg.favorites ?? [], id, on);
+  await write({ ...cfg, favorites });
+  return favorites;
 }
 
 /** Test-only: drop the in-memory cache so a fresh read hits disk. */

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -224,6 +224,12 @@ export async function fleetSharedDir(): Promise<string> {
   return join(await getFleetRoot(), 'shared');
 }
 
+/** Return the current global loadout favorites list. */
+export async function getFavorites(): Promise<string[]> {
+  const cfg = await read();
+  return cfg.favorites ?? [];
+}
+
 /** Toggle a global loadout favorite and persist it. Returns the new list. */
 export async function setFavorite(id: string, on: boolean): Promise<string[]> {
   const cfg = await read();

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,8 +22,10 @@ import {
   getUsageBudget,
   setUsageBudget,
   USAGE_BUDGET_WINDOW_HOURS,
-  type UsageBudgetPreset
+  type UsageBudgetPreset,
+  setFavorite
 } from './config.js';
+import { buildLoadoutCatalog } from './loadoutCatalog.js';
 import * as realDocker from './docker.js';
 import * as realLocal from './local.js';
 import * as mockDocker from './mock.js';
@@ -887,6 +889,8 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     const dir = loadoutDir(id);
     return RUNNING_IN_WSL ? openPathViaExplorer(dir) : shell.openPath(dir);
   });
+  ipcMain.handle('loadouts:catalog', (_e, workspaceId?: string) => buildLoadoutCatalog(workspaceId));
+  ipcMain.handle('loadouts:setFavorite', (_e, id: string, on: boolean) => setFavorite(id, on));
 
   // App-level settings. The fleet root is the single host dir holding every
   // workspace's private folder (<root>/<id>) plus the shared folder

--- a/src/main/loadoutCatalog.ts
+++ b/src/main/loadoutCatalog.ts
@@ -1,0 +1,29 @@
+// Assemble the loadout catalog for the renderer (browser modal + rail). Phase 1
+// is local-only: the local library + the target workspace's installed set +
+// global favorites, with no remote sources (assembleCatalog `remote` is []).
+// Pure assembly lives in ociCore.ts:assembleCatalog; this is the I/O glue.
+
+import { listLoadouts } from './loadouts.js';
+import { getFavorites } from './config.js';
+import { readWorkspaceManifest } from './workspaces.js';
+import { assembleCatalog, type CatalogEntry, type LocalLoadout, type InstalledRef } from './ociCore.js';
+
+export async function buildLoadoutCatalog(workspaceId?: string): Promise<CatalogEntry[]> {
+  const [summaries, favorites] = await Promise.all([listLoadouts(), getFavorites()]);
+  const local: LocalLoadout[] = summaries.map((s) => ({
+    id: s.id,
+    title: s.title,
+    description: s.description,
+    tags: s.tags
+    // version omitted — local list carries none; update detection is Phase 2.
+  }));
+  let installed: InstalledRef[] = [];
+  if (workspaceId) {
+    const ws = await readWorkspaceManifest(workspaceId);
+    installed = (ws?.installedLoadouts ?? []).map((l) => ({
+      id: l.id,
+      version: (l as { version?: string }).version
+    }));
+  }
+  return assembleCatalog({ local, installed, favorites });
+}

--- a/src/main/ociCore.test.ts
+++ b/src/main/ociCore.test.ts
@@ -12,6 +12,7 @@ import {
   compareVersions,
   isUpdateAvailable,
   assembleCatalog,
+  toggleFavorite,
   SUPPORTED_REGISTRY
 } from './ociCore.js';
 
@@ -169,6 +170,19 @@ describe('ociClient (GHCR pull)', () => {
   it.todo('pulls every layer blob by digest and reconstructs the tree from layer titles');
   it.todo('routes every layer write through safeLayerPath and aborts the pull on a traversal title');
   it.todo('enforces a per-blob size cap');
+});
+
+describe('toggleFavorite', () => {
+  it('adds an id (idempotent) and removes it, de-duplicating', () => {
+    expect(toggleFavorite([], 'a', true)).toEqual(['a']);
+    expect(toggleFavorite(['a'], 'a', true)).toEqual(['a']); // idempotent add
+    expect(toggleFavorite(['a', 'b'], 'a', false)).toEqual(['b']);
+    expect(toggleFavorite(['a'], 'z', false)).toEqual(['a']); // remove absent = no-op
+  });
+
+  it('preserves existing order and appends new ids', () => {
+    expect(toggleFavorite(['b', 'a'], 'c', true)).toEqual(['b', 'a', 'c']);
+  });
 });
 
 // ── Source + provenance + favorites layer (loadoutSources.ts) — to implement ──

--- a/src/main/ociCore.ts
+++ b/src/main/ociCore.ts
@@ -230,3 +230,12 @@ export function assembleCatalog(args: {
 
   return [...map.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
+
+/** Add or remove `id` from a favorites list, returning a new de-duplicated array.
+ *  Adding is idempotent; removing an absent id is a no-op. Existing order is
+ *  preserved and a newly-added id is appended. */
+export function toggleFavorite(favorites: string[], id: string, on: boolean): string[] {
+  const set = favorites.filter((f) => f !== id);
+  if (on) set.push(id);
+  return set;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -328,7 +328,27 @@ const api = {
     install: (workspaceId: string, loadoutId: string): Promise<unknown> =>
       ipcRenderer.invoke('loadouts:install', workspaceId, loadoutId),
     uninstall: (workspaceId: string, loadoutId: string): Promise<void> =>
-      ipcRenderer.invoke('loadouts:uninstall', workspaceId, loadoutId)
+      ipcRenderer.invoke('loadouts:uninstall', workspaceId, loadoutId),
+    catalog: (
+      workspaceId?: string
+    ): Promise<
+      Array<{
+        id: string;
+        title: string;
+        description: string;
+        tags: string[];
+        version: string;
+        remoteVersion?: string;
+        present: boolean;
+        installed: boolean;
+        installedVersion?: string;
+        updateAvailable: boolean;
+        favorited: boolean;
+        sources: string[];
+      }>
+    > => ipcRenderer.invoke('loadouts:catalog', workspaceId),
+    setFavorite: (id: string, on: boolean): Promise<string[]> =>
+      ipcRenderer.invoke('loadouts:setFavorite', id, on)
   },
   config: {
     /** App-level settings: the fleet root, its derived shared folder, and the

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -10,6 +10,7 @@ import { CloseWorkspaceModal } from './components/CloseWorkspaceModal';
 import { DeleteWorkspaceModal } from './components/DeleteWorkspaceModal';
 import { EditWorkspaceModal, containerLevelChanged } from './components/EditWorkspaceModal';
 import { SettingsModal } from './components/SettingsModal';
+import LoadoutBrowserModal from './components/LoadoutBrowserModal';
 import { useDropIngestion } from './dropIngestion';
 import { contextBarSummary } from './contextBarSource';
 import { busyClaudeIdSet } from './busySessions';
@@ -156,6 +157,7 @@ export function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [browseOpen, setBrowseOpen] = useState(false);
   // Observability rail collapse, persisted across restarts (pure UI pref —
   // localStorage, not the main-side config.json).
   const [obsCollapsed, setObsCollapsed] = useState(
@@ -937,6 +939,7 @@ export function App() {
           onResume={handleResumeSession}
           onChanged={refresh}
           onLoadoutInstalled={handleLoadoutInstalled}
+          onBrowse={() => setBrowseOpen(true)}
         />
 
         <main
@@ -1104,6 +1107,13 @@ export function App() {
           />
         );
       })()}
+      {browseOpen && (
+        <LoadoutBrowserModal
+          workspace={selectedWorkspace}
+          onClose={() => setBrowseOpen(false)}
+          onChanged={() => void refresh()}
+        />
+      )}
       {dragging && (
         <div className="drop-overlay" aria-hidden="true">
           <div className="drop-overlay-card">

--- a/src/renderer/src/components/LeftRail.tsx
+++ b/src/renderer/src/components/LeftRail.tsx
@@ -24,6 +24,8 @@ interface Props {
   collapsed: boolean;
   /** Toggle the collapsed state (persisted by App.tsx). */
   onToggleCollapse: () => void;
+  /** Open the full loadout browser modal. */
+  onBrowse?: () => void;
 }
 
 interface OpenState {
@@ -54,7 +56,8 @@ export function LeftRail({
   onChanged,
   onLoadoutInstalled,
   collapsed,
-  onToggleCollapse
+  onToggleCollapse,
+  onBrowse
 }: Props) {
   const [open, setOpen] = useState<OpenState>(loadOpen);
   const toggle = (k: keyof OpenState): void =>
@@ -131,6 +134,7 @@ export function LeftRail({
             selectedWorkspace={selectedWorkspace}
             onChanged={onChanged}
             onInstalled={onLoadoutInstalled}
+            onBrowse={onBrowse}
           />
         )}
       </section>

--- a/src/renderer/src/components/LibraryPane.tsx
+++ b/src/renderer/src/components/LibraryPane.tsx
@@ -3,16 +3,11 @@
 // into the selected workspace. Clicking a card opens the review modal; an
 // installed card offers a ⋮ → Uninstall shortcut.
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { WorkspaceSummary } from '../App';
 import { LoadoutReviewModal } from './LoadoutReviewModal';
 
-interface LoadoutSummary {
-  id: string;
-  title: string;
-  description: string;
-  tags: string[];
-}
+type Entry = Awaited<ReturnType<typeof window.api.loadouts.catalog>>[number];
 
 /** localStorage key for the set of collapsed loadout ids (default: expanded). */
 const COLLAPSE_KEY = 'loadoutLibraryCollapsed';
@@ -23,13 +18,16 @@ interface Props {
   onChanged: () => void;
   /** A loadout finished installing into this workspace (#16 auto-reload). */
   onInstalled?: (workspaceId: string) => void;
+  /** Open the browse-all / OCI registry browser (wired in Task 6). */
+  onBrowse?: () => void;
 }
 
-export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props) {
-  const [loadouts, setLoadouts] = useState<LoadoutSummary[]>([]);
+export function LibraryPane({ selectedWorkspace, onChanged, onInstalled, onBrowse }: Props) {
+  const [entries, setEntries] = useState<Entry[]>([]);
   const [query, setQuery] = useState('');
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [tagMenu, setTagMenu] = useState(false);
+  const [favOnly, setFavOnly] = useState(false);
   const [reviewId, setReviewId] = useState<string | null>(null);
   const [menuId, setMenuId] = useState<string | null>(null);
   // Per-card collapse — cards default expanded; the set holds collapsed ids,
@@ -60,16 +58,21 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
       return next;
     });
 
+  const reload = useCallback(async () => {
+    try {
+      setEntries(await window.api.loadouts.catalog(selectedWorkspace?.id));
+    } catch {
+      setEntries([]);
+    }
+  }, [selectedWorkspace?.id]);
+
   useEffect(() => {
-    window.api.loadouts
-      .list()
-      .then((l) => setLoadouts(l as LoadoutSummary[]))
-      .catch(() => setLoadouts([]));
-  }, []);
+    void reload();
+  }, [reload]);
 
   const installedIds = useMemo(
-    () => new Set((selectedWorkspace?.installedLoadouts ?? []).map((l) => l.id)),
-    [selectedWorkspace]
+    () => new Set(entries.filter((e) => e.installed).map((e) => e.id)),
+    [entries]
   );
   const installable =
     !!selectedWorkspace &&
@@ -79,26 +82,27 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
 
   const allTags = useMemo(() => {
     const c = new Map<string, number>();
-    for (const l of loadouts) for (const t of l.tags) c.set(t, (c.get(t) ?? 0) + 1);
+    for (const e of entries) for (const t of e.tags) c.set(t, (c.get(t) ?? 0) + 1);
     return [...c.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-  }, [loadouts]);
+  }, [entries]);
 
   const toggleTag = (t: string): void =>
     setActiveTags((p) => (p.includes(t) ? p.filter((x) => x !== t) : [...p, t]));
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return loadouts.filter((l) => {
+    return entries.filter((e) => {
+      if (favOnly && !e.favorited) return false;
       const matchesQ =
-        !q || l.title.toLowerCase().includes(q) || l.description.toLowerCase().includes(q);
-      const matchesTags = activeTags.length === 0 || activeTags.some((t) => l.tags.includes(t));
+        !q || e.title.toLowerCase().includes(q) || e.description.toLowerCase().includes(q);
+      const matchesTags = activeTags.length === 0 || activeTags.some((t) => e.tags.includes(t));
       return matchesQ && matchesTags;
     });
-  }, [loadouts, query, activeTags]);
+  }, [entries, query, activeTags, favOnly]);
 
   // Header toggle, scoped to the visible (filtered) cards: collapse them all
   // when most are open, otherwise expand them all.
-  const visibleIds = filtered.map((l) => l.id);
+  const visibleIds = filtered.map((e) => e.id);
   const mostlyExpanded =
     visibleIds.filter((id) => collapsed.has(id)).length <= visibleIds.length / 2;
   const bulkToggle = (): void =>
@@ -115,11 +119,13 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
     await window.api.loadouts.install(selectedWorkspace.id, id);
     onChanged();
     onInstalled?.(selectedWorkspace.id);
+    void reload();
   };
   const doUninstall = async (id: string): Promise<void> => {
     if (!selectedWorkspace) return;
     await window.api.loadouts.uninstall(selectedWorkspace.id, id);
     onChanged();
+    void reload();
   };
 
   const note = !installable
@@ -141,6 +147,9 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Search loadouts"
         />
+        <button type="button" className="btn btn-sm lib-browse" onClick={() => onBrowse?.()}>
+          Browse all
+        </button>
       </div>
 
       <div className="library-filter">
@@ -151,13 +160,22 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
         >
           Tags ▾
         </button>
+        <button
+          type="button"
+          className={`fav-filter ${favOnly ? 'on' : ''}`}
+          aria-pressed={favOnly}
+          title="Show favorites only"
+          onClick={() => setFavOnly((v) => !v)}
+        >
+          {favOnly ? '★' : '☆'}
+        </button>
         {activeTags.map((t) => (
           <button key={t} className="pill" onClick={() => toggleTag(t)} title="Remove filter">
             {t} ✕
           </button>
         ))}
         <span className="nofm">
-          {filtered.length} of {loadouts.length}
+          {filtered.length} of {entries.length}
         </span>
         {tagMenu && (
           <div className="tag-menu" onMouseLeave={() => setTagMenu(false)}>
@@ -194,50 +212,50 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
 
       <div className="library-cards">
         {filtered.length === 0 && <div className="pane-placeholder subdued">No loadouts match.</div>}
-        {filtered.map((l) => {
-          const inst = installedIds.has(l.id);
-          const isCollapsed = collapsed.has(l.id);
+        {filtered.map((e) => {
+          const inst = installedIds.has(e.id);
+          const isCollapsed = collapsed.has(e.id);
           return (
             <div
-              key={l.id}
+              key={e.id}
               className={`loadout-card ${inst ? 'installed' : ''} ${isCollapsed ? 'collapsed' : ''}`}
-              onClick={() => setReviewId(l.id)}
+              onClick={() => setReviewId(e.id)}
             >
               <div className="lc-top">
                 <div className="lc-title">
                   <button
                     type="button"
                     className="lc-chevron"
-                    aria-label={isCollapsed ? `Expand ${l.title}` : `Collapse ${l.title}`}
+                    aria-label={isCollapsed ? `Expand ${e.title}` : `Collapse ${e.title}`}
                     aria-expanded={!isCollapsed}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      toggleCollapse(l.id);
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      toggleCollapse(e.id);
                     }}
                   >
                     <ChevronIcon />
                   </button>
-                  <span className="lc-title-text">{l.title}</span>
+                  <span className="lc-title-text">{e.title}</span>
                 </div>
-                <div className="lc-actions" onClick={(e) => e.stopPropagation()}>
+                <div className="lc-actions" onClick={(ev) => ev.stopPropagation()}>
                   {inst ? (
                     <>
-                      <button className="btn installed btn-sm" onClick={() => setReviewId(l.id)}>
+                      <button className="btn installed btn-sm" onClick={() => setReviewId(e.id)}>
                         ✓ Installed
                       </button>
                       <button
                         className="lc-menu-trigger"
                         aria-label="Loadout actions"
-                        onClick={() => setMenuId((m) => (m === l.id ? null : l.id))}
+                        onClick={() => setMenuId((m) => (m === e.id ? null : e.id))}
                       >
                         ⋮
                       </button>
-                      {menuId === l.id && (
+                      {menuId === e.id && (
                         <div className="lc-menu" onMouseLeave={() => setMenuId(null)}>
                           <button
                             onClick={() => {
                               setMenuId(null);
-                              setReviewId(l.id);
+                              setReviewId(e.id);
                             }}
                           >
                             Review
@@ -246,7 +264,7 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
                             className="danger"
                             onClick={() => {
                               setMenuId(null);
-                              void doUninstall(l.id);
+                              void doUninstall(e.id);
                             }}
                           >
                             Uninstall
@@ -258,22 +276,35 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
                     <button
                       className="btn primary btn-sm"
                       disabled={!installable}
-                      onClick={() => void doInstall(l.id)}
+                      onClick={() => void doInstall(e.id)}
                     >
                       + Install
                     </button>
                   )}
                 </div>
               </div>
-              {!isCollapsed && l.description && <div className="lc-desc">{l.description}</div>}
-              {!isCollapsed && l.tags.length > 0 && (
+              {!isCollapsed && e.description && <div className="lc-desc">{e.description}</div>}
+              {!isCollapsed && e.tags.length > 0 && (
                 <div className="tags">
-                  {l.tags.map((t) => (
+                  {e.tags.map((t) => (
                     <span className="tag" key={t}>
                       {t}
                     </span>
                   ))}
                 </div>
+              )}
+              {!isCollapsed && (
+                <button
+                  type="button"
+                  className={`lc-fav ${e.favorited ? 'on' : ''}`}
+                  onClick={async (ev) => {
+                    ev.stopPropagation();
+                    await window.api.loadouts.setFavorite(e.id, !e.favorited);
+                    void reload();
+                  }}
+                >
+                  {e.favorited ? '★ Favorited' : '☆ Favorite'}
+                </button>
               )}
             </div>
           );
@@ -291,8 +322,12 @@ export function LibraryPane({ selectedWorkspace, onChanged, onInstalled }: Props
           onInstalled={() => {
             onChanged();
             if (selectedWorkspace) onInstalled?.(selectedWorkspace.id);
+            void reload();
           }}
-          onUninstalled={onChanged}
+          onUninstalled={() => {
+            onChanged();
+            void reload();
+          }}
         />
       )}
     </div>

--- a/src/renderer/src/components/LoadoutBrowserModal.tsx
+++ b/src/renderer/src/components/LoadoutBrowserModal.tsx
@@ -17,7 +17,11 @@ export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: P
   const [entries, setEntries] = useState<Entry[]>([]);
   const [query, setQuery] = useState('');
   const [activeTags, setActiveTags] = useState<string[]>([]);
-  const installable = !!workspace && workspace.kind === 'container' && !!workspace.containerId;
+  const installable =
+    !!workspace &&
+    workspace.kind === 'container' &&
+    (workspace.state === 'running' || workspace.state === 'paused') &&
+    !!workspace.containerId;
 
   const reload = useCallback(async () => {
     setEntries(await window.api.loadouts.catalog(workspace?.id));
@@ -40,7 +44,8 @@ export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: P
     setActiveTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
 
   const onInstall = async (id: string): Promise<void> => {
-    if (workspace) await window.api.loadouts.install(workspace.id, id);
+    if (!workspace) return;
+    await window.api.loadouts.install(workspace.id, id);
     onChanged();
     void reload();
   };

--- a/src/renderer/src/components/LoadoutBrowserModal.tsx
+++ b/src/renderer/src/components/LoadoutBrowserModal.tsx
@@ -1,0 +1,121 @@
+// Full-catalog browse modal (#16 Phase 1). Facet sidebar (tag cloud + search)
+// + results list with install / favorite actions. Phase 2 will add source
+// checkboxes and the Update ↑ affordance — those are deliberately omitted here.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { WorkspaceSummary } from '../App';
+
+type Entry = Awaited<ReturnType<typeof window.api.loadouts.catalog>>[number];
+
+interface Props {
+  workspace: WorkspaceSummary | null;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: Props): React.JSX.Element {
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [query, setQuery] = useState('');
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const installable = !!workspace && workspace.kind === 'container' && !!workspace.containerId;
+
+  const reload = useCallback(async () => {
+    setEntries(await window.api.loadouts.catalog(workspace?.id));
+  }, [workspace?.id]);
+  useEffect(() => { void reload(); }, [reload]);
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of entries) for (const t of e.tags) set.add(t);
+    return [...set].sort();
+  }, [entries]);
+
+  const filtered = entries.filter((e) => {
+    if (activeTags.length && !activeTags.every((t) => e.tags.includes(t))) return false;
+    if (query && !`${e.title} ${e.description}`.toLowerCase().includes(query.toLowerCase())) return false;
+    return true;
+  });
+
+  const toggleTag = (t: string): void =>
+    setActiveTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
+
+  const onInstall = async (id: string): Promise<void> => {
+    if (workspace) await window.api.loadouts.install(workspace.id, id);
+    onChanged();
+    void reload();
+  };
+  const onFav = async (e: Entry): Promise<void> => {
+    await window.api.loadouts.setFavorite(e.id, !e.favorited);
+    void reload();
+  };
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal loadout-browser" onClick={(ev) => ev.stopPropagation()}>
+        <div className="lb-head">
+          <span className="eyebrow">Loadouts · browse</span>
+          <button className="btn btn-sm" onClick={onClose}>Close</button>
+        </div>
+        <div className="lb-body">
+          <aside className="lb-facets">
+            <input
+              className="lb-search"
+              placeholder="Search loadouts…"
+              value={query}
+              onChange={(ev) => setQuery(ev.target.value)}
+            />
+            <div className="lb-tagcloud">
+              {allTags.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  className={`lb-tag ${activeTags.includes(t) ? 'on' : ''}`}
+                  onClick={() => toggleTag(t)}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </aside>
+          <ul className="lb-results">
+            {filtered.map((e) => (
+              <li key={e.id} className="lb-row">
+                <div className="lb-row-main">
+                  <span className="lb-row-title">{e.title}</span>
+                  {e.tags.length > 0 && (
+                    <span className="tags">
+                      {e.tags.map((t) => <span className="tag" key={t}>{t}</span>)}
+                    </span>
+                  )}
+                  {e.description && <span className="lb-row-desc">{e.description}</span>}
+                </div>
+                <div className="lb-row-actions">
+                  <button
+                    type="button"
+                    className={`lc-fav ${e.favorited ? 'on' : ''}`}
+                    title="Favorite"
+                    onClick={() => void onFav(e)}
+                  >
+                    {e.favorited ? '★' : '☆'}
+                  </button>
+                  {e.installed ? (
+                    <button className="btn installed btn-sm" disabled>✓ Installed</button>
+                  ) : (
+                    <button
+                      className="btn primary btn-sm"
+                      disabled={!installable}
+                      onClick={() => void onInstall(e.id)}
+                    >
+                      + Install
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+            {filtered.length === 0 && <li className="lb-empty">No loadouts match.</li>}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -2983,3 +2983,26 @@ button.obs-ws-row:hover .obs-ws-icon { opacity: 1; color: var(--ink); }
   padding: 10px 11px; margin-bottom: 12px; max-height: 160px; overflow: auto;
 }
 .lr-foot { display: flex; justify-content: flex-end; gap: 9px; margin-top: 6px; padding-top: 14px; border-top: 1px solid var(--rule); }
+
+/* Loadout favorites + browser (library v2 Phase 1) */
+.fav-filter { padding: 3px 8px; font-size: 13px; border: 1px solid var(--rule); border-radius: var(--r-sm); background: var(--bg-3); color: var(--ink-2); cursor: pointer; }
+.fav-filter.on { color: var(--ok); border-color: var(--ok); }
+.lc-fav { align-self: flex-start; padding: 2px 7px; font-size: 11px; background: none; border: 1px solid var(--rule); border-radius: var(--r-sm); color: var(--ink-2); cursor: pointer; }
+.lc-fav.on { color: var(--ok); border-color: var(--ok); }
+.lib-browse { margin-left: auto; }
+
+.modal.loadout-browser { width: 720px; max-width: 94vw; max-height: 86vh; display: flex; flex-direction: column; }
+.lb-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.lb-body { display: grid; grid-template-columns: 200px 1fr; gap: 14px; min-height: 0; overflow: hidden; }
+.lb-facets { display: flex; flex-direction: column; gap: 10px; }
+.lb-search { width: 100%; }
+.lb-tagcloud { display: flex; flex-wrap: wrap; gap: 5px; }
+.lb-tag { padding: 2px 8px; font-size: 11px; border: 1px solid var(--rule); border-radius: 999px; background: var(--bg-3); color: var(--ink-2); cursor: pointer; }
+.lb-tag.on { color: var(--ok); border-color: var(--ok); }
+.lb-results { list-style: none; margin: 0; padding: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; }
+.lb-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; padding: 8px; border: 1px solid var(--rule); border-radius: var(--r-md); background: var(--bg-3); }
+.lb-row-main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.lb-row-title { font-weight: 600; color: var(--ink); }
+.lb-row-desc { font-size: 11px; color: var(--ink-2); }
+.lb-row-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.lb-empty { color: var(--ink-2); font-size: 12px; padding: 8px; }

--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -174,6 +174,19 @@ export interface MockOpts {
   // Fleet root returned from config:get (sharedDir is `${fleetRoot}/shared`).
   // Defaults to /tmp/fleet.
   fleetRoot?: string;
+  // Loadout catalog entries returned from loadouts:catalog. Defaults to [].
+  loadoutCatalog?: Array<{
+    id: string;
+    title: string;
+    description: string;
+    tags: string[];
+    version: string;
+    present: boolean;
+    installed: boolean;
+    updateAvailable: boolean;
+    favorited: boolean;
+    sources: string[];
+  }>;
 }
 
 export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {}): Promise<void> {
@@ -193,7 +206,8 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       openPath: [],
       setFleetRoot: [],
       vaultSetSecret: [],
-      vaultDeleteAllForWorkspace: []
+      vaultDeleteAllForWorkspace: [],
+      setFavorite: []
     };
 
     const channels = [
@@ -223,7 +237,9 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       'observability:summaryForWorkspace',
       'observability:summaryForBrokerSession',
       'observability:getCost',
-      'observability:getCostForWorkspace'
+      'observability:getCostForWorkspace',
+      'loadouts:catalog',
+      'loadouts:setFavorite'
     ];
     for (const ch of channels) {
       try {
@@ -406,6 +422,15 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
         return null;
       }
     );
+    // Loadout catalog + favorites mocks. Return the caller's catalog (defaults
+    // to []) and record setFavorite calls for assertion.
+    const catalog = opts.loadoutCatalog ?? [];
+    ipcMain.handle('loadouts:catalog', () => catalog);
+    ipcMain.handle('loadouts:setFavorite', (_e, id: string, on: boolean) => {
+      g.__calls.setFavorite.push({ id, on });
+      return undefined;
+    });
+
     // Cost endpoints used by the sessions table and detail views;
     // return zeroed data for tests that don't care.
     const zeroCost = {

--- a/tests/loadout-library.spec.ts
+++ b/tests/loadout-library.spec.ts
@@ -4,7 +4,7 @@
 // loadout via the left-rail Library accordion.
 
 import { test, expect } from '@playwright/test';
-import { launch } from './_helpers.js';
+import { launch, mockMainIpc, getCalls } from './_helpers.js';
 
 test('Library: accordion lists starters, search filters, install + uninstall round-trip (#16)', async () => {
   const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
@@ -108,6 +108,157 @@ test('Library: per-card chevron + Collapse all / Expand all (view A)', async () 
     // Expand all → descriptions return.
     await window.getByRole('button', { name: /Expand all/ }).click();
     expect(await window.locator('.loadout-card .lc-desc').count()).toBe(descCount);
+  } finally {
+    await app.close();
+  }
+});
+
+// ── Library v2 Phase 1: favorites + browse modal ─────────────────────────────
+// These tests use mockMainIpc so they don't rely on seeded built-in starters or
+// Docker. They exercise: the .lc-fav favorite toggle wires loadouts:setFavorite
+// IPC, the .fav-filter hides non-favorited entries, and .lib-browse opens the
+// LoadoutBrowserModal (.modal.loadout-browser) with the catalog entry visible.
+
+const PHASE1_ENTRY = {
+  id: 'spec-driven',
+  title: 'Spec-Driven',
+  description: 'Spec-driven dev workflow',
+  tags: ['workflow'],
+  version: '1.0.0',
+  present: true,
+  installed: false,
+  updateAvailable: false,
+  favorited: false,
+  sources: [],
+};
+
+test('Library v2: favorite toggle calls setFavorite IPC', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, {
+      workspaceList: [
+        {
+          id: 'ws-1',
+          name: 'test-workspace',
+          state: 'running',
+          workspaceRoot: '/workspace/test',
+          containerId: 'container-abc',
+          kind: 'container',
+        },
+      ],
+      loadoutCatalog: [PHASE1_ENTRY],
+    });
+
+    await window.waitForTimeout(400);
+
+    // Ensure Library accordion is open.
+    const libraryAccHeader = window.locator('.acc-header', { hasText: 'Library' });
+    await libraryAccHeader.waitFor({ state: 'visible', timeout: 8_000 });
+    const isExpanded = await libraryAccHeader.getAttribute('aria-expanded');
+    if (isExpanded !== 'true') {
+      await libraryAccHeader.click();
+      await window.waitForTimeout(200);
+    }
+
+    // The catalog entry should appear as a loadout card.
+    const card = window.locator('.loadout-card', { hasText: 'Spec-Driven' });
+    await card.waitFor({ state: 'visible', timeout: 8_000 });
+
+    // Click the .lc-fav button (visible on expanded cards).
+    const favBtn = card.locator('.lc-fav');
+    await favBtn.waitFor({ state: 'visible', timeout: 4_000 });
+    await favBtn.click();
+    await window.waitForTimeout(300);
+
+    // Assert loadouts:setFavorite was called with id='spec-driven', on=true.
+    const calls = await getCalls(app);
+    const favCalls = calls.setFavorite as Array<{ id: string; on: boolean }>;
+    expect(favCalls.length).toBeGreaterThanOrEqual(1);
+    expect(favCalls[favCalls.length - 1]).toMatchObject({ id: 'spec-driven', on: true });
+  } finally {
+    await app.close();
+  }
+});
+
+test('Library v2: favorites filter hides non-favorited entries', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, {
+      workspaceList: [],
+      loadoutCatalog: [PHASE1_ENTRY],
+    });
+
+    await window.waitForTimeout(400);
+
+    const libraryAccHeader = window.locator('.acc-header', { hasText: 'Library' });
+    await libraryAccHeader.waitFor({ state: 'visible', timeout: 8_000 });
+    const isExpanded = await libraryAccHeader.getAttribute('aria-expanded');
+    if (isExpanded !== 'true') {
+      await libraryAccHeader.click();
+      await window.waitForTimeout(200);
+    }
+
+    const card = window.locator('.loadout-card', { hasText: 'Spec-Driven' });
+    await card.waitFor({ state: 'visible', timeout: 8_000 });
+
+    const favFilter = window.locator('.fav-filter');
+    await favFilter.waitFor({ state: 'visible', timeout: 4_000 });
+
+    // Card is visible before filter is active.
+    await expect(card).toBeVisible();
+
+    // Activate the favorites filter — our entry is not favorited, so it should
+    // disappear and the "No loadouts match." placeholder should appear.
+    await favFilter.click();
+    await window.waitForTimeout(200);
+    await expect(favFilter).toHaveClass(/\bon\b/);
+    await expect(window.locator('.pane-placeholder', { hasText: 'No loadouts match.' })).toBeVisible();
+
+    // Deactivate the filter — card returns.
+    await favFilter.click();
+    await window.waitForTimeout(200);
+    await expect(favFilter).not.toHaveClass(/\bon\b/);
+    await expect(card).toBeVisible();
+  } finally {
+    await app.close();
+  }
+});
+
+test('Library v2: Browse-all button opens loadout browser modal', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, {
+      workspaceList: [],
+      loadoutCatalog: [PHASE1_ENTRY],
+    });
+
+    await window.waitForTimeout(400);
+
+    const libraryAccHeader = window.locator('.acc-header', { hasText: 'Library' });
+    await libraryAccHeader.waitFor({ state: 'visible', timeout: 8_000 });
+    const isExpanded = await libraryAccHeader.getAttribute('aria-expanded');
+    if (isExpanded !== 'true') {
+      await libraryAccHeader.click();
+      await window.waitForTimeout(200);
+    }
+
+    // The "Browse all" button has class .lib-browse and opens the modal.
+    const browseBtn = window.locator('.lib-browse');
+    await browseBtn.waitFor({ state: 'visible', timeout: 4_000 });
+    await browseBtn.click();
+
+    // LoadoutBrowserModal renders as .modal.loadout-browser.
+    const browserModal = window.locator('.modal.loadout-browser');
+    await browserModal.waitFor({ state: 'visible', timeout: 6_000 });
+
+    // The catalog entry should appear in the results list.
+    const browserRow = browserModal.locator('.lb-row', { hasText: 'Spec-Driven' });
+    await browserRow.waitFor({ state: 'visible', timeout: 4_000 });
+    await expect(browserRow.locator('.lb-row-title')).toContainText('Spec-Driven');
+
+    // Close the modal via the Close button.
+    await browserModal.locator('button', { hasText: 'Close' }).click();
+    await expect(browserModal).not.toBeVisible();
   } finally {
     await app.close();
   }

--- a/tests/loadout-library.spec.ts
+++ b/tests/loadout-library.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 import { launch, mockMainIpc, getCalls } from './_helpers.js';
 
 test('Library: accordion lists starters, search filters, install + uninstall round-trip (#16)', async () => {
-  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  const { app, window } = await launch();
   try {
     // Create a container workspace — install needs a manifest on disk to track.
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
@@ -48,7 +48,7 @@ test('Library: accordion lists starters, search filters, install + uninstall rou
 });
 
 test('Library: clicking a card opens the review with files + Install (#16)', async () => {
-  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  const { app, window } = await launch();
   try {
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
     await window.getByLabel('Workspace name').fill('lib-test2');
@@ -78,7 +78,7 @@ test('Library: clicking a card opens the review with files + Install (#16)', asy
 });
 
 test('Library: per-card chevron + Collapse all / Expand all (view A)', async () => {
-  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
+  const { app, window } = await launch();
   try {
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
     await window.getByLabel('Workspace name').fill('lib-collapse');

--- a/tests/loadout-library.spec.ts
+++ b/tests/loadout-library.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 import { launch, mockMainIpc, getCalls } from './_helpers.js';
 
 test('Library: accordion lists starters, search filters, install + uninstall round-trip (#16)', async () => {
-  const { app, window } = await launch();
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
   try {
     // Create a container workspace — install needs a manifest on disk to track.
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
@@ -48,7 +48,7 @@ test('Library: accordion lists starters, search filters, install + uninstall rou
 });
 
 test('Library: clicking a card opens the review with files + Install (#16)', async () => {
-  const { app, window } = await launch();
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
   try {
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
     await window.getByLabel('Workspace name').fill('lib-test2');
@@ -78,7 +78,7 @@ test('Library: clicking a card opens the review with files + Install (#16)', asy
 });
 
 test('Library: per-card chevron + Collapse all / Expand all (view A)', async () => {
-  const { app, window } = await launch();
+  const { app, window } = await launch({ CLAUDE_FLEET_MOCK: '1' });
   try {
     await window.locator('.top-strip').getByRole('button', { name: 'Add workspace' }).click();
     await window.getByLabel('Workspace name').fill('lib-collapse');


### PR DESCRIPTION
Closes #168.

Phase 1 of the loadout library v2 design — **local-only** (no network; Phase 2 adds remote OCI sources). Built subagent-driven from `docs/superpowers/plans/2026-06-28-loadout-library-v2-phase1.md`; per-task spec+quality reviews and a final whole-branch review all clean.

## What
- **Favorites (global):** pure `toggleFavorite` (`ociCore.ts`); `AppConfig.favorites` in `config.json` via `setFavorite`/`getFavorites`.
- **Catalog:** `buildLoadoutCatalog(workspaceId?)` (`loadoutCatalog.ts`) reuses the unit-tested pure `assembleCatalog` (local library + workspace installed set + favorites; `remote: []`).
- **IPC:** `loadouts:catalog` + `loadouts:setFavorite` + preload methods. MCP server untouched (stays read-only).
- **Rail (`LibraryPane`):** catalog-backed data, expanded-card ★ favorite toggle, favorites-only filter, "Browse all" entry point. Existing behavior (search, tags, collapse, install/uninstall, review modal) preserved.
- **Browser modal (`LoadoutBrowserModal`):** facet sidebar (search + tag cloud — no source checkboxes, that's Phase 2), rows with favorite ★ + Install/Installed (install gated by the same predicate as the rail).
- Styles, e2e (`tests/loadout-library.spec.ts` + `_helpers` catalog mock), SPEC §7/§11.

## Phase boundary
No network, no `ociClient`/`loadoutSources`, no source checkboxes, no `Update ↑` affordance — the catalog shape already carries `updateAvailable`/`remoteVersion`/`sources` so Phase 2 is additive.

## Tests
Local: typecheck ✅, 253 unit ✅ (+14 `it.todo` Phase-2 stubs), build ✅. E2e runs on CI (Electron can't launch in the dev sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)