### PR TITLE
feat(docker): add Argo CD / Workflows / Rollouts CLIs to the devops runner image

### DIFF
--- a/docker/devops/Dockerfile
+++ b/docker/devops/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 # DevOps runner image — the base claude-fleet runner + the SumerSports
 # platform-engineering toolset (GitHub CLI, OpenTofu/Terramate, OPA, tflint/
-# trivy, kubectl/helm/kustomize, dnsutils, Doppler, AWS CLI; Azure CLI opt-in).
+# trivy, kubectl/helm/kustomize, Argo CD/Workflows/Rollouts, dnsutils, Doppler,
+# AWS CLI; Azure CLI opt-in).
 # The committee experts/manager run on this image (loadouts reach for gh,
 # IaC tools).
 #
@@ -21,6 +22,9 @@ ARG OPA_VERSION=1.13.2
 ARG AWS_CLI_VERSION=2.33.27
 ARG AZURE_CLI_VERSION=2.83.0
 ARG DOPPLER_VERSION=3.76.0
+ARG ARGOCD_VERSION=3.4.5
+ARG ARGO_WORKFLOWS_VERSION=4.0.7
+ARG ARGO_ROLLOUTS_VERSION=1.9.0
 # Heavy / creds-dependent CLIs. AWS is on by default; Azure is OFF by default
 # (its pip tree roughly doubles the image to ~3.4 GB) — opt in per build.
 ARG INSTALL_AWS_CLI=true
@@ -30,9 +34,9 @@ ARG INSTALL_AZURE_CLI=false
 # in the workspace image picker, so these let you find "the one with kubectl /
 # aws / tofu". The cloud CLIs reflect the build args (accurate per build).
 LABEL org.opencontainers.image.title="claude-fleet runner · devops" \
-      org.opencontainers.image.description="Base claude-fleet runner + platform-engineering toolset: gh, OpenTofu/Terramate (tenv), OPA, tflint/trivy, kubectl/kustomize/helm, dnsutils, Doppler, AWS CLI." \
+      org.opencontainers.image.description="Base claude-fleet runner + platform-engineering toolset: gh, OpenTofu/Terramate (tenv), OPA, tflint/trivy, kubectl/kustomize/helm, Argo CD/Workflows/Rollouts, dnsutils, Doppler, AWS CLI." \
       com.claude-fleet.variant="devops" \
-      com.claude-fleet.capabilities="gh yq tofu opentofu terramate opa tflint trivy kubectl kustomize helm dig dnsutils pre-commit shellcheck doppler" \
+      com.claude-fleet.capabilities="gh yq tofu opentofu terramate opa tflint trivy kubectl kustomize helm dig dnsutils pre-commit shellcheck doppler argocd argo argo-workflows argo-rollouts" \
       com.claude-fleet.cloud="aws=${INSTALL_AWS_CLI} azure=${INSTALL_AZURE_CLI}"
 
 # tenv's `tofu` shim reads TENV_ROOT at runtime; point every container UID
@@ -61,6 +65,7 @@ RUN --mount=type=secret,id=github_token set -eux; \
     bash iac-lint.sh; \
     bash kubectl.sh; \
     bash helm.sh; \
+    bash argo.sh; \
     bash doppler.sh; \
     if [ "$INSTALL_AWS_CLI" = "true" ]; then bash aws-cli.sh; fi; \
     if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash azure-cli.sh; fi; \

--- a/docker/scripts/argo.sh
+++ b/docker/scripts/argo.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Argo CLIs — argocd (GitOps sync/diff), argo (Workflows), and the Rollouts
+# kubectl plugin. All three are single static binaries from argoproj releases.
+set -euo pipefail
+source "$(dirname "$0")/_arch.sh"
+CD_V="${ARGOCD_VERSION:-3.4.5}"
+WF_V="${ARGO_WORKFLOWS_VERSION:-4.0.7}"
+RO_V="${ARGO_ROLLOUTS_VERSION:-1.9.0}"
+tmp="$(mktemp -d)"
+curl -fsSL -o "$tmp/argocd" \
+  "https://github.com/argoproj/argo-cd/releases/download/v${CD_V}/argocd-linux-${ARCH_DEB}"
+curl -fsSL "https://github.com/argoproj/argo-workflows/releases/download/v${WF_V}/argo-linux-${ARCH_DEB}.gz" \
+  | gunzip > "$tmp/argo"
+curl -fsSL -o "$tmp/kubectl-argo-rollouts" \
+  "https://github.com/argoproj/argo-rollouts/releases/download/v${RO_V}/kubectl-argo-rollouts-linux-${ARCH_DEB}"
+install -m 0755 -t /usr/local/bin "$tmp/argocd" "$tmp/argo" "$tmp/kubectl-argo-rollouts"
+rm -rf "$tmp"
+argocd version --client --short
+argo version --short
+kubectl-argo-rollouts version --short

--- a/docker/versions.yaml
+++ b/docker/versions.yaml
@@ -14,6 +14,9 @@ opa: 1.13.2           # Open Policy Agent
 aws_cli: 2.33.27      # AWS CLI v2
 azure_cli: 2.83.0     # Azure CLI
 doppler: 3.76.0       # Doppler CLI (secrets manager)
+argocd: 3.4.5         # Argo CD CLI
+argo_workflows: 4.0.7 # Argo Workflows CLI (`argo`)
+argo_rollouts: 1.9.0  # Argo Rollouts kubectl plugin
 
 # These track the tool's own latest-release installer (robust, self-updating).
 # Set a concrete version here + teach the script to honor it if you need to pin.


### PR DESCRIPTION
## Summary
- Adds all three Argo CLIs to the devops runner image, pinned in the org-canon block of `versions.yaml`:
  - **argocd 3.4.5** (Argo CD), **argo 4.0.7** (Workflows), **kubectl-argo-rollouts 1.9.0** (Rollouts kubectl plugin)
- One shared installer `docker/scripts/argo.sh` (bundled like `iac-lint.sh`): arch-aware via `_arch.sh`, downloads the static binaries from argoproj releases (amd64 + arm64 assets exist for all three; Workflows ships gzipped), installs to `/usr/local/bin`, prints each version as a build-time smoke check.
- Dockerfile gains the three `ARG *_VERSION` defaults mirroring `versions.yaml`; `argocd argo argo-workflows argo-rollouts` added to the capabilities label for the image-picker chips.

## Testing
- Downloaded all three binaries via the exact script URLs on this arch and ran the version commands: `argocd: v3.4.5+564b949`, `argo: v4.0.7`, `kubectl-argo-rollouts: v1.9.0+838d4e7` (confirms the `--short` flags too).
- Full image build happens in the publish-runner workflow on merge (docker/** path trigger).

Note: these are chunky static Go binaries (~250 MB total uncompressed), same trade-off as the rest of the toolset. Runtime access to Argo CD/Workflows servers still needs per-workspace credentials — not part of this change.

No SPEC.md change: tool addition within the existing devops image structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)