### PR TITLE
chore: release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.6.0 minor release. Headline: **Phase 2 session hooks** (#207/#208) — ground-truth tab↔session mapping via SessionStart hook (heals `/clear` drift), turn-debounced chaptered LLM summaries with concept tags, and value-signal collection (usage_events, mark_useful, get_config) feeding Phase 3 (#206). Runner image with the hooks is already published; activation = this app build + image pull + workspace recreate.

Tag `v0.6.0` follows the squash merge; the tag build drafts the GitHub Release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)