### PR TITLE
chore: release v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the **v0.8.0** release. Bumps `package.json` + `package-lock.json` `0.7.0 → 0.8.0`; no other changes.

## Highlights since v0.7.0
**Features**
- Sessions **Open/Recent grouping**, jump-to-tab, and summary tags (#222)
- **Plan-usage ledger** + observability (#216)
- New **dev runner image** (`runner-dev`): polyglot toolchain to build/test claude-fleet in-workspace (#229)
- Auto-rename / session-tab-rename fix (#227)

**Deps (security)**
- `electron-builder` 24 → 26 — resolves the critical `tar` chain + updater credential leak (#225)
- `vite` 5 → 7 + `electron-vite` 2 → 5 — resolves the esbuild advisory (#226)

**CI**
- Native multi-arch runner pipeline, no QEMU (#232)
- Pre-merge gate that builds + smokes the runner images (#234)

After merge, the `release` workflow is dispatched with tag **`v0.8.0`** to build the unsigned installers and publish a draft GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)