### PR TITLE
chore: release v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for v0.7.0. First release since v0.5.2 (v0.6.0 was drafted but never published), so this ships everything from v0.6.0 + the fixes since:

- Phase 2 session hooks: mapping ground truth, chaptered summaries with tags, value-signal collection (#208)
- summarize.sh tolerates code-fenced JSON from `claude -p` (#215)
- Version exposure: `get_config` app.version + runnerImage, Help-menu version item, dev sha suffix (#219/#220)
- Windows e2e CI + ConPTY test (#213), local-session pause removal (#212), attach log level fix (#214)
- devops runner image: Doppler (#217), Argo CD/Workflows/Rollouts CLIs (#218)

After merge: tag `v0.7.0` → CI drafts the release → publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)