### PR TITLE
fix(docker): ship the waiting-chip hook assets in the runner image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,13 @@
 # Shared install scripts the devops (and future) images COPY — they build from
 # this same repo-root context (see docker/devops/Dockerfile).
 !docker/scripts/**
+# Runner hook assets the base image COPYs in (input-wait-report.sh +
+# hooks.settings.json) — loaded via `claude --settings` for the waiting-chip.
+# Without this opt-in those COPYs fail with "not found" and the publish breaks.
+!docker/runner/**
 
 # Even within broker/, drop things the binary doesn't need:
 broker/**/*_test.go
 broker/cmd/**/testdata/**
+# …and the runner hook test harness — not COPYd into any image.
+docker/runner/*.test.sh

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -713,7 +713,7 @@ claude-fleet/
 │   │   └── aws-cli.sh  azure-cli.sh   #   AWS CLI v2; Azure CLI (build-arg gated)
 │   └── devops/
 │       └── Dockerfile                 # FROM base + the platform-engineering toolset (runner-devops)
-├── .dockerignore                      # opt-in: broker/** + docker/Dockerfile + docker/scripts/**
+├── .dockerignore                      # opt-in: broker/** + docker/Dockerfile + docker/scripts/** + docker/runner/**
 ├── broker/                            # in-container session multiplexer (Go)
 │   ├── go.mod / go.sum
 │   ├── cmd/broker/main.go             # entrypoint; reads env, listens on socket
@@ -1124,6 +1124,8 @@ Right now the profile name is stamped on the container as a label and the API ke
 
 ### Runner image build
 The runner image is published by CI (`.github/workflows/publish-runner.yml`) to `ghcr.io/imioimi/claude-fleet/runner:latest` as a multi-arch (`linux/amd64` + `linux/arm64`) image on every push to `main` that touches `docker/**`. Tags emitted: `latest` (main only) and `sha-<short>`.
+
+**Build-context contract (load-bearing).** The Docker build context is the repo root with a deny-all `.dockerignore` that opts paths back in (`!broker/**`, `!docker/Dockerfile`, `!docker/scripts/**`, `!docker/runner/**`). **Anything the Dockerfile `COPY`s must be opted in here** — a `COPY` of an unlisted path fails the build with `"…": not found` and **nothing publishes**, leaving the previous (stale) `:latest` in place. This is exactly how the runner hook assets (`docker/runner/hooks.settings.json` + `input-wait-report.sh`) were once added with the `--settings` launch flag but *without* the `.dockerignore` opt-in: the app shipped a flag pointing at a file no published image contained, so every new in-container `claude` died with "Settings file not found". The publish workflow **should also smoke-test the built base image** (`test -f …/hooks.settings.json`) so a silently-absent asset can't ship green. Coupling note: the app's `claude --settings …` launch (§4 hooks) hard-depends on the image carrying that file; keep the flag and the image asset in lockstep, or make the launch degrade gracefully when the file is absent.
 
 On first container-create (or app startup), the app should `docker pull` the image if it isn't already present locally. New IPC channel `docker:ensureImage` returns a pull-progress stream; the UI surfaces this as a one-time toast or as part of the create-container flow.
 


### PR DESCRIPTION
## Problem

Every new in-container `claude` session dies instantly, fleet-wide, with:

```
Error: Settings file not found: /usr/local/lib/claude-fleet/hooks.settings.json
```

(captured from dead broker sessions' ring buffers). Clicking **+** / **Resume** creates the tab, but `claude` exits before it attaches → the "claude session ended" overlay. Already-running sessions are unaffected.

## Root cause

PR #182 (waiting-chip) did three things but missed one:

1. ✅ `src/main/claudeArgs.ts` — every launch now passes `--settings /usr/local/lib/claude-fleet/hooks.settings.json`.
2. ✅ `docker/Dockerfile` — `COPY docker/runner/{hooks.settings.json,input-wait-report.sh}` into the image.
3. ❌ **`.dockerignore` was never updated.** It's deny-all (`**`) then opt-in (`!broker/**`, `!docker/Dockerfile`, `!docker/scripts/**`) — `docker/runner/**` was never opted in.

So those files aren't in the build context, the `COPY` failed with `"…": not found`, the **`Build and push base` step of `publish-runner.yml` failed** ([run 28450504039](https://github.com/ImIOImI/claude-fleet/actions/runs/28450504039)), and **no runner/runner-devops image was ever published with the hook file**. The v0.4.0 app shipped the `--settings` flag anyway → it points at a file that exists in no image → fleet-wide crash. (devops builds `FROM` base, so it's broken too.)

## Fix

- **`.dockerignore`**: opt in `!docker/runner/**` (and drop the `*.test.sh` harness, which no image `COPY`s — matching the existing `broker/**/*_test.go` exclusion style).
- **`docs/SPEC.md`**: document the build-context contract (every `COPY` source must be opted in; a miss fails the build and leaves a stale `:latest`) and the app↔image lockstep coupling.

After this merges, `publish-runner.yml` re-runs and publishes a `runner:latest` + `runner-devops:latest` that actually contain the hook assets; users then `docker pull` + recreate their workspaces.

## Follow-ups (not in this PR)

- **CI smoke-test guard** for `publish-runner.yml` (assert the built base image carries the hook assets so a silently-absent file can't publish green). Split out because pushing `.github/workflows/**` needs the `workflow` token scope — patch is ready to apply.
- Optional **graceful degradation**: probe the selected image at create-time and only pass `--settings` when the file is present, so a missing asset disables the waiting-chip instead of bricking sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)