### PR TITLE
fix: restart-to-apply banner recreates the container (#236)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -773,8 +773,8 @@ Each chip in the workspace strip has a `⋮` trigger that opens a contextual men
 
 > Changes apply on next start. **[Restart now]** ×
 
-- **Restart now**: `workspace:stop(containerId)` → `workspace:start(id)`. Banner clears.
-- **×** (dismiss): banner clears without restart.
+- **Restart now**: **recreates** the container from the saved manifest — `workspace:getManifest(id)` → `workspace:ensureImage` (pull the possibly-new image) → `workspace:stop(containerId)` → `workspace:remove(containerId, {deleteState:false, id})` → `workspace:create(spec)`, reusing the same ULID so the private state dir + vault history stay attached. A plain `stop`→`start` would reuse the existing container and silently *not* apply the image/env/resource change (the container's spec is fixed at create time), so it must be recreated. The orchestration lives in `applyContainerEdit` (`src/renderer/src/workspaceLifecycle.ts`, unit-tested with an injected api); on success the banner clears and the workspace is re-focused, on failure the banner stays up for a retry. Recreating ends the current PTYs/Claude sessions (they start fresh in the new container); the host-side `/workspace` files persist and remount.
+- **×** (dismiss): banner clears without recreating.
 - The banner is keyed by workspace id in App.tsx's `restartBannerIds` Set; the corresponding TerminalPane reads `restartBanner` as a prop and renders accordingly. The Set survives chip switches — selecting another workspace and coming back still shows the banner until dismissed.
 
 ### Close a workspace

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,6 +14,11 @@ import { EditWorkspaceModal, containerLevelChanged } from './components/EditWork
 import { SettingsModal } from './components/SettingsModal';
 import LoadoutBrowserModal from './components/LoadoutBrowserModal';
 import { useDropIngestion } from './dropIngestion';
+import {
+  applyContainerEdit,
+  type WorkspaceLifecycleApi,
+  type WorkspaceManifest
+} from './workspaceLifecycle';
 import { contextBarSummary } from './contextBarSource';
 import { busyClaudeIdSet, openSessionMap, type OpenTabRef } from './busySessions';
 import { mergeWaitingSessionIds, waitingFlags } from './waitingSessions';
@@ -1030,23 +1035,39 @@ export function App() {
   };
 
   const restartFromBanner = async (workspaceId: string, containerId: string): Promise<void> => {
+    // Container-level edits (image/env/resources/authMode) are fixed at
+    // create time, so applying them means RECREATING the container from the
+    // saved manifest — not a stop→start, which would reuse the old spec.
+    const api: WorkspaceLifecycleApi = {
+      getManifest: (id) =>
+        window.api.workspace.getManifest(id) as Promise<WorkspaceManifest | null>,
+      ensureImage: (onProgress, image) => window.api.workspace.ensureImage(onProgress, image),
+      stop: (cid) => window.api.workspace.stop(cid),
+      start: (id) => window.api.workspace.start(id),
+      remove: (cid, opts) => window.api.workspace.remove(cid, opts),
+      create: (input) => window.api.workspace.create(input)
+    };
     try {
-      await window.api.workspace.stop(containerId);
+      await applyContainerEdit(
+        api,
+        { id: workspaceId, containerId },
+        (message) => pushToast(message, 'Recreating', 4000, 'progress')
+      );
+      setRestartBannerIds((prev) => {
+        if (!prev.has(workspaceId)) return prev;
+        const next = new Set(prev);
+        next.delete(workspaceId);
+        return next;
+      });
+      focusWorkspaceWhenWarm(workspaceId);
+      pushToast('Workspace recreated with the updated settings.', 'Recreated', 4000, 'ok');
     } catch (err) {
-      console.warn('workspace.stop during restart-banner failed:', err);
+      // Keep the banner up so the user can retry.
+      console.error('recreate from restart-banner failed:', err);
+      pushToast(`Recreate failed: ${(err as Error).message}`, 'Recreate failed', 8000, 'error');
+    } finally {
+      refresh();
     }
-    try {
-      await window.api.workspace.start(workspaceId);
-    } catch (err) {
-      console.warn('workspace.start during restart-banner failed:', err);
-    }
-    setRestartBannerIds((prev) => {
-      if (!prev.has(workspaceId)) return prev;
-      const next = new Set(prev);
-      next.delete(workspaceId);
-      return next;
-    });
-    refresh();
   };
 
   const dismissBanner = (workspaceId: string): void => {

--- a/src/renderer/src/workspaceLifecycle.test.ts
+++ b/src/renderer/src/workspaceLifecycle.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { applyContainerEdit, type WorkspaceLifecycleApi, type WorkspaceManifest } from './workspaceLifecycle';
+
+/** A fake api that records the ordered sequence of lifecycle calls. */
+function makeFakeApi(manifest: WorkspaceManifest | null): {
+  api: WorkspaceLifecycleApi;
+  calls: string[];
+  createInput: () => unknown;
+} {
+  const calls: string[] = [];
+  let createInput: unknown = null;
+  const api: WorkspaceLifecycleApi = {
+    async getManifest() {
+      calls.push('getManifest');
+      return manifest;
+    },
+    async ensureImage(_cb, image) {
+      calls.push(`ensureImage:${image ?? ''}`);
+    },
+    async stop() {
+      calls.push('stop');
+    },
+    async start() {
+      calls.push('start');
+      return null;
+    },
+    async remove(_c, opts) {
+      calls.push(`remove:deleteState=${opts?.deleteState}`);
+    },
+    async create(input) {
+      calls.push('create');
+      createInput = input;
+      return {};
+    }
+  };
+  return { api, calls, createInput: () => createInput };
+}
+
+const manifest: WorkspaceManifest = {
+  id: 'ws-1',
+  name: 'demo',
+  labels: [],
+  workspaceSubdir: '',
+  kind: 'container',
+  workspaceRoot: '/fleet/ws-1',
+  image: 'ghcr.io/imioimi/claude-fleet/runner-dev:latest',
+  authMode: 'oauth',
+  env: { plain: {}, secretKeys: [] },
+  mirror: 'on'
+};
+
+describe('applyContainerEdit', () => {
+  it('recreates the container from the saved manifest so image/env edits take effect', async () => {
+    const { api, calls, createInput } = makeFakeApi(manifest);
+
+    await applyContainerEdit(api, { id: 'ws-1', containerId: 'c-1' });
+
+    // Pull the (possibly new) image, then replace the container: stop → remove
+    // (keeping state) → create. A plain `start` would reuse the old container.
+    expect(calls).toEqual([
+      'getManifest',
+      'ensureImage:ghcr.io/imioimi/claude-fleet/runner-dev:latest',
+      'stop',
+      'remove:deleteState=false',
+      'create'
+    ]);
+    expect(calls).not.toContain('start');
+    // Recreated from the manifest, reusing the same id and the new image.
+    expect(createInput()).toMatchObject({
+      id: 'ws-1',
+      image: 'ghcr.io/imioimi/claude-fleet/runner-dev:latest'
+    });
+  });
+
+  it('skips the image pull for local workspaces (no image to fetch)', async () => {
+    const { api, calls } = makeFakeApi({ ...manifest, kind: 'local', image: undefined });
+
+    await applyContainerEdit(api, { id: 'ws-1', containerId: 'c-1' });
+
+    expect(calls.some((c) => c.startsWith('ensureImage'))).toBe(false);
+    expect(calls).toEqual(['getManifest', 'stop', 'remove:deleteState=false', 'create']);
+  });
+});

--- a/src/renderer/src/workspaceLifecycle.ts
+++ b/src/renderer/src/workspaceLifecycle.ts
@@ -1,0 +1,74 @@
+// Orchestration for applying a container-level edit (image/env/resources/
+// authMode) to a *live* workspace, extracted from App so it can be unit-tested
+// with an injected api. Kept dependency-free (no window.api, no React).
+
+/** Saved workspace manifest — the subset needed to recreate a container. */
+export interface WorkspaceManifest {
+  id: string;
+  name: string;
+  description?: string;
+  labels: string[];
+  color?: string;
+  workspaceSubdir: string;
+  kind: 'container' | 'local';
+  workspaceRoot: string;
+  image?: string;
+  authMode: string;
+  env: unknown;
+  resources?: unknown;
+  mirror: unknown;
+}
+
+/** The workspace lifecycle calls this orchestration needs (injected for tests). */
+export interface WorkspaceLifecycleApi {
+  getManifest(id: string): Promise<WorkspaceManifest | null>;
+  ensureImage(onProgress: (p: { message: string }) => void, image?: string): Promise<void>;
+  stop(containerId: string): Promise<void>;
+  start(id: string): Promise<unknown>;
+  remove(containerId: string, opts?: { deleteState?: boolean; id?: string }): Promise<void>;
+  create(input: unknown): Promise<unknown>;
+}
+
+/**
+ * Apply a container-level edit (image/env/resources/authMode) to a live
+ * workspace after the restart-to-apply banner's "Restart now".
+ *
+ * These fields are fixed at container-**create** time, so a stop→start would
+ * silently reuse the old spec (the bug this replaces). We instead **recreate**
+ * from the saved manifest (already updated by the edit): pull the possibly-new
+ * image, then stop → remove → create. The container is removed with
+ * `deleteState: false` and recreated with the same `id`, so the workspace's
+ * private state dir + vault history stay attached.
+ */
+export async function applyContainerEdit(
+  api: WorkspaceLifecycleApi,
+  ids: { id: string; containerId: string },
+  onProgress: (message: string) => void = () => {}
+): Promise<void> {
+  const spec = await api.getManifest(ids.id);
+  if (!spec) throw new Error(`No saved manifest for workspace ${ids.id}; cannot recreate.`);
+
+  // Pull the (possibly new) image first so the container is down for the least
+  // time. Local workspaces have no image to fetch.
+  if (spec.kind === 'container') {
+    await api.ensureImage(({ message }) => onProgress(message), spec.image);
+  }
+
+  await api.stop(ids.containerId);
+  await api.remove(ids.containerId, { deleteState: false, id: ids.id });
+  await api.create({
+    id: spec.id,
+    name: spec.name,
+    description: spec.description,
+    labels: spec.labels,
+    color: spec.color,
+    workspaceSubdir: spec.workspaceSubdir,
+    kind: spec.kind,
+    workspaceRoot: spec.workspaceRoot,
+    image: spec.image,
+    authMode: spec.authMode,
+    env: spec.env,
+    resources: spec.resources,
+    mirror: spec.mirror
+  });
+}

--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -205,6 +205,7 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       pause: [],
       remove: [],
       writeManifest: [],
+      getManifest: [],
       isDirectory: [],
       mkdirp: [],
       openPath: [],
@@ -227,6 +228,7 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
       'workspace:remove',
       'workspace:ping',
       'workspace:writeManifest',
+      'workspace:getManifest',
       'images:list',
       'images:remove',
       'fs:isDirectory',
@@ -324,6 +326,17 @@ export async function mockMainIpc(app: ElectronApplication, opts: MockOpts = {})
     // No persistence — just record the call shape for assertions.
     ipcMain.handle('workspace:writeManifest', async (_e, spec: Record<string, unknown>) => {
       g.__calls.writeManifest.push(spec);
+    });
+    // Recreate flow (restart-to-apply banner) reads the saved manifest before
+    // rebuilding the container. Return the most recent writeManifest'd spec for
+    // the id (so edits like a new image are reflected), else the list entry.
+    ipcMain.handle('workspace:getManifest', async (_e, id: string) => {
+      g.__calls.getManifest.push(id);
+      const written = [...g.__calls.writeManifest]
+        .reverse()
+        .find((s) => (s as { id?: string }).id === id);
+      if (written) return written;
+      return list.find((w) => w.id === id || w.name === id) ?? null;
     });
     ipcMain.handle('workspace:stop', async (_e, containerId: string) => {
       g.__calls.stop.push(containerId);

--- a/tests/workspace-actions.spec.ts
+++ b/tests/workspace-actions.spec.ts
@@ -221,7 +221,7 @@ test('Chip ⋮ Edit: Save with container-level changes (image) shows the restart
   }
 });
 
-test('Restart banner: Dismiss removes it; Restart now calls stop + start', async () => {
+test('Restart banner: Restart now recreates the container on the edited image', async () => {
   const { app, window } = await launch();
   try {
     await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
@@ -236,13 +236,52 @@ test('Restart banner: Dismiss removes it; Restart now calls stop + start', async
     const banner = window.locator('.terminal-pane:not([aria-hidden="true"]) .restart-banner');
     await expect(banner).toBeVisible();
 
-    // Restart now → stop + start fire; banner disappears.
+    // Restart now → the container is RECREATED (not stop→start, which would
+    // reuse it and drop the image change): ensureImage → stop → remove
+    // (keeping state) → create on the new image. Banner clears.
     await banner.getByRole('button', { name: 'Restart now' }).click();
     await expect(banner).toBeHidden();
 
     const calls = await getCalls(app);
+    expect(calls.getManifest).toContain(RUNNING_WS.id);
+    expect(calls.ensureImage).toContain('ghcr.io/imioimi/claude-fleet/runner:different');
     expect(calls.stop).toContain(RUNNING_WS.containerId);
-    expect(calls.start).toContain(RUNNING_WS.id);
+    // Removed with state preserved, keyed by the workspace id.
+    expect(calls.remove).toContainEqual(
+      expect.objectContaining({ containerId: RUNNING_WS.containerId, deleteState: false, id: RUNNING_WS.id })
+    );
+    // Recreated with the same id on the new image.
+    expect(calls.create).toContainEqual(
+      expect.objectContaining({ id: RUNNING_WS.id, image: 'ghcr.io/imioimi/claude-fleet/runner:different' })
+    );
+    // NOT a plain restart — start must not be called for the recreate.
+    expect(calls.start).not.toContain(RUNNING_WS.id);
+  } finally {
+    await app.close();
+  }
+});
+
+test('Restart banner: Dismiss removes it without recreating', async () => {
+  const { app, window } = await launch();
+  try {
+    await mockMainIpc(app, { workspaceList: [RUNNING_WS] });
+    await window.locator('.ws-chip-group', { hasText: 'happy-llama' }).getByRole('button').first().click();
+
+    const menu = await openChipMenu(window, 'happy-llama');
+    await menu.getByRole('menuitem', { name: 'Edit…' }).click();
+    await window.getByLabel('Image reference').fill('ghcr.io/imioimi/claude-fleet/runner:different');
+    await window.getByRole('button', { name: 'Save' }).click();
+
+    const banner = window.locator('.terminal-pane:not([aria-hidden="true"]) .restart-banner');
+    await expect(banner).toBeVisible();
+
+    // × dismiss → banner clears, nothing is recreated.
+    await banner.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(banner).toBeHidden();
+
+    const calls = await getCalls(app);
+    expect(calls.create).toHaveLength(0);
+    expect(calls.remove).toHaveLength(0);
   } finally {
     await app.close();
   }


### PR DESCRIPTION
Fixes #236.

## Bug
The **"Restart now"** banner (shown after editing a live workspace's `image`/`env`/`resources`/`authMode`) did `workspace:stop` → `workspace:start`, which **reuses the existing container**. Those fields are baked in at container-**create** time, so the edit silently never took effect — e.g. pointing a running workspace at `runner-dev` left it on its old image.

## Fix
Extracted the orchestration into `applyContainerEdit` (`src/renderer/src/workspaceLifecycle.ts`, dependency-injected so it's unit-testable) and changed it to **recreate** from the saved manifest:

```
getManifest → ensureImage (pull possibly-new image)
            → stop → remove(deleteState:false) → create
```

Reuses the **same ULID**, so the workspace's private state dir + vault history stay attached. On success the banner clears and the workspace re-focuses; on failure it stays up for a retry (with an error toast). Recreating ends the current PTYs (they restart fresh in the new container); host-side `/workspace` files persist and remount.

## TDD
1. **Verify current behavior** — a characterization test pinned the old `['stop','start']` sequence (green), proving the test seam works.
2. **RED** — flipped the test to assert the recreate sequence (`getManifest → ensureImage → stop → remove(deleteState:false) → create`, never `start`); watched it fail against the current impl.
3. **GREEN** — implemented the recreate; both tests pass (incl. a local-workspace case that skips the image pull).

## Verification
- `npx vitest run src/renderer` — **83 passing** (14 files, incl. the 2 new)
- `npm run typecheck` ✅ · `npm run build` ✅
- SPEC's *Restart-to-apply banner* section updated to describe the recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)