### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump **0.3.1 → 0.4.0**. Bumps `package.json` + `package-lock.json` only — no code changes.

Once merged, push an annotated `v0.4.0` tag at the merge commit to trigger `build-app` (macOS/Windows/Linux installers → draft GitHub Release).

## Included since v0.3.1
- Errors via MCP: scoped `list_errors` + Help-menu host-file affordances (#181)
- "waiting on AskUserQuestion" chip state (#182)
- Port-forward preview — auto-detect dev servers, one-click browser preview (#173)
- Loadout library v2 — remote OCI sources (#172) + Phase 1 local catalog/favorites (#169)
- Scoped state-DB `query` + cheaper MCP aggregation tools (#174/#179)
- Remove committee-run USD ceiling (#180)
- Workspace chip reorder fix (#178)
- Consolidated toasts + sticky MCP-unreachable toast (#167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)