### PR TITLE
fix: make the port-preview toast sticky (it's the only route to a preview)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -291,25 +291,29 @@ export function App() {
   useEffect(() => {
     return window.api.ports.onDetected((workspaceId, port) => {
       const name = workspacesRef.current.find((w) => w.id === workspaceId)?.name ?? 'workspace';
+      // Sticky: this toast is the only way to reach the preview (bridge IPs
+      // aren't routable from the host on Windows), so it must never expire —
+      // missing it means restarting the dev server to re-trigger detection.
+      // It clears on click or ✕. Keyless so multiple ports can stack.
+      const id = ++toastIdRef.current;
       dispatchToast({
         type: 'push',
-        toast: makeToast(++toastIdRef.current, {
+        toast: makeToast(id, {
           kind: 'info',
           eyebrow: 'Preview',
           message: `Dev server detected on port ${port} in ${name}`,
           placement: 'global',
-          sticky: false,
+          sticky: true,
           dismissible: true,
           action: {
             label: 'Open preview',
-            onClick: () => void window.api.ports.open(workspaceId, port)
+            onClick: () => {
+              void window.api.ports.open(workspaceId, port);
+              dispatchToast({ type: 'dismiss', id });
+            }
           }
         })
       });
-      // Auto-dismiss after a longer window than the default — give the user
-      // time to click. Keyless so multiple ports can stack.
-      const id = toastIdRef.current;
-      setTimeout(() => dispatchToast({ type: 'dismiss', id }), 12000);
     });
   }, []);
 


### PR DESCRIPTION
## Problem
The dev-server preview toast auto-dismisses after 12 s. On Windows the bridge IPs aren't routable from the host browser, so this toast is the **only** way to open a preview — missing it means killing the dev server, waiting, and restarting it to re-trigger detection. Worse, a re-trigger isn't guaranteed: `portforward.ts` polls every 3 s and skips failed polls silently, so during broker churn (#243) the poller can miss the close/open transition entirely. Troy hit exactly this today, twice, trying to read a hosted spec.

## Fix
Make the toast **sticky** (the toasts framework already supports it — same mechanism as the MCP-unreachable toast, #167): it stays until acted on. Clicking **Open preview** now also dismisses it; ✕ still works. Toasts remain keyless so multiple detected ports stack.

Behavior is otherwise unchanged; `tests/port-forward.spec.ts` doesn't pin the auto-dismiss and still passes conceptually (toast visible → click → `ports.open` round-trip).

## Testing
- `npm run typecheck` clean (node + web).
- e2e `port-forward.spec.ts` covers the toast render + action wiring; no timing assertion existed or was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)