### PR TITLE
feat(docker): add Doppler CLI to the devops runner image

### DIFF
--- a/docker/devops/Dockerfile
+++ b/docker/devops/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1
 # DevOps runner image — the base claude-fleet runner + the SumerSports
 # platform-engineering toolset (GitHub CLI, OpenTofu/Terramate, OPA, tflint/
-# trivy, kubectl/helm/kustomize, dnsutils, AWS CLI; Azure CLI opt-in). The
-# committee experts/manager run on this image (loadouts reach for gh, IaC tools).
+# trivy, kubectl/helm/kustomize, dnsutils, Doppler, AWS CLI; Azure CLI opt-in).
+# The committee experts/manager run on this image (loadouts reach for gh,
+# IaC tools).
 #
 # Built FROM the published base so the base stays lean and standalone; future
 # images can likewise stack on either. Build with the REPO ROOT as context
@@ -19,6 +20,7 @@ ARG TERRAMATE_VERSION=0.17.1
 ARG OPA_VERSION=1.13.2
 ARG AWS_CLI_VERSION=2.33.27
 ARG AZURE_CLI_VERSION=2.83.0
+ARG DOPPLER_VERSION=3.76.0
 # Heavy / creds-dependent CLIs. AWS is on by default; Azure is OFF by default
 # (its pip tree roughly doubles the image to ~3.4 GB) — opt in per build.
 ARG INSTALL_AWS_CLI=true
@@ -28,9 +30,9 @@ ARG INSTALL_AZURE_CLI=false
 # in the workspace image picker, so these let you find "the one with kubectl /
 # aws / tofu". The cloud CLIs reflect the build args (accurate per build).
 LABEL org.opencontainers.image.title="claude-fleet runner · devops" \
-      org.opencontainers.image.description="Base claude-fleet runner + platform-engineering toolset: gh, OpenTofu/Terramate (tenv), OPA, tflint/trivy, kubectl/kustomize/helm, dnsutils, AWS CLI." \
+      org.opencontainers.image.description="Base claude-fleet runner + platform-engineering toolset: gh, OpenTofu/Terramate (tenv), OPA, tflint/trivy, kubectl/kustomize/helm, dnsutils, Doppler, AWS CLI." \
       com.claude-fleet.variant="devops" \
-      com.claude-fleet.capabilities="gh yq tofu opentofu terramate opa tflint trivy kubectl kustomize helm dig dnsutils pre-commit shellcheck" \
+      com.claude-fleet.capabilities="gh yq tofu opentofu terramate opa tflint trivy kubectl kustomize helm dig dnsutils pre-commit shellcheck doppler" \
       com.claude-fleet.cloud="aws=${INSTALL_AWS_CLI} azure=${INSTALL_AZURE_CLI}"
 
 # tenv's `tofu` shim reads TENV_ROOT at runtime; point every container UID
@@ -59,6 +61,7 @@ RUN --mount=type=secret,id=github_token set -eux; \
     bash iac-lint.sh; \
     bash kubectl.sh; \
     bash helm.sh; \
+    bash doppler.sh; \
     if [ "$INSTALL_AWS_CLI" = "true" ]; then bash aws-cli.sh; fi; \
     if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash azure-cli.sh; fi; \
     rm -rf /opt/install-scripts

--- a/docker/scripts/doppler.sh
+++ b/docker/scripts/doppler.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Doppler CLI — secrets manager; experts read/run app config via `doppler run`.
+set -euo pipefail
+source "$(dirname "$0")/_arch.sh"
+V="${DOPPLER_VERSION:-3.76.0}"
+tmp="$(mktemp -d)"
+curl -fsSL "https://github.com/DopplerHQ/cli/releases/download/${V}/doppler_${V}_linux_${ARCH_DEB}.tar.gz" \
+  | tar -xz -C "$tmp"
+install -m 0755 "$tmp/doppler" /usr/local/bin/doppler
+rm -rf "$tmp"
+doppler --version

--- a/docker/versions.yaml
+++ b/docker/versions.yaml
@@ -13,6 +13,7 @@ terramate: 0.17.1     # latest stable; ci-images pins a private 0.17.0-betaNN ch
 opa: 1.13.2           # Open Policy Agent
 aws_cli: 2.33.27      # AWS CLI v2
 azure_cli: 2.83.0     # Azure CLI
+doppler: 3.76.0       # Doppler CLI (secrets manager)
 
 # These track the tool's own latest-release installer (robust, self-updating).
 # Set a concrete version here + teach the script to honor it if you need to pin.


### PR DESCRIPTION
## Summary
- Adds the Doppler CLI (secrets manager) to the devops runner image, pinned at **3.76.0**.
- New shared installer `docker/scripts/doppler.sh` follows the `gh.sh` pattern: arch-aware (`_arch.sh`), downloads the release tarball from DopplerHQ/cli (amd64 + arm64 assets exist), installs to `/usr/local/bin`, prints the version as a build-time smoke check.
- `docker/versions.yaml` gains `doppler: 3.76.0` in the pinned org-canon block; `ARG DOPPLER_VERSION` default mirrors it.
- `doppler` added to the `com.claude-fleet.capabilities` label so it's a searchable chip in the workspace image picker.

## Testing
- Ran the download/extract path locally on this arch: URL resolves, tarball has `doppler` at root, `./doppler --version` → `v3.76.0`.
- Full image build happens in the publish-runner workflow on merge (docker/** path trigger).

No SPEC.md change: the devops image's tool-stacking structure is unchanged; this adds one tool within it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)