### PR TITLE
fix(embeddings): cap embedder memory — q8 model, batch 8, 1000-char truncation

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -472,7 +472,14 @@ CREATE INDEX idx_errors_session ON errors(session_id);
 
 -- v6: semantic transcript search (rebuildable from JSONL — additive).
 -- vec is a Float32 BLOB (384 floats, L2-normalized) produced by bge-small-en-v1.5
--- via the local onnxruntime-node backend. Brute-force cosine search; no sqlite-vec.
+-- via the local onnxruntime-node backend (bge-small-en-v1.5 at dtype q8; the DB
+-- model key carries the dtype -- 'Xenova/bge-small-en-v1.5@q8' -- because q8 and
+-- fp32 vectors are not comparable: a dtype change re-keys and re-embeds, and the
+-- backfill purges rows under retired keys via deleteEmbeddingsForOtherModels).
+-- Indexing batch (8) and per-text truncation (1000 chars) are MEMORY controls:
+-- onnxruntime's arena holds its peak allocation for the process lifetime, and
+-- fp32 at batch 64 x 2000 chars grew the main process past 3 GB; q8 at 8 x 1000
+-- holds ~300 MB steady. Brute-force cosine search; no sqlite-vec.
 -- dedup_key = 't<ref_event_id>' for turns, String(source_max_event_id) for summaries.
 CREATE TABLE embeddings (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -1155,6 +1155,14 @@ export interface EmbeddingInsert {
   dedupKey: string;
 }
 
+/** Drop embedding rows keyed to any OTHER model id. Run before backfill so a
+ *  model/dtype change (which re-keys EMBED_MODEL_ID) doesn't leave dead
+ *  vectors accumulating under retired keys. Returns rows deleted. */
+export function deleteEmbeddingsForOtherModels(modelId: string): number {
+  const d = openDbOrThrow();
+  return d.prepare('DELETE FROM embeddings WHERE model_id != ?').run(modelId).changes;
+}
+
 export function insertEmbedding(row: EmbeddingInsert): boolean {
   const d = openDbOrThrow();
   const info = d

--- a/src/main/dbEmbeddings.test.ts
+++ b/src/main/dbEmbeddings.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { openDb, closeDb, ingestLine, insertEmbedding, unembeddedTurnEvents, maxEventId } from './db.js';
-import { encodeVector, EMBED_MODEL_ID } from './vectors.js';
+import { openDb, closeDb, deleteEmbeddingsForOtherModels, ingestLine, insertEmbedding, unembeddedTurnEvents, maxEventId } from './db.js';
+import { encodeVector, EMBED_MODEL_ID, EMBED_DIM } from './vectors.js';
 
 let dir: string;
 const WS = '01WS';
@@ -48,5 +48,26 @@ describe('embeddings schema + helpers', () => {
     ingestLine(WS, SES, userLine('u1', 'a'));
     ingestLine(WS, SES, userLine('u2', 'b'));
     expect(maxEventId(SES)).toBeGreaterThan(0);
+  });
+});
+
+describe('deleteEmbeddingsForOtherModels', () => {
+  it('drops rows keyed to a different model, keeps the current ones', () => {
+    ingestLine(WS, SES, userLine('u1', 'hello there'));
+    const [ev] = unembeddedTurnEvents(SES, EMBED_MODEL_ID);
+    insertEmbedding({
+      workspaceId: WS, sessionId: SES, kind: 'turn', refEventId: ev.id,
+      ts: ev.ts, text: 'old fp32 row', modelId: 'Xenova/bge-small-en-v1.5', dim: EMBED_DIM,
+      vec: encodeVector(new Float32Array(EMBED_DIM)), dedupKey: `t${ev.id}-old`,
+    });
+    insertEmbedding({
+      workspaceId: WS, sessionId: SES, kind: 'turn', refEventId: ev.id,
+      ts: ev.ts, text: 'current row', modelId: EMBED_MODEL_ID, dim: EMBED_DIM,
+      vec: encodeVector(new Float32Array(EMBED_DIM)), dedupKey: `t${ev.id}`,
+    });
+    expect(deleteEmbeddingsForOtherModels(EMBED_MODEL_ID)).toBe(1);
+    // The current-model row still satisfies the pending query (row is embedded).
+    expect(unembeddedTurnEvents(SES, EMBED_MODEL_ID).length).toBe(0);
+    expect(deleteEmbeddingsForOtherModels(EMBED_MODEL_ID)).toBe(0);
   });
 });

--- a/src/main/embeddings.ts
+++ b/src/main/embeddings.ts
@@ -1,7 +1,7 @@
 // Local, on-host embedding model (native onnxruntime-node backend). Transcript
 // text never leaves the machine. Lazy-loads the model once per process.
 import { createRequire } from 'node:module';
-import { EMBED_MODEL_ID, EMBED_DIM } from './vectors.js';
+import { EMBED_HF_ID, EMBED_DTYPE, EMBED_DIM } from './vectors.js';
 
 // transformers must load through the CJS loader: a dynamic import() resolves
 // via Electron's ESM loader, which cannot load packages from inside app.asar
@@ -19,7 +19,7 @@ export function makeEmbedder(cacheDir: string): (texts: string[]) => Promise<Flo
     const { pipeline, env } = requireCjs('@huggingface/transformers') as typeof import('@huggingface/transformers');
     env.cacheDir = cacheDir;          // cache weights under <userData>
     env.allowRemoteModels = true;     // fetch once on first use
-    return (await pipeline('feature-extraction', EMBED_MODEL_ID)) as unknown as Extractor;
+    return (await pipeline('feature-extraction', EMBED_HF_ID, { dtype: EMBED_DTYPE })) as unknown as Extractor;
   }
 
   return async function embed(texts: string[]): Promise<Float32Array[]> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,8 @@
 import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'node:path';
 import { registerIpc } from './ipc.js';
-import { openDb, closeDb, recordError, listSessions } from './db.js';
+import { openDb, closeDb, deleteEmbeddingsForOtherModels, recordError, listSessions } from './db.js';
+import { EMBED_MODEL_ID } from './vectors.js';
 import { startMcpServer, stopMcpServer, ensureWorkspaceSocket, setMcpStatusListener, setQueryEmbedder } from './mcpServer.js';
 import { broadcastMcpStatus } from './mcpStatusBroadcast.js';
 import { ensureBuiltinLoadouts } from './loadouts.js';
@@ -148,6 +149,9 @@ if (gotSingleInstanceLock) app.whenReady().then(async () => {
     // model change. Non-blocking; walks every known session once.
     void (async () => {
       try {
+        // A model/dtype change re-keys EMBED_MODEL_ID; drop vectors under
+        // retired keys so they don't accumulate as dead weight.
+        deleteEmbeddingsForOtherModels(EMBED_MODEL_ID);
         for (const s of listSessions()) await indexSessionTurns(s.id, embed);
         await indexSessionSummaries(embed);
       } catch (e) {

--- a/src/main/mcpServer.test.ts
+++ b/src/main/mcpServer.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TOOLS, resolveAllowedWorkspaces, setInputWaitHandler, setQueryEmbedder, type ToolCtx } from './mcpServer.js';
-import { EMBED_DIM } from './vectors.js';
+import { EMBED_DIM, EMBED_MODEL_ID } from './vectors.js';
 
 const WS_A = '01WORKSPACEAAAAAAAAAAAAAAA';
 const WS_B = '01WORKSPACEBBBBBBBBBBBBBBB';
@@ -339,8 +339,8 @@ describe('search_transcripts is workspace-scoped (#146)', () => {
     const unit = () => { const v = new Float32Array(EMBED_DIM); v[0] = 1; return v; };
     db.prepare(`CREATE TABLE IF NOT EXISTS embeddings (id INTEGER PRIMARY KEY AUTOINCREMENT, workspace_id TEXT, session_id TEXT, kind TEXT, ref_event_id INTEGER, ts INTEGER, text TEXT, model_id TEXT, dim INTEGER, vec BLOB, dedup_key TEXT, UNIQUE(session_id,kind,dedup_key))`).run();
     const ins = db.prepare(`INSERT INTO embeddings (workspace_id,session_id,kind,ref_event_id,ts,text,model_id,dim,vec,dedup_key) VALUES (?,?,?,?,?,?,?,?,?,?)`);
-    ins.run(WS_A, 'sa', 'turn', 1, 1000, 'A content', 'Xenova/bge-small-en-v1.5', EMBED_DIM, enc(unit()), 't1');
-    ins.run(WS_B, 'sb', 'turn', 2, 2000, 'B secret content', 'Xenova/bge-small-en-v1.5', EMBED_DIM, enc(unit()), 't2');
+    ins.run(WS_A, 'sa', 'turn', 1, 1000, 'A content', EMBED_MODEL_ID, EMBED_DIM, enc(unit()), 't1');
+    ins.run(WS_B, 'sb', 'turn', 2, 2000, 'B secret content', EMBED_MODEL_ID, EMBED_DIM, enc(unit()), 't2');
 
     setQueryEmbedder(async (texts) => texts.map(() => unit()));
     const hits = (await tool('search_transcripts').run(db, { query: 'anything' }, ctxA)) as Array<{ workspace_id?: string; workspaceId?: string }>;

--- a/src/main/transcriptIndex.ts
+++ b/src/main/transcriptIndex.ts
@@ -8,7 +8,14 @@ import { encodeVector, decodeVector, topK, EMBED_MODEL_ID, EMBED_DIM } from './v
 
 export type EmbedFn = (texts: string[]) => Promise<Float32Array[]>;
 
-const MAX_CHARS = 2000;
+// Truncation + batch size are MEMORY controls, not just throughput knobs:
+// activation memory scales with batch × sequence length, and onnxruntime's
+// arena holds its peak allocation for the life of the process. Measured on
+// bge-small q8: 1000 chars × batch 8 holds ~300 MB steady; 2000 chars ×
+// batch 64 on fp32 grew past 3 GB. Retrieval quality is insensitive to the
+// tail truncation (the head of a turn carries its topic).
+const MAX_CHARS = 1000;
+const EMBED_BATCH = 8;
 
 /** Human-readable text of a JSONL event's `message`, or '' if it carries none. */
 export function extractText(message: unknown): string {
@@ -24,7 +31,7 @@ export function extractText(message: unknown): string {
 }
 
 /** Embed every pending turn for a session. Returns rows inserted. */
-export async function indexSessionTurns(sessionId: string, embed: EmbedFn, batch = 64): Promise<number> {
+export async function indexSessionTurns(sessionId: string, embed: EmbedFn, batch = EMBED_BATCH): Promise<number> {
   let total = 0;
   // Loop so a session with a large backlog drains across batches.
   // unembeddedTurnEvents only returns rows still lacking an embedding, so the
@@ -116,7 +123,7 @@ export async function searchTranscripts(
   });
 }
 
-export async function indexSessionSummaries(embed: EmbedFn, batch = 64): Promise<number> {
+export async function indexSessionSummaries(embed: EmbedFn, batch = EMBED_BATCH): Promise<number> {
   let total = 0;
   for (;;) {
     const pending = unembeddedSummaries(EMBED_MODEL_ID, batch);

--- a/src/main/vectors.ts
+++ b/src/main/vectors.ts
@@ -2,7 +2,17 @@
 // tool (read side). No transformers/db imports here so mcpServer can use it
 // without pulling in the model runtime.
 
-export const EMBED_MODEL_ID = 'Xenova/bge-small-en-v1.5';
+/** HuggingFace repo the embedder loads. */
+export const EMBED_HF_ID = 'Xenova/bge-small-en-v1.5';
+/** Quantization the embedder runs at. q8 cuts steady-state RSS from
+ *  1.9–3.4 GB (fp32, growing per batch — the ORT arena never shrinks) to
+ *  ~300 MB at the indexer's batch/truncation settings, with negligible
+ *  retrieval-quality loss for bge-small. */
+export const EMBED_DTYPE = 'q8';
+/** DB key for embedding rows. Includes the dtype: q8 vectors are not
+ *  comparable to fp32 ones, so a dtype change re-keys (and re-embeds)
+ *  everything rather than mixing incompatible vectors in one search. */
+export const EMBED_MODEL_ID = `${EMBED_HF_ID}@${EMBED_DTYPE}`;
 export const EMBED_DIM = 384;
 
 /** Float32Array → little-endian BLOB. */


### PR DESCRIPTION
## The >1 GB process (reported on v0.5.x + fixes)

Once #199 let the embedder actually load, the backfill exposed its memory profile. Measured at the indexer's settings (fp32, batch 64, 2000-char texts):

| point | RSS |
|---|---|
| model loaded | 334 MB |
| after 1 batch | **1.9 GB** |
| after 2 batches | **3.4 GB** (keeps growing) |

onnxruntime's arena holds its peak allocation for the life of the process and compounds across large fp32 batches — the main process just keeps climbing while the backfill walks history.

## Fix (measured)

`dtype: 'q8'` + batch 64→8 + truncation 2000→1000 chars → **~300 MB steady, flat across batches**. Retrieval quality is insensitive: bge-small quantizes well and the head of a turn carries its topic (the real-model similarity test still passes on q8).

## Correctness

q8 and fp32 vectors aren't comparable, so `EMBED_MODEL_ID` now carries the dtype (`Xenova/bge-small-en-v1.5@q8`): all rows re-embed under the new key, and the backfill first purges rows under retired keys (`deleteEmbeddingsForOtherModels`, unit-tested) so dead vectors don't accumulate. Existing fp32 rows on users' machines are dropped and re-created by the same backfill.

Suite 382/382; SPEC §7 records batch/truncation as memory controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)