### PR TITLE
ci: retry Playwright e2e twice on CI to absorb Windows flakes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
   timeout: 30000,
   fullyParallel: false,
   workers: 1,
+  // Retry transient flakes on CI (slow Windows runners occasionally miss the
+  // modal-close timing window); keep local runs retry-free to surface flakes.
+  retries: process.env.CI ? 2 : 0,
   reporter: 'list'
 });


### PR DESCRIPTION
## What

Add `retries: process.env.CI ? 2 : 0` to `playwright.config.ts`.

## Why

The e2e config set no `retries`, so a single transient assertion timeout fails the whole gate with zero retry. This surfaced on #224 (a lockfile-only chore) where `e2e (playwright, windows)` reded on the flaky `workspace-modal.spec.ts:204` Resume test — the modal-close assertion occasionally exceeds its 5s window on slow Windows runners. The same test passed on Linux in the same run and passed cleanly on re-run.

Retrying twice on CI absorbs these transient Windows timing flakes without masking real regressions. Local runs stay retry-free (`retries: 0`) so flakes still surface during development.

## Verification

- Lint/typecheck via CI on this PR.
- The Windows e2e flake that motivated this is a known timing race, not a logic bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)