### PR TITLE
Close out ai_title

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -420,14 +420,16 @@ CREATE TABLE sessions (
   cwd TEXT,                            -- from first `system` event carrying it
   started_at INTEGER,                  -- first event ts
   last_active_at INTEGER,              -- max(event ts)
-  ai_title TEXT,                       -- latest `ai-title.aiTitle` (dormant — no producer yet)
-  first_user_message TEXT,             -- last-prompt or first user.content
+  ai_title TEXT,                       -- latest `ai-title.aiTitle`; Claude Code emits these lines natively (see below)
+  first_user_message TEXT,             -- last-prompt or first user.content; synthetic command-wrapper messages skipped
   user_set_name TEXT                   -- manual override set via sessions:rename
 );
 CREATE INDEX idx_sessions_workspace ON sessions(workspace_id);
 ```
 
 This `sessions` table is the index behind the Sessions table feature (§6 *Sessions*, §8 *Browse & resume a past session*): `listSessions` reads it (joined to a grouped `events` pass for cost + event count), `renameSession` sets `user_set_name`, and `deleteSession` removes the session's rows here + in `events`/`broker_sessions` before the IPC layer unlinks the JSONL.
+
+**Title derivation.** The display title is `user_set_name ?? ai_title ?? first_user_message`. `ai_title` is **populated, not dormant** — Claude Code (≥2.1.x) writes `{"type":"ai-title","aiTitle":…,"sessionId":…}` lines into its own transcript natively (no hook, no statusline), and `ingestLine` folds the latest into `sessions.ai_title`. This rides on an **undocumented native transcript line type**, so it is the kind of thing a `claude` pin bump can silently break (§4 — bumping the pin is deliberate; re-verify the `ai-title` line still appears). `first_user_message` is the COALESCE'd first value, but **synthetic command-wrapper messages are skipped** when deriving it (`src/main/userPromptText.ts`): a session started with a slash command (e.g. `/clear`) emits a wrapper-only first `user` message (`<local-command-caveat>`/`<command-name>`/…) that would otherwise lock in as a junk fallback title; the first *real* prompt wins instead. `tests/ai-title.spec.ts` pins both behaviors against the real watcher + DB.
 
 **Why these design choices:**
 - **Unique `(session_id, dedup_key)`** makes ingestion idempotent. Re-tailing a JSONL from byte 0 (after crash, after losing in-memory offsets) produces no duplicates: heavy events use their `uuid` as the key; light events without a `uuid` use a SHA-256 hash of the raw line. Insert uses `INSERT OR IGNORE`.
@@ -761,7 +763,7 @@ Per-session cost and token counts derived from Claude transcript JSONL events. *
 **Resume mechanism.** The host knows the Claude session UUID up front, so the broker→claude mapping is written **directly** at attach time rather than via the watcher's pending-attach queue — `claude --resume` appends to the existing `<uuid>.jsonl`, so no `new-session` event ever fires. The broker gained an optional `args` field on `CREATE` (`broker/internal/proto`) threaded through `Manager.Create` → `newSession` → `exec.Command(claude, args...)`; the host passes `["--resume", "<uuid>"]`.
 
 **Open (residual):**
-- **Auto-title (`ai_title`).** The column + ingest hook (`type: 'ai-title'`) exist but nothing populates them yet — the display title currently falls back to the first user message. An LLM-generated short description is the intended occupant; open questions: which model, when (on first surface? on significant `last_active_at` advance?), and how much transcript to feed it. This is the natural consumer of the future meta-observability LLM-parsing layer (see *Permission-request log*).
+- **Auto-title (`ai_title`) — shipped, not an LLM build.** This was once an open question ("which model / when / how much transcript"); it's moot. Claude Code emits `ai-title` transcript lines natively and the watcher already ingests them (§7 *JSONL→SQLite cache → Title derivation*), so titles are accurate with zero app-side LLM cost. The only residual is **fragility**: the title depends on an undocumented native transcript line type, so a `claude` pin bump should re-verify the `ai-title` line still appears (`tests/ai-title.spec.ts` is the guard). A future app-generated titler is unnecessary unless Claude Code stops emitting the line.
 - **In-progress sessions.** The list shows active sessions too (they refresh on every ingest push). No distinct "live row" affordance vs. ended sessions yet — tab-state richness is tracked under *Observability layer*.
 - **Deleting a live session's transcript.** `sessions:delete` unlinks the JSONL even if claude is still appending to it (rare — you'd be deleting the session you're in). On Linux the open fd keeps the inode alive, so claude keeps writing to the now-unlinked file until it reopens; the row reappears on the next new transcript. Acceptable for v1; revisit if it bites.
 

--- a/docs/superpowers/specs/2026-06-29-ai-title-closeout-design.md
+++ b/docs/superpowers/specs/2026-06-29-ai-title-closeout-design.md
@@ -1,0 +1,166 @@
+# Design: close out `ai_title`
+
+**Date:** 2026-06-29
+**Status:** approved (brainstorming) — pending implementation plan
+
+## Background
+
+`ai_title` was flagged as a "loose thread": the spec (§7, §11) describes the
+column as dormant — schema + ingest hook present, but "nothing populates them
+yet," with open questions about which model to use, when to title, and how much
+transcript to feed it.
+
+**That premise is stale.** Investigation against this dogfooding environment's
+live state DB shows the chain already works end-to-end:
+
+- Claude Code **2.1.177** (the pinned runner version) natively emits
+  `{"type":"ai-title","aiTitle":"…","sessionId":…}` lines into its own
+  transcript JSONL — verified with no hooks and no statusline configured.
+- `db.ts:317-318` already ingests that line into `sessions.ai_title`.
+- `db.ts:656-658` (`summaryFor*`) already prefers it:
+  `ai_title ?? first_user_message`.
+- A live `list_sessions` MCP query returned good titles for every session
+  (e.g. "Review Claude Fleet repository updates",
+  "Redesign Claude Fleet landing page as advertisement").
+
+So there is **no titler to build**. The work is to close the thread out
+honestly: correct the stale spec, lock the behavior in with a regression test
+(it rides on an *undocumented native CC line type*, so it is fragile across
+`claude` version bumps), and fix one latent bug surfaced along the way.
+
+## Goals
+
+1. Make `docs/SPEC.md` reflect reality: `ai_title` is populated natively, with a
+   fragility note tying re-verification to the `claude` version pin.
+2. Fix the `first_user_message` command-wrapper-noise bug.
+3. Add a regression test that fails if either the `ai-title` ingest→display path
+   or the noise filter regresses.
+
+## Non-goals
+
+- Building any LLM-based titler (Claude Code already produces the title).
+- Stripping synthetic blocks out of otherwise-real prompts ("aggressive strip").
+  We do conservative skip only — see Part 2.
+- Backfilling titles for historical sessions (they already have them; the DB is
+  rebuildable from JSONL regardless).
+
+## Part 1 — Fix the stale spec
+
+Two spots in `docs/SPEC.md` are now false and must be corrected in the same
+change (per `.claude/rules/spec-maintenance.md`):
+
+- **§7 JSONL→SQLite cache** — the `ai_title TEXT, -- latest \`ai-title.aiTitle\`
+  (dormant — no producer yet)` comment becomes a statement of fact: Claude Code
+  (≥2.1.x) writes `{type:"ai-title",aiTitle,sessionId}` lines natively; the
+  watcher ingests them into the column; `summaryFor*` prefers it over
+  `first_user_message`.
+- **§11 Sessions table → Open (residual)** — remove the "nothing populates them
+  yet / which model / when / how much transcript" bullet (moot). Replace with a
+  short **fragility note**: the title depends on an undocumented native CC
+  transcript line type, so bumping the `claude` pin (§4) should re-verify the
+  `ai-title` line still appears, the same "bumping the pin is deliberate"
+  discipline already documented for the PTY-navigation regression.
+- Tighten §7's `first_user_message` derivation note to record that synthetic
+  command-wrapper content is skipped (Part 2).
+
+These are descriptive edits only — no changelog prose, edit in place.
+
+## Part 2 — `first_user_message` noise fix
+
+### Root cause
+
+`updateSessionLastPrompt` is:
+
+```sql
+UPDATE sessions SET first_user_message = COALESCE(first_user_message, ?) WHERE id = ?
+```
+
+First non-null value wins, permanently. For a session started with `/clear`,
+the first string-content `user` message ingested is the command-wrapper blob
+(`<local-command-caveat>…</local-command-caveat>` + `<command-name>` etc.), so it
+locks in as `first_user_message`. The real prompt — which arrived cleanly on its
+own `last-prompt` line — never gets to win. `ai_title` masks this in the display,
+but any session lacking an `ai-title` line shows the wrapper noise as its title.
+
+### Fix
+
+- New **pure module** `src/main/userPromptText.ts` exporting
+  `isSyntheticPromptText(text: string): boolean`. Returns `true` when the
+  *trimmed* string **starts with** a known harness/slash-command wrapper tag.
+  Recognized set (conservative):
+  - `<local-command-caveat>`
+  - `<command-name>`
+  - `<command-message>`
+  - `<command-args>`
+  - `<local-command-stdout>`
+  - `<system-reminder>`
+- In `db.ts` `ingestLine`, guard **both** `updateSessionLastPrompt` calls with
+  `!isSyntheticPromptText(...)`:
+  - the `last-prompt` path (`parsed.lastPrompt`, ~:320)
+  - the `user` string-content path (`message.content`, ~:322)
+
+  so the first *real* prompt wins instead of a wrapper blob.
+
+### Behavior choice: conservative skip (approved)
+
+If a message *starts with* a wrapper tag, the **whole message is treated as
+noise and skipped** — `first_user_message` is left for the next real message to
+fill. We do **not** attempt to strip a wrapper block out of an otherwise-real
+prompt and keep the remainder. Rationale: the observed bug is an entirely-synthetic
+`/clear` message, which skip handles perfectly; the real prompt arrives separately
+and wins once the blob is skipped. Stripping is more code and risks mangling a
+legitimate prompt that contains angle-bracket text. The only case conservative
+skip loses is a session whose *very first* message is a real prompt with a wrapper
+glued on and no clean prompt anywhere else — and `ai_title` covers the display
+there anyway.
+
+### Testability
+
+`db.ts` imports `better-sqlite3` (native, Electron-ABI) and cannot run under
+vitest. `userPromptText.ts` is pure, so it is unit-tested directly in
+`src/main/userPromptText.test.ts`:
+
+- each wrapper blob (incl. leading whitespace) → `true`
+- ordinary prompts → `false`
+- a real prompt that merely *mentions* a `<tag>` mid-text → `false`
+- empty / whitespace-only string → its own defined result (treat as synthetic
+  so it never wins as a title)
+
+## Part 3 — regression test (e2e)
+
+Because the ingest→column→display path runs through `db.ts`, the regression test
+is Playwright, mirroring `tests/sessions-list.spec.ts` (seed a transcript JSONL on
+disk, launch the app without `CLAUDE_FLEET_MOCK`, let the real watcher ingest, read
+back through `window.api.sessions.list`).
+
+New focused spec `tests/ai-title.spec.ts`, one workspace, two seeded sessions:
+
+- **Session A** — lines in order: a synthetic wrapper `user` message (the
+  `/clear` blob), then a real `last-prompt` line, then an `ai-title` line, then an
+  `assistant` line. Assert on the `sessions:list` row:
+  - `aiTitle` === the seeded title
+  - `firstUserMessage` === the real prompt (**not** the wrapper blob)
+- **Session B** — same shape but **no** `ai-title` line. Assert:
+  - `aiTitle` === null
+  - `firstUserMessage` === the real prompt (noise still skipped)
+
+This pins both invariants: if a `claude` bump drops the `ai-title` line or an
+ingest refactor breaks the column, Session A fails; if the noise filter
+regresses, both fail.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/main/userPromptText.ts` | new pure module — `isSyntheticPromptText` |
+| `src/main/userPromptText.test.ts` | new vitest unit tests |
+| `src/main/db.ts` | guard both `updateSessionLastPrompt` calls |
+| `tests/ai-title.spec.ts` | new e2e regression (2 seeded sessions) |
+| `docs/SPEC.md` | §7 + §11 stale-note corrections + fragility note |
+
+## Verification
+
+- `npx vitest run src/main/userPromptText.test.ts` — unit green.
+- `npx playwright test tests/ai-title.spec.ts` — e2e green (needs a display).
+- `npm run typecheck` — both tsconfigs clean.
+- Spec re-read: §7 and §11 no longer describe `ai_title` as dormant.

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -14,6 +14,7 @@ import { dirname, join } from 'node:path';
 import Database from 'better-sqlite3';
 import { costFor } from './pricing.js';
 import { contextWindowFor } from './contextWindow.js';
+import { isSyntheticPromptText } from './userPromptText.js';
 
 let db: Database.Database | null = null;
 
@@ -316,9 +317,17 @@ export function ingestLine(
     s.updateSessionCwd.run(parsed.cwd, sessionId);
   } else if (type === 'ai-title' && typeof parsed.aiTitle === 'string') {
     s.updateSessionAiTitle.run(parsed.aiTitle, sessionId);
-  } else if (type === 'last-prompt' && typeof parsed.lastPrompt === 'string') {
+  } else if (
+    type === 'last-prompt' &&
+    typeof parsed.lastPrompt === 'string' &&
+    !isSyntheticPromptText(parsed.lastPrompt)
+  ) {
     s.updateSessionLastPrompt.run(parsed.lastPrompt, sessionId);
-  } else if (type === 'user' && typeof message?.content === 'string') {
+  } else if (
+    type === 'user' &&
+    typeof message?.content === 'string' &&
+    !isSyntheticPromptText(message.content)
+  ) {
     s.updateSessionLastPrompt.run(message.content, sessionId);
   }
 

--- a/src/main/userPromptText.test.ts
+++ b/src/main/userPromptText.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isSyntheticPromptText } from './userPromptText.js';
+
+describe('isSyntheticPromptText', () => {
+  it('flags messages that are entirely a command/harness wrapper', () => {
+    expect(
+      isSyntheticPromptText(
+        '<local-command-caveat>Caveat: messages below were generated while running local commands.</local-command-caveat>'
+      )
+    ).toBe(true);
+    expect(isSyntheticPromptText('<command-name>/clear</command-name>')).toBe(true);
+    expect(isSyntheticPromptText('<command-message>clear</command-message>')).toBe(true);
+    expect(isSyntheticPromptText('<command-args></command-args>')).toBe(true);
+    expect(isSyntheticPromptText('<local-command-stdout></local-command-stdout>')).toBe(true);
+    expect(isSyntheticPromptText('<system-reminder>As you answer…</system-reminder>')).toBe(true);
+  });
+
+  it('flags a wrapper even with leading whitespace', () => {
+    expect(isSyntheticPromptText('\n  \t<local-command-caveat>x</local-command-caveat>')).toBe(true);
+  });
+
+  it('flags empty / whitespace-only content (never a real title)', () => {
+    expect(isSyntheticPromptText('')).toBe(true);
+    expect(isSyntheticPromptText('   \n\t ')).toBe(true);
+  });
+
+  it('keeps an ordinary prompt', () => {
+    expect(
+      isSyntheticPromptText('I want you to look at claude fleet again and refresh your understanding.')
+    ).toBe(false);
+  });
+
+  it('keeps a real prompt that merely mentions a tag mid-text', () => {
+    expect(
+      isSyntheticPromptText('Why does the parser choke on a <system-reminder> tag in the input?')
+    ).toBe(false);
+  });
+});

--- a/src/main/userPromptText.ts
+++ b/src/main/userPromptText.ts
@@ -1,0 +1,30 @@
+/**
+ * Recognizes user-message text that is synthetic harness/slash-command wrapper
+ * content rather than a real prompt, so the JSONL ingest can skip it when
+ * deriving a session's `first_user_message` (see db.ts).
+ *
+ * A session started with a slash command (e.g. `/clear`) has its first
+ * string-content `user` message be an entirely-synthetic wrapper blob; because
+ * `first_user_message` is COALESCE'd (first value wins, permanently), that blob
+ * would otherwise lock in as the session's fallback title.
+ *
+ * Conservative by design: only a message that *starts with* a known wrapper tag
+ * (or is empty/whitespace) is treated as synthetic. A real prompt that merely
+ * mentions a tag mid-text is kept. We never try to strip a wrapper block out of
+ * an otherwise-real prompt.
+ */
+
+const WRAPPER_TAGS = [
+  '<local-command-caveat>',
+  '<command-name>',
+  '<command-message>',
+  '<command-args>',
+  '<local-command-stdout>',
+  '<system-reminder>',
+];
+
+export function isSyntheticPromptText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed === '') return true;
+  return WRAPPER_TAGS.some((tag) => trimmed.startsWith(tag));
+}

--- a/tests/ai-title.spec.ts
+++ b/tests/ai-title.spec.ts
@@ -1,0 +1,155 @@
+// ai_title ingest -> display, and the first_user_message noise skip, against
+// the real DB + watcher. Seed two workspaces-worth of transcript on disk,
+// launch the real app (no mock — mock disables the watcher + DB), and read the
+// session rows back through window.api.sessions.list.
+//
+// Regression net for two invariants:
+//  - Claude Code's native `ai-title` transcript line populates sessions.ai_title
+//    (the title rides on an undocumented native CC line type; a `claude` pin
+//    bump that drops it should fail here — see SPEC.md §7/§11).
+//  - A `/clear`-style synthetic command-wrapper user message is NOT captured as
+//    first_user_message; the first real prompt wins (userPromptText.ts).
+
+import { _electron as electron, test, expect, type Page } from '@playwright/test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { REPO_ROOT } from './_helpers.js';
+
+interface SessionListItem {
+  id: string;
+  workspaceId: string;
+  aiTitle: string | null;
+  firstUserMessage: string | null;
+}
+
+function listSessions(window: Page, workspaceId?: string): Promise<SessionListItem[]> {
+  return window.evaluate(
+    (wsId) =>
+      (window as unknown as {
+        api: { sessions: { list: (id?: string) => Promise<SessionListItem[]> } };
+      }).api.sessions.list(wsId),
+    workspaceId
+  );
+}
+
+const SYNTHETIC_USER_BLOB =
+  '<local-command-caveat>Caveat: messages below were generated while running ' +
+  'local commands. DO NOT respond to these.</local-command-caveat>\n' +
+  '<command-name>/clear</command-name>\n<command-message>clear</command-message>';
+
+const REAL_PROMPT_A = 'Investigate why the flaky test intermittently fails';
+const REAL_PROMPT_B = 'Add a retry around the network call';
+const AI_TITLE_A = 'Investigate flaky test failure';
+
+function writeWorkspace(userDataDir: string, wsId: string, name: string): string {
+  const stateDir = path.join(userDataDir, 'state', wsId);
+  const jsonlDir = path.join(stateDir, '.claude', 'projects', '-workspace');
+  mkdirSync(jsonlDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, 'workspace.json'),
+    JSON.stringify({
+      id: wsId,
+      name,
+      labels: [],
+      workspaceRoot: `/tmp/fleet-test-${name}`,
+      workspaceSubdir: '',
+      kind: 'container',
+      image: 'mock',
+      authMode: 'oauth',
+      env: { plain: {}, secretKeys: [] },
+      createdAt: Date.now(),
+      lastUsedAt: Date.now()
+    })
+  );
+  return jsonlDir;
+}
+
+function writeTranscript(jsonlDir: string, sessionId: string, lines: object[]): void {
+  writeFileSync(
+    path.join(jsonlDir, `${sessionId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join('\n') + '\n'
+  );
+}
+
+function userLine(content: string): object {
+  return { type: 'user', timestamp: new Date().toISOString(), message: { content } };
+}
+function assistantLine(): object {
+  return {
+    type: 'assistant',
+    timestamp: new Date().toISOString(),
+    message: {
+      model: 'claude-opus-4-8',
+      content: [],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        service_tier: 'standard'
+      }
+    }
+  };
+}
+
+test('ai-title populates the title; a synthetic command-wrapper is skipped for first_user_message', async () => {
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'claude-fleet-aititle-'));
+  // 26-char Crockford-base32 ids so the startup migration treats them as
+  // already-migrated and leaves the state dirs alone.
+  const wsId = '01TESTAITITLE0000000000000';
+
+  const jsonlDir = writeWorkspace(userDataDir, wsId, 'aititle-ws');
+
+  // Session A: synthetic wrapper first, then a real last-prompt, then ai-title.
+  const sessionA = '11111111-1111-4111-8111-111111111111';
+  writeTranscript(jsonlDir, sessionA, [
+    userLine(SYNTHETIC_USER_BLOB),
+    { type: 'last-prompt', lastPrompt: REAL_PROMPT_A, sessionId: sessionA },
+    { type: 'ai-title', aiTitle: AI_TITLE_A, sessionId: sessionA },
+    assistantLine()
+  ]);
+
+  // Session B: same noise, real prompt, but NO ai-title line.
+  const sessionB = '22222222-2222-4222-8222-222222222222';
+  writeTranscript(jsonlDir, sessionB, [
+    userLine(SYNTHETIC_USER_BLOB),
+    { type: 'last-prompt', lastPrompt: REAL_PROMPT_B, sessionId: sessionB },
+    assistantLine()
+  ]);
+
+  const app = await electron.launch({
+    args: [REPO_ROOT, `--user-data-dir=${userDataDir}`],
+    cwd: REPO_ROOT,
+    // Drop CLAUDE_FLEET_MOCK so the real watcher + DB run.
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([k]) => k !== 'CLAUDE_FLEET_MOCK')
+    ) as Record<string, string>
+  });
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  try {
+    await expect
+      .poll(async () => (await listSessions(window, wsId)).length, {
+        timeout: 8_000,
+        intervals: [200, 500, 1000]
+      })
+      .toBe(2);
+
+    const rows = await listSessions(window, wsId);
+    const a = rows.find((r) => r.id === sessionA);
+    const b = rows.find((r) => r.id === sessionB);
+
+    // Session A: ai-title populated the title; the synthetic blob was skipped.
+    expect(a?.aiTitle).toBe(AI_TITLE_A);
+    expect(a?.firstUserMessage).toBe(REAL_PROMPT_A);
+
+    // Session B: no ai-title -> null; the real prompt (not the blob) is the
+    // first_user_message fallback.
+    expect(b?.aiTitle).toBeNull();
+    expect(b?.firstUserMessage).toBe(REAL_PROMPT_B);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## What

`ai_title` was flagged as a dead-schema "loose thread." It isn't dead — **Claude Code 2.1.x (the pinned runner version) emits `ai-title` transcript lines natively**, the watcher already ingests them into `sessions.ai_title`, and `summaryFor*` already prefers it. Verified against this dogfooding environment's live state DB (`list_sessions` returned good titles for every session, e.g. "Review Claude Fleet repository updates"). The spec's §7/§11 "no producer yet / which model / when" notes were stale.

So there is no titler to build. This PR closes the thread honestly.

## Changes

1. **Stale spec fixed** — SPEC.md §7 (new *Title derivation* note) + §11 document `ai_title` as natively populated, with a **fragility note**: it rides on an undocumented native CC transcript line type, so a `claude` pin bump should re-verify the line still appears (ties into §4's "bumping the pin is deliberate" discipline).
2. **`first_user_message` noise fix** — `COALESCE(...)` locks in the *first* value, which for a `/clear`-started session is the command-wrapper blob (`<local-command-caveat>`/`<command-name>`/…). New pure `src/main/userPromptText.ts` (`isSyntheticPromptText`, **conservative skip** — flags only messages that *start with* a wrapper tag, or are empty) guards both `updateSessionLastPrompt` call sites in `db.ts`, so the first *real* prompt wins.
3. **Regression test** — `tests/ai-title.spec.ts` (Playwright, mirrors `sessions-list.spec.ts`) seeds two sessions to pin both the `ai-title` ingest→display path and the noise skip.

## Verification

- ✅ `npx vitest run src/main/userPromptText.test.ts` — 5/5 green (RED-first per TDD).
- ✅ `npm run typecheck` — both tsconfigs clean.
- ⚠️ `tests/ai-title.spec.ts` — **not executed locally**: the dev container has no C++ compiler (better-sqlite3/node-pty can't build) and no display, so Electron e2e can't run here. **Needs CI / a dev box with the toolchain + display to confirm green.**

Spec doc: `docs/superpowers/specs/2026-06-29-ai-title-closeout-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)