### PR TITLE
chore: release v0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.5.2 patch release — v0.5.1 (never published) plus #204: tab Refresh refuses to resume from legacy-guessed mappings (`broker_sessions.verified`, migration v7), closing the last hole behind the wrong-session Refresh (#195).

Everything in the unpublished v0.5.1 rides along: working packaged `search_transcripts` (#196/#199), capped embedder memory (#201), deterministic session ids (#198), the MCP bridge reconnect+resend fix (#200/#202), and the errors-DB diagnostics (#197).

Tag `v0.5.2` follows the squash merge; the tag build drafts the GitHub Release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)