### PR TITLE
chore: release v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.5.1 patch release. Headline: **semantic transcript search actually works in packaged builds** — v0.5.0 shipped it broken (#194). Seven fixes since v0.5.0:

- `search_transcripts` packaged-app loader — CJS require instead of dynamic import (#196), and ship `sharp`, which transformers requires at module load (#199)
- embedder memory capped: q8 model, batch 8, 1000-char truncation — ~300 MB steady instead of 1.9–3.4 GB and growing (#201)
- wrong-session tab Refresh: host-assigned claude session ids, no more FIFO mapping guesses (#195/#198)
- first-MCP-call-after-restart hang: reconnect+resend container bridge (#200), delivered to existing workspaces via startup reconcile (#202)
- operational diagnostics in the errors DB, readable via `list_errors`: MCP tool errors with stacks, stall/slow-call watchdogs, mapping lifecycle, connection lifecycle (#197)

Tag `v0.5.1` follows the squash merge; the tag build drafts the GitHub Release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)