### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.9.0 release. Changes since v0.8.1:

- feat: model-endpoint workspaces — run non-Claude models behind claude-code (#250) (#252)
- docs: add latest-release download badges to the README header (#251)

After merge, tagging the merge commit as `v0.9.0` triggers the build-app workflow, which builds the macOS/Windows/Linux installers and publishes a draft GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)