### PR TITLE
chore: release v0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for **v0.8.1**. Bumps `package.json` + `package-lock.json` `0.8.0 → 0.8.1`; no other changes.

## Highlights since v0.8.0
**Stability (the headline — fixes a wedged-v0.8.0 runaway)**
- #244 — bound MCP-bridge reconnect + new-session emission to stop the launch/resume runaway that pegged CPU and hung the UI (#243)
- #245 — CI: wait for the Docker engine before Windows e2e (fixes the `//./pipe/docker_engine` flake #243 exposed)
- #247 — make the port-preview toast sticky (the only route to a preview on Windows; broker churn could make users miss it)

**Feature**
- #248 — chapter-summary backfill: chunked summarization + session-start sweep (#246) — advances the summarization pipeline (extracts shared `summary-core.sh`, fixes the resume mega-window + whole-transcript timestamp bugs)

After merge, the `release` workflow is dispatched with tag **`v0.8.1`** to build the unsigned installers and publish a draft GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)