### PR TITLE
chore: release v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.4.1 patch release. Headline: local (non-container) workspaces now find the host `claude` reliably — on Linux/macOS GUI launches (#188) and on Windows (#190) — plus the committee post fix (#187).

Tag `v0.4.1` follows the squash merge; the tag build drafts the GitHub Release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)