### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.5.0 minor release. Headline: **semantic transcript search for agents** (#185, #189) — a scoped `search_transcripts` MCP tool backed by local embeddings (bge-small-en-v1.5 via onnxruntime-node), turn-level search over transcript history, DB migration v6.

Tag `v0.5.0` follows the squash merge; the tag build drafts the GitHub Release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)