### PR TITLE
Log successful pty:attach at level info, not error (#210)

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1218,6 +1218,10 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
       // correlate against attach failures across long sessions.
       logError({
         source: 'main',
+        // Success, not a failure: recordError persists `level ?? 'error'`, so an
+        // unspecified level would store this as `error` and the create modal, which
+        // styles entries by level, would flash it red (#210). Pin it to `info`.
+        level: 'info',
         type: 'pty-attach',
         message: `pty:attach OK (live=${ptySessions.size})`,
         // cols/rows are the dimensions the broker spawned the PTY at.


### PR DESCRIPTION
## Summary

Successful `pty:attach OK` breadcrumbs were being persisted as **error**-level rows and rendered **red** in the workspace create modal, misleading users into thinking an attach failed.

Root cause: `recordError` stores `row.level ?? 'error'` (db.ts:1367). The pty-attach success `logError` call (ipc.ts) omitted `level`, so it defaulted to `error`. This fix pins it to `level: 'info'`.

This is the visible half of the recreate-noise problem: per #211's evidence, each dead-container retry flashes a red `pty:attach OK` precisely *because* of this mislabeling. Fixing #210 removes the red-flash symptom; #211 (the underlying wasted retries against a stale container) is tracked separately and needs a Docker repro to fix safely — the attach/reattach path is load-bearing race-handling code (#18/#89/#195).

## Test plan

- [x] `npm run typecheck` clean (one pre-existing `@huggingface/transformers` error, unrelated)
- [x] `db.test.ts` passes (covers `recordError` level default)
- [ ] Manual: stop+recreate a workspace, confirm `pty:attach OK` entries no longer render red in the create modal

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)