### PR TITLE
Fix #177: workspace chip reorder no-ops — dragover clobbers dropEffect

### DIFF
--- a/src/renderer/src/components/WorkspaceTabStrip.tsx
+++ b/src/renderer/src/components/WorkspaceTabStrip.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceObservabilitySummary } from '../../../preload';
 import { colorFor, type WorkspaceState, type WorkspaceSummary } from '../App';
 import { isManager, isReachable, ManagerGlyph, WifiGlyph } from './committee';
 import { useBlinkSync } from '../blinkSync';
+import { setInternalDragActive } from '../dropIngestion';
 
 /**
  * The chip's status dot. A separate component so the busy pulse can be
@@ -264,6 +265,10 @@ export function WorkspaceTabStrip({
           onDragStart={(e) => {
             setDragId(w.id);
             e.dataTransfer.effectAllowed = 'move';
+            // Tell the window-level file-ingestion handlers to stay out of this
+            // internal drag — otherwise its dragover forces dropEffect='copy'
+            // over our 'move' and cancels the reorder drop (#177).
+            setInternalDragActive(true);
           }}
           onDragOver={(e) => {
             if (dragId && dragId !== w.id) e.preventDefault(); // allow drop
@@ -272,8 +277,14 @@ export function WorkspaceTabStrip({
             e.preventDefault();
             if (dragId && dragId !== w.id) onReorderWorkspace(dragId, w.id);
             setDragId(null);
+            setInternalDragActive(false);
           }}
-          onDragEnd={() => setDragId(null)}
+          onDragEnd={() => {
+            setDragId(null);
+            // dragend always fires (drop or cancel), so this is the guaranteed
+            // clear; the onDrop clear above just frees it a beat earlier.
+            setInternalDragActive(false);
+          }}
         >
           <button
             className="ws-chip"

--- a/src/renderer/src/dropIngestion.test.ts
+++ b/src/renderer/src/dropIngestion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isExternalDrag } from './dropIngestion';
+import { isExternalDrag, shouldClaimDragOver } from './dropIngestion';
 
 describe('isExternalDrag', () => {
   // #147: an internal workspace-chip reorder drag carries effectAllowed='move'
@@ -27,5 +27,22 @@ describe('isExternalDrag', () => {
 
   it('ignores unrelated-only type lists', () => {
     expect(isExternalDrag(['application/x-internal-thing'])).toBe(false);
+  });
+});
+
+describe('shouldClaimDragOver', () => {
+  // #177: #147 stopped the overlay/drop from hijacking a chip reorder, but the
+  // window-level onDragOver still preventDefault'd and set dropEffect='copy'
+  // UNCONDITIONALLY — even for an internal chip drag. The chip drag carries
+  // effectAllowed='move', and 'copy' is incompatible with 'move', so Chromium
+  // computes the drag operation as none and never fires the chip's drop event:
+  // no overlay (good) but also no reorder. The window must NOT claim dragover
+  // while an internal drag is in flight, leaving the chip's 'move' to stand.
+  it('does NOT claim dragover while an internal chip drag is active', () => {
+    expect(shouldClaimDragOver(true)).toBe(false);
+  });
+
+  it('claims dragover for ordinary (external) drags so the copy cursor shows', () => {
+    expect(shouldClaimDragOver(false)).toBe(true);
   });
 });

--- a/src/renderer/src/dropIngestion.ts
+++ b/src/renderer/src/dropIngestion.ts
@@ -40,6 +40,33 @@ export function isExternalDrag(types: readonly string[] | undefined): boolean {
   return EXTERNAL_DRAG_TYPES.some((t) => types.includes(t));
 }
 
+// True for the lifetime of an internal app drag (a workspace-chip reorder),
+// set on the chip's dragstart and cleared on dragend. The window-level
+// dragover handler consults this instead of sniffing dataTransfer.types,
+// which can read empty mid-drag in some Chromium/Electron builds (the reason
+// onDragOver is otherwise unconditional). It's a module-scoped flag because
+// the chip handlers (WorkspaceTabStrip) and the window handlers (here) live in
+// different components but share the same native drag.
+let internalDragActive = false;
+
+/** Mark/clear an in-flight internal app drag (chip reorder). Called from the
+ *  chip's dragstart (true) and dragend (false). */
+export function setInternalDragActive(active: boolean): void {
+  internalDragActive = active;
+}
+
+/** Whether the window-level ingestion should claim a `dragover` —
+ *  `preventDefault()` + `dropEffect='copy'`. It must NOT claim an internal
+ *  chip drag (#177): that drag carries `effectAllowed='move'`, and forcing
+ *  `dropEffect='copy'` is incompatible with `'move'`, so Chromium resolves the
+ *  drag operation to `none` and never fires the chip's `drop` event — the
+ *  reorder silently no-ops (no overlay, but no reorder either). Leaving it
+ *  unclaimed lets the chip's `'move'` stand. External drags (flag false) are
+ *  claimed exactly as before, preserving the protected-mode fix above. */
+export function shouldClaimDragOver(internalActive: boolean): boolean {
+  return !internalActive;
+}
+
 export function useDropIngestion({ workspaceId, notify }: Options): { dragging: boolean } {
   const [dragging, setDragging] = useState(false);
 
@@ -70,6 +97,11 @@ export function useDropIngestion({ workspaceId, notify }: Options): { dragging: 
     };
 
     const onDragOver = (e: DragEvent): void => {
+      // Don't touch an internal chip-reorder drag (#177): forcing
+      // dropEffect='copy' over its effectAllowed='move' makes Chromium cancel
+      // the drop, so the reorder never fires. The chip's own dragover handles
+      // its drop target; we stay out of the way.
+      if (!shouldClaimDragOver(internalDragActive)) return;
       // preventDefault on dragover is what marks the window as a valid drop
       // target — without it the OS shows the "not-allowed" cursor. Call it
       // UNCONDITIONALLY and first: during a drag the dataTransfer is in

--- a/tests/committee-post.spec.ts
+++ b/tests/committee-post.spec.ts
@@ -59,8 +59,12 @@ test('Committee: post + collect gated by grant (#120)', async () => {
     expect(posted).toMatchObject({ id: ids['expert-c'] });
 
     // The post broadcasts a [committee] inbound toast into the expert's tab (#123).
-    const toast = window.locator('.terminal-pane:not([aria-hidden="true"]) .committee-toast');
+    // After the toast consolidation (#167) this renders via the shared ToastView
+    // as the in-tab `.toast--tab` (eyebrow "committee"); the bespoke
+    // `.committee-toast` class is gone (see Toast.tsx / styles.css).
+    const toast = window.locator('.terminal-pane:not([aria-hidden="true"]) .toast--tab');
     await expect(toast).toBeVisible({ timeout: 5_000 });
+    await expect(toast).toContainText('committee');
     await expect(toast).toContainText('review PR #42');
 
     // Granted status resolves (paused/busy computed without the DB; #121).


### PR DESCRIPTION
Fixes #177. Follow-up to #147 (fixed in #151 / `dbcb7ca`).

## Root cause
#151 stopped the file-drop overlay (`onDragEnter`) and the window `onDrop` from hijacking a chip reorder, but left the window-level **`onDragOver`** in `dropIngestion.ts` calling `preventDefault()` + `dropEffect = 'copy'` **unconditionally** — even for an internal chip drag.

The chip drag sets `effectAllowed = 'move'` (`WorkspaceTabStrip.tsx`). `'copy'` is not compatible with `'move'`, so Chromium resolves the drag operation to `none` and **never fires the chip's `drop` event** → `onReorderWorkspace` never runs. Net effect after #151: the overlay correctly stays hidden (matching the report), but the reorder also silently no-ops.

## Fix
- A module-scoped `internalDragActive` flag, set on the chip's `dragstart` and cleared on `dragend`/`drop`, gates a new pure `shouldClaimDragOver(internalActive)` chokepoint (repo's unit-tested-chokepoint pattern).
- The window `onDragOver` now bails while an internal drag is in flight, leaving the chip's `'move'` to stand. External file/URL/text drags are claimed exactly as before — preserving #151's "protected mode" fix (the flag avoids re-reading `dataTransfer.types` mid-drag, which can read empty in some Chromium/Electron builds).

## Verification
- ✅ Red-green regression test on `shouldClaimDragOver` (reverted the fix → the internal-drag assertion fails; restored → 7/7 pass).
- ✅ `npm run typecheck` clean (node + web).
- ✅ `npm run build` clean (main + preload + renderer).
- ✅ Full unit suite: 236 passed. The only 2 failing files (`mcpServer.test.ts` + 1) fail with `"Electron failed to install correctly"` — a container env issue (no Electron binary), unrelated to this change.
- ⚠️ **Not** verified by driving the actual drag gesture: Electron can't launch in this container, and native HTML5 DnD isn't reliably automatable. The root cause is grounded in the diff + the documented `effectAllowed`/`dropEffect` compatibility rule; please confirm the gesture once in a real build.

No `SPEC.md` change: this is a no-behavior-change bug fix that restores the already-documented reorder, and the spec doesn't document the drag/`dropEffect` internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)