### PR TITLE
Extract shared usePortalMenu hook + menuIcons (#264)

### DIFF
--- a/docs/superpowers/plans/2026-08-06-use-portal-menu.md
+++ b/docs/superpowers/plans/2026-08-06-use-portal-menu.md
@@ -1,0 +1,65 @@
+# usePortalMenu Extraction Implementation Plan (#264)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the thrice-duplicated portaled ⋮ menu mechanics (anchor state, close-listener effect, viewport clamp) into a shared `usePortalMenu()` hook and consolidate the duplicated menu SVG icons into one module, then migrate `WorkspaceTabStrip`, `TerminalPane`, and `SessionsPane`.
+
+**Architecture:** Pure refactor — no behavior change, no IPC/data-model/SPEC changes (spec-maintenance rule classifies shape-preserving refactors as trivial). New `portalMenu.tsx` exports pure anchor math (`leftAnchor`/`rightAnchor`, unit-testable without DOM) and the `usePortalMenu` hook (state + close-on-outside-click/Escape/scroll/resize effect + `toggle`/`close`). New `menuIcons.tsx` exports the glyph components. One deliberate visual nit: the session-row Delete icon switches from the one-off stroke trash (added in #263) to the shared filled `IconTrash` used by the chip menu.
+
+**Tech Stack:** React 18, vitest for the pure anchor math.
+
+**Base:** stacked on `worktree-session-row-kebab` (PR #263); branch `feat/use-portal-menu`.
+
+## Global Constraints
+
+- Work in `/workspace/claude-fleet/.claude/worktrees/session-row-kebab`; never `cd` to the main checkout.
+- Behavior parity: every menu must keep its exact anchor side, clamp values (188/8/4), open/close semantics, `aria-*` attributes, and item structure. `IconGear` stays in `WorkspaceTabStrip` (top-strip button, not a menu icon).
+- Gate: `npm run typecheck && npm run test:unit && npm run build`.
+
+---
+
+### Task 1: `portalMenu.tsx` + unit tests (TDD)
+
+**Files:**
+- Create: `src/renderer/src/components/portalMenu.tsx`
+- Create: `src/renderer/src/components/portalMenu.test.ts`
+
+**Interfaces (produced):**
+- `interface MenuAnchor { id: string; top: number; left?: number; right?: number }`
+- `leftAnchor(rect: {left: number; right: number; bottom: number}, innerWidth: number): { top: number; left: number }` — `top = bottom + 4`, `left = max(8, min(rect.left, innerWidth - 188))`
+- `rightAnchor(rect, innerWidth): { top: number; right: number }` — `top = bottom + 4`, `right = max(8, innerWidth - rect.right)`
+- `usePortalMenu(): { menu: MenuAnchor | null; toggle(trigger: HTMLElement, id: string, side?: 'left' | 'right'): void; close(): void }` — `toggle` closes when `menu.id === id`, else opens anchored to the trigger (default `'left'`); the hook owns the close-on-outside-click/Escape/scroll(capture)/resize effect.
+
+- [ ] **Step 1: Write failing tests** (`portalMenu.test.ts`): leftAnchor passes `rect.left` through when it fits; clamps to `innerWidth - 188` when the trigger sits too far right; floors at 8 on a viewport narrower than the menu; `top = bottom + 4`. rightAnchor mirrors from the right edge and floors at 8.
+- [ ] **Step 2: Run** `npx vitest run src/renderer/src/components/portalMenu.test.ts` — expect FAIL (module missing).
+- [ ] **Step 3: Implement** `portalMenu.tsx` (constants `MENU_WIDTH=188`, `VIEWPORT_MARGIN=8`, `TRIGGER_GAP=4`; pure fns; hook with the exact close-listener effect currently copied in the three components).
+- [ ] **Step 4: Run the test again** — expect PASS.
+- [ ] **Step 5: Commit** `feat: add shared usePortalMenu hook + anchor math (#264)`.
+
+### Task 2: `menuIcons.tsx`
+
+**Files:**
+- Create: `src/renderer/src/components/menuIcons.tsx`
+
+**Interfaces (produced):** `IconPlay, IconPause, IconStop, IconEject, IconPencil, IconCopy, IconTrash, IconRefresh, IconAuto` — glyph-named; SVG bodies moved verbatim from `WorkspaceTabStrip.tsx` (Play/Pause/Stop/Eject/Edit→Pencil/Copy/Trash) and `TerminalPane.tsx` (Refresh, Auto).
+
+- [ ] **Step 1: Create the module** with the nine components (12×12 viewBox, `currentColor`, `aria-hidden`), header comment noting they serve the shared `.ws-chip-menu` idiom.
+- [ ] **Step 2: Commit** `feat: consolidate menu SVG icons into menuIcons.tsx (#264)`.
+
+### Task 3: Migrate the three components
+
+**Files:**
+- Modify: `src/renderer/src/components/WorkspaceTabStrip.tsx` (delete local icons except `IconGear`, `menuPositionFor`, `MenuAnchor`, menu state + effect; use `usePortalMenu` with `side: 'right'`; `menu.for` → `menu.id`)
+- Modify: `src/renderer/src/components/TerminalPane.tsx` (delete `IconRename/IconAuto/IconClose/IconRefresh`, `tabMenu` state + effect + `openTabMenu`; use hook; `tabMenu` → `menu`)
+- Modify: `src/renderer/src/components/SessionsPane.tsx` (delete `IconResume/IconRename/IconDelete`, `rowMenu` state + effect + `openRowMenu`; use hook; Delete item uses `IconTrash`)
+
+- [ ] **Step 1: Migrate `SessionsPane.tsx`** (freshest copy, in this PR stack).
+- [ ] **Step 2: Migrate `TerminalPane.tsx`**.
+- [ ] **Step 3: Migrate `WorkspaceTabStrip.tsx`**.
+- [ ] **Step 4: Gate** `npm run typecheck && npm run test:unit && npm run build` — expect clean / 483+new passing / build ok.
+- [ ] **Step 5: Grep for leftovers** `grep -rn "menuPositionFor\|openTabMenu\|openRowMenu\|IconRename\|IconResume\|IconDelete\|IconEdit\|IconClose\b" src/renderer/src/components/*.tsx` — expect no hits outside `menuIcons.tsx`/`portalMenu.tsx`.
+- [ ] **Step 6: Commit** `refactor: migrate chip/tab/row menus to usePortalMenu (#264)`.
+
+### Task 4: PR
+
+- [ ] **Step 1:** Push `feat/use-portal-menu`, open PR with base `worktree-session-row-kebab` (retargets to main when #263 merges), body links #264, notes the one visual nit (session-row Delete icon → filled trash).

--- a/src/renderer/src/components/SessionsPane.tsx
+++ b/src/renderer/src/components/SessionsPane.tsx
@@ -19,6 +19,8 @@ import type { SessionListItem } from '../../../preload';
 import { sessionsForScope, filterSessions, partitionByOpen, tagCounts } from '../sessionsView';
 import { useBlinkSync } from '../blinkSync';
 import type { OpenTabRef } from '../busySessions';
+import { usePortalMenu } from './portalMenu';
+import { IconPencil, IconRefresh, IconTrash } from './menuIcons';
 
 type Scope = 'workspace' | 'all';
 
@@ -70,33 +72,6 @@ function formatUsd(usd: number): string {
   return `$${Math.round(usd).toLocaleString('en-US')}`;
 }
 
-// Row-menu icons — 12×12 viewBox, same visual set as the session-tab ⋮ menu
-// (TerminalPane). Resume reuses the circular-arrow, rename the pencil.
-function IconResume(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M10 6 A4 4 0 1 1 8.6 3" />
-      <path d="M10.4 1.6 L10.4 4 L8 4" />
-    </svg>
-  );
-}
-function IconRename(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
-      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
-    </svg>
-  );
-}
-function IconDelete(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" aria-hidden="true">
-      <path d="M2 3.5 H10" />
-      <path d="M4.5 3.5 V2.5 H7.5 V3.5" />
-      <path d="M3 3.5 L3.7 10.5 H8.3 L9 3.5" />
-    </svg>
-  );
-}
-
 export function SessionsPane({
   selectedWorkspaceId,
   busySessionIds,
@@ -116,36 +91,8 @@ export function SessionsPane({
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [tagMenu, setTagMenu] = useState(false);
 
-  // ── Row ⋮ menu: resume / rename / delete ──────────────────────────────────
-  // Single open menu at a time; viewport coords for the portaled dropdown.
-  // Same pattern as the session-tab menu (TerminalPane) and workspace chips.
-  const [rowMenu, setRowMenu] = useState<{ id: string; top: number; left: number } | null>(null);
-
-  // Close the menu on any outside click / Escape / layout shift (the portal is
-  // positioned in viewport coords, so we can't follow the trigger when it moves).
-  useEffect(() => {
-    if (!rowMenu) return;
-    const close = (): void => setRowMenu(null);
-    const esc = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setRowMenu(null);
-    };
-    document.addEventListener('click', close);
-    document.addEventListener('keydown', esc);
-    window.addEventListener('scroll', close, true);
-    window.addEventListener('resize', close);
-    return () => {
-      document.removeEventListener('click', close);
-      document.removeEventListener('keydown', esc);
-      window.removeEventListener('scroll', close, true);
-      window.removeEventListener('resize', close);
-    };
-  }, [rowMenu]);
-
-  function openRowMenu(trigger: HTMLElement, id: string): void {
-    const r = trigger.getBoundingClientRect();
-    const left = Math.max(8, Math.min(r.left, window.innerWidth - 188));
-    setRowMenu({ id, top: r.bottom + 4, left });
-  }
+  // Row ⋮ menu: resume / rename / delete — shared portaled-menu mechanics.
+  const { menu: rowMenu, toggle: toggleRowMenu, close: closeRowMenu } = usePortalMenu();
 
   const toggleTag = (t: string): void =>
     setActiveTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
@@ -329,8 +276,7 @@ export function SessionsPane({
                 aria-expanded={rowMenu?.id === s.id}
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (rowMenu?.id === s.id) setRowMenu(null);
-                  else openRowMenu(e.currentTarget, s.id);
+                  toggleRowMenu(e.currentTarget, s.id);
                 }}
               >
                 ⋮
@@ -455,22 +401,22 @@ export function SessionsPane({
                 role="menuitem"
                 title={isOpen ? 'Jump to the open terminal tab' : 'Resume this session'}
                 onClick={() => {
-                  setRowMenu(null);
+                  closeRowMenu();
                   onResume(s);
                 }}
               >
-                <IconResume />
+                <IconRefresh />
                 <span>{isOpen ? 'Go to tab' : 'Resume'}</span>
               </button>
               <button
                 role="menuitem"
                 onClick={() => {
-                  setRowMenu(null);
+                  closeRowMenu();
                   setDraftName(s.userSetName ?? displayTitle(s));
                   setEditingId(s.id);
                 }}
               >
-                <IconRename />
+                <IconPencil />
                 <span>Rename</span>
               </button>
               <div className="ws-chip-menu-divider" />
@@ -479,11 +425,11 @@ export function SessionsPane({
                 className="danger"
                 title="Delete session + transcript"
                 onClick={() => {
-                  setRowMenu(null);
+                  closeRowMenu();
                   setConfirmDeleteId(s.id);
                 }}
               >
-                <IconDelete />
+                <IconTrash />
                 <span>Delete</span>
               </button>
             </div>,

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -22,6 +22,8 @@ import { ToastView } from './Toast';
 import { makeToast } from '../toasts';
 import { readyToRefresh } from './refreshQueue';
 import { useBlinkSync } from '../blinkSync';
+import { usePortalMenu } from './portalMenu';
+import { IconAuto, IconEject, IconPencil, IconRefresh } from './menuIcons';
 
 /**
  * A session tab's status dot. `live`/`ended` colors it; `busy` makes it pulse
@@ -190,41 +192,6 @@ interface Session {
 
 function uid(): string {
   return globalThis.crypto?.randomUUID?.() ?? `s-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-// Session-tab menu icons — 12×12 viewBox so they sit on the menu text baseline.
-function IconRename(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
-      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
-    </svg>
-  );
-}
-function IconAuto(): JSX.Element {
-  // A sparkle — "let Claude name it".
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <path d="M6 1 L7 4.5 L10.5 6 L7 7.5 L6 11 L5 7.5 L1.5 6 L5 4.5 Z" />
-    </svg>
-  );
-}
-function IconClose(): JSX.Element {
-  // Eject — matches the workspace chip menu's "Close" affordance.
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <path d="M6 2 L10 8 L2 8 Z" />
-      <rect x="2" y="9" width="8" height="1.6" rx="0.4" />
-    </svg>
-  );
-}
-function IconRefresh(): JSX.Element {
-  // Circular arrow — exit & resume this session in place.
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M10 6 A4 4 0 1 1 8.6 3" />
-      <path d="M10.4 1.6 L10.4 4 L8 4" />
-    </svg>
-  );
 }
 
 export function TerminalPane({
@@ -406,38 +373,13 @@ export function TerminalPane({
     setNextNum((n) => n + 1);
   }
 
-  // ── Session-tab ⋮ menu: rename / auto-rename / close ──────────────────────
-  // Single open menu at a time; viewport coords for the portaled dropdown.
-  const [tabMenu, setTabMenu] = useState<{ id: string; top: number; left: number } | null>(null);
+  // Session-tab ⋮ menu: rename / auto-rename / close — shared portaled-menu
+  // mechanics (state + close listeners + anchor math) live in usePortalMenu.
+  const { menu: tabMenu, toggle: toggleTabMenu, close: closeTabMenu } = usePortalMenu();
   // Inline rename: the tab whose name is being edited, plus the draft text.
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
 
-  // Close the menu on any outside click / Escape / layout shift (the portal is
-  // positioned in viewport coords, so we can't follow the trigger when it moves).
-  useEffect(() => {
-    if (!tabMenu) return;
-    const close = (): void => setTabMenu(null);
-    const esc = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setTabMenu(null);
-    };
-    document.addEventListener('click', close);
-    document.addEventListener('keydown', esc);
-    window.addEventListener('scroll', close, true);
-    window.addEventListener('resize', close);
-    return () => {
-      document.removeEventListener('click', close);
-      document.removeEventListener('keydown', esc);
-      window.removeEventListener('scroll', close, true);
-      window.removeEventListener('resize', close);
-    };
-  }, [tabMenu]);
-
-  function openTabMenu(trigger: HTMLElement, id: string): void {
-    const r = trigger.getBoundingClientRect();
-    const left = Math.max(8, Math.min(r.left, window.innerWidth - 188));
-    setTabMenu({ id, top: r.bottom + 4, left });
-  }
   function startRename(id: string): void {
     const s = sessions.find((x) => x.id === id);
     setDraftName(s?.name ?? '');
@@ -820,11 +762,7 @@ export function TerminalPane({
                 title="Session actions"
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (tabMenu?.id === s.id) {
-                    setTabMenu(null);
-                    return;
-                  }
-                  openTabMenu(e.currentTarget, s.id);
+                  toggleTabMenu(e.currentTarget, s.id);
                 }}
               >
                 ⋮
@@ -871,11 +809,11 @@ export function TerminalPane({
               <button
                 role="menuitem"
                 onClick={() => {
-                  setTabMenu(null);
+                  closeTabMenu();
                   startRename(s.id);
                 }}
               >
-                <IconRename />
+                <IconPencil />
                 <span>Rename</span>
               </button>
               <button
@@ -884,7 +822,7 @@ export function TerminalPane({
                 aria-disabled={endedIds.has(s.id)}
                 title="Exit and resume this session (waits until it's idle)"
                 onClick={() => {
-                  setTabMenu(null);
+                  closeTabMenu();
                   requestRefresh(s);
                 }}
               >
@@ -896,7 +834,7 @@ export function TerminalPane({
                 aria-checked={!!s.autoName}
                 title="Name this tab from Claude's session summary, kept up to date"
                 onClick={() => {
-                  setTabMenu(null);
+                  closeTabMenu();
                   toggleAutoName(s.id);
                 }}
               >
@@ -913,11 +851,11 @@ export function TerminalPane({
                 role="menuitem"
                 className="danger"
                 onClick={() => {
-                  setTabMenu(null);
+                  closeTabMenu();
                   void requestClose(s);
                 }}
               >
-                <IconClose />
+                <IconEject />
                 <span>Close</span>
               </button>
             </div>,

--- a/src/renderer/src/components/WorkspaceTabStrip.tsx
+++ b/src/renderer/src/components/WorkspaceTabStrip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { WorkspaceObservabilitySummary } from '../../../preload';
 import { colorFor, type WorkspaceState, type WorkspaceSummary } from '../App';
@@ -6,6 +6,8 @@ import { isManager, isReachable, ManagerGlyph, WifiGlyph } from './committee';
 import { useBlinkSync } from '../blinkSync';
 import { setInternalDragActive } from '../dropIngestion';
 import { dotClass } from './chipState';
+import { usePortalMenu } from './portalMenu';
+import { IconCopy, IconEject, IconPause, IconPencil, IconPlay, IconStop, IconTrash } from './menuIcons';
 
 /**
  * The chip's status dot. A separate component so the busy pulse can be
@@ -83,24 +85,6 @@ function chipActivityText(s: WorkspaceObservabilitySummary | null | undefined): 
 }
 
 
-// ── Media-control icons for the menu ─────────────────────────────────
-// All sized to a 12×12 viewBox so they sit on the menu's text baseline.
-// `currentColor` lets each menu item pick up its hover/danger styling.
-function IconPlay(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <path d="M3 2 L10 6 L3 10 Z" />
-    </svg>
-  );
-}
-function IconPause(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <rect x="3" y="2" width="2.4" height="8" rx="0.6" />
-      <rect x="6.6" y="2" width="2.4" height="8" rx="0.6" />
-    </svg>
-  );
-}
 function IconGear(): JSX.Element {
   return (
     <svg
@@ -119,64 +103,6 @@ function IconGear(): JSX.Element {
     </svg>
   );
 }
-function IconStop(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <rect x="2.5" y="2.5" width="7" height="7" rx="0.8" />
-    </svg>
-  );
-}
-function IconEject(): JSX.Element {
-  // Used for Close — eject is the natural "remove the media" sibling of
-  // play/pause/stop, and reads as "take this out" instead of "delete."
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <path d="M6 2 L10 8 L2 8 Z" />
-      <rect x="2" y="9" width="8" height="1.6" rx="0.4" />
-    </svg>
-  );
-}
-function IconEdit(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
-      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
-    </svg>
-  );
-}
-function IconCopy(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
-      <rect x="3" y="3" width="7" height="8" rx="0.8" />
-      <path d="M2 8 V2 a1 1 0 0 1 1 -1 H8" />
-    </svg>
-  );
-}
-function IconTrash(): JSX.Element {
-  return (
-    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
-      <path d="M4 1 H8 V2 H11 V3 H1 V2 H4 Z M2 4 H10 L9 11 H3 Z" />
-    </svg>
-  );
-}
-
-/**
- * Compute the screen-coordinate position of the menu, anchored to the
- * trigger button's bottom-right corner. Clamps so the menu can't overflow
- * the viewport on the right edge.
- */
-function menuPositionFor(triggerEl: HTMLElement): { top: number; right: number } {
-  const rect = triggerEl.getBoundingClientRect();
-  const right = Math.max(8, window.innerWidth - rect.right);
-  const top = rect.bottom + 4;
-  return { top, right };
-}
-
-interface MenuAnchor {
-  for: string;
-  top: number;
-  right: number;
-}
-
 export function WorkspaceTabStrip({
   workspaces,
   summaries,
@@ -195,41 +121,19 @@ export function WorkspaceTabStrip({
   onRefresh,
   onReorderWorkspace
 }: Props) {
-  // Single open menu at a time. `for` = workspace id; top/right are
-  // viewport coordinates for the portaled menu.
-  const [menu, setMenu] = useState<MenuAnchor | null>(null);
+  // Chip ⋮ menu — shared portaled-menu mechanics (right-anchored).
+  const { menu, toggle: toggleMenu, close: closeMenu } = usePortalMenu();
   // Id of the chip currently being dragged (for reorder), null when idle.
   const [dragId, setDragId] = useState<string | null>(null);
-
-  // Close the menu on any outside click, Escape, or layout disturbance
-  // (scroll / resize) — the portal positions the menu in viewport coords,
-  // so we can't easily follow the trigger when the page moves.
-  useEffect(() => {
-    if (menu === null) return;
-    const close = (): void => setMenu(null);
-    const escClose = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setMenu(null);
-    };
-    document.addEventListener('click', close);
-    document.addEventListener('keydown', escClose);
-    window.addEventListener('scroll', close, true);
-    window.addEventListener('resize', close);
-    return () => {
-      document.removeEventListener('click', close);
-      document.removeEventListener('keydown', escClose);
-      window.removeEventListener('scroll', close, true);
-      window.removeEventListener('resize', close);
-    };
-  }, [menu]);
 
   // Top strip = the "warm" fleet: running + paused only (instant switch).
   // "stopped" and "deleted" are the "cold" fleet — they live in the
   // workspace modal's Saved list and need a restart (#21).
   const live = workspaces.filter((w) => w.state === 'running' || w.state === 'paused');
-  const menuWorkspace = menu ? live.find((w) => w.id === menu.for) ?? null : null;
+  const menuWorkspace = menu ? live.find((w) => w.id === menu.id) ?? null : null;
 
   async function doAction(action: 'start' | 'pause' | 'stop', w: WorkspaceSummary): Promise<void> {
-    setMenu(null);
+    closeMenu();
     try {
       if (action === 'start') {
         await window.api.workspace.start(w.id);
@@ -339,15 +243,10 @@ export function WorkspaceTabStrip({
             className="ws-chip-menu-trigger"
             aria-label={`Actions for ${w.name}`}
             aria-haspopup="menu"
-            aria-expanded={menu?.for === w.id}
+            aria-expanded={menu?.id === w.id}
             onClick={(e) => {
               e.stopPropagation();
-              if (menu?.for === w.id) {
-                setMenu(null);
-                return;
-              }
-              const pos = menuPositionFor(e.currentTarget);
-              setMenu({ for: w.id, ...pos });
+              toggleMenu(e.currentTarget, w.id, 'right');
             }}
             title="Workspace actions"
           >
@@ -436,17 +335,17 @@ export function WorkspaceTabStrip({
             <button
               role="menuitem"
               onClick={() => {
-                setMenu(null);
+                closeMenu();
                 onEditWorkspace(menuWorkspace);
               }}
             >
-              <IconEdit />
+              <IconPencil />
               <span>Edit…</span>
             </button>
             <button
               role="menuitem"
               onClick={() => {
-                setMenu(null);
+                closeMenu();
                 onCloneWorkspace(menuWorkspace);
               }}
             >
@@ -458,7 +357,7 @@ export function WorkspaceTabStrip({
               role="menuitem"
               className="danger"
               onClick={() => {
-                setMenu(null);
+                closeMenu();
                 onCloseWorkspace(menuWorkspace);
               }}
             >
@@ -469,7 +368,7 @@ export function WorkspaceTabStrip({
               role="menuitem"
               className="danger"
               onClick={() => {
-                setMenu(null);
+                closeMenu();
                 onDeleteWorkspace(menuWorkspace);
               }}
               title="Permanently delete (purges state dir + keychain entries)"

--- a/src/renderer/src/components/menuIcons.tsx
+++ b/src/renderer/src/components/menuIcons.tsx
@@ -1,0 +1,78 @@
+// Icons for the portaled `.ws-chip-menu` dropdowns (#264) — previously
+// duplicated per component (the pencil existed three times). All sized to a
+// 12×12 viewBox so they sit on the menu's text baseline; `currentColor` lets
+// each menu item pick up its hover/danger styling. Named by glyph, not by
+// call-site action, since the same glyph serves different actions (the pencil
+// is Edit… on a chip and Rename on a tab/row).
+
+export function IconPlay(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M3 2 L10 6 L3 10 Z" />
+    </svg>
+  );
+}
+export function IconPause(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <rect x="3" y="2" width="2.4" height="8" rx="0.6" />
+      <rect x="6.6" y="2" width="2.4" height="8" rx="0.6" />
+    </svg>
+  );
+}
+export function IconStop(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <rect x="2.5" y="2.5" width="7" height="7" rx="0.8" />
+    </svg>
+  );
+}
+export function IconEject(): JSX.Element {
+  // Used for Close — eject is the natural "remove the media" sibling of
+  // play/pause/stop, and reads as "take this out" instead of "delete."
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M6 2 L10 8 L2 8 Z" />
+      <rect x="2" y="9" width="8" height="1.6" rx="0.4" />
+    </svg>
+  );
+}
+export function IconPencil(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <path d="M2 9 L9 2 L11 4 L4 11 L2 11 Z" />
+    </svg>
+  );
+}
+export function IconCopy(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
+      <rect x="3" y="3" width="7" height="8" rx="0.8" />
+      <path d="M2 8 V2 a1 1 0 0 1 1 -1 H8" />
+    </svg>
+  );
+}
+export function IconTrash(): JSX.Element {
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M4 1 H8 V2 H11 V3 H1 V2 H4 Z M2 4 H10 L9 11 H3 Z" />
+    </svg>
+  );
+}
+export function IconRefresh(): JSX.Element {
+  // Circular arrow — resume / refresh a session.
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M10 6 A4 4 0 1 1 8.6 3" />
+      <path d="M10.4 1.6 L10.4 4 L8 4" />
+    </svg>
+  );
+}
+export function IconAuto(): JSX.Element {
+  // A sparkle — "let Claude name it".
+  return (
+    <svg viewBox="0 0 12 12" width="11" height="11" fill="currentColor" aria-hidden="true">
+      <path d="M6 1 L7 4.5 L10.5 6 L7 7.5 L6 11 L5 7.5 L1.5 6 L5 4.5 Z" />
+    </svg>
+  );
+}

--- a/src/renderer/src/components/portalMenu.test.ts
+++ b/src/renderer/src/components/portalMenu.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { leftAnchor, rightAnchor } from './portalMenu';
+
+// Anchor math for the portaled ⋮ menus (#264). Geometry contract:
+// MENU_WIDTH=188 (the widest .ws-chip-menu incl. padding/border slack),
+// VIEWPORT_MARGIN=8, TRIGGER_GAP=4 — values carried over verbatim from the
+// three pre-extraction copies (WorkspaceTabStrip / TerminalPane / SessionsPane).
+
+const rect = (left: number, right: number, bottom: number) => ({ left, right, bottom });
+
+describe('leftAnchor', () => {
+  it('passes the trigger left edge through when the menu fits', () => {
+    expect(leftAnchor(rect(100, 120, 50), 1000)).toEqual({ top: 54, left: 100 });
+  });
+
+  it('clamps so the menu cannot overflow the right viewport edge', () => {
+    // innerWidth 1000 - MENU_WIDTH 188 = 812 max left.
+    expect(leftAnchor(rect(900, 920, 50), 1000).left).toBe(812);
+  });
+
+  it('floors at the viewport margin on a viewport narrower than the menu', () => {
+    // innerWidth 100 → innerWidth - 188 is negative → floor at 8.
+    expect(leftAnchor(rect(50, 70, 50), 100).left).toBe(8);
+  });
+
+  it('drops the menu below the trigger with a 4px gap', () => {
+    expect(leftAnchor(rect(0, 20, 33), 1000).top).toBe(37);
+  });
+});
+
+describe('rightAnchor', () => {
+  it('mirrors the trigger right edge as a distance from the viewport right edge', () => {
+    expect(rightAnchor(rect(900, 950, 50), 1000)).toEqual({ top: 54, right: 50 });
+  });
+
+  it('floors at the viewport margin when the trigger touches the right edge', () => {
+    expect(rightAnchor(rect(960, 998, 50), 1000).right).toBe(8);
+  });
+});

--- a/src/renderer/src/components/portalMenu.tsx
+++ b/src/renderer/src/components/portalMenu.tsx
@@ -1,0 +1,98 @@
+// Shared mechanics for the portaled ⋮ dropdown menus (#264) — the workspace
+// chips (WorkspaceTabStrip), session tabs (TerminalPane), and session rows
+// (SessionsPane) all render the same `.ws-chip-menu` pattern: one open menu
+// per component, `position: fixed` at viewport coordinates, closed on any
+// outside click / Escape / layout disturbance. This module owns the anchor
+// state, the close listeners, and the position math; menu *contents* stay in
+// each component.
+
+import { useEffect, useState } from 'react';
+
+// Geometry shared by the anchor helpers. MENU_WIDTH is the widest rendered
+// `.ws-chip-menu` (CSS min-width 160px + padding/border slack) — used to
+// clamp a left-anchored menu fully on-screen.
+const MENU_WIDTH = 188;
+const VIEWPORT_MARGIN = 8;
+const TRIGGER_GAP = 4;
+
+export interface MenuAnchor {
+  /** Id of the chip / tab / row whose menu is open. */
+  id: string;
+  top: number;
+  left?: number;
+  right?: number;
+}
+
+/** The subset of DOMRect the anchor math reads — pure and unit-testable. */
+export interface AnchorRect {
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+/** Anchor to the trigger's bottom-left corner, clamped on-screen. */
+export function leftAnchor(rect: AnchorRect, innerWidth: number): { top: number; left: number } {
+  return {
+    top: rect.bottom + TRIGGER_GAP,
+    left: Math.max(VIEWPORT_MARGIN, Math.min(rect.left, innerWidth - MENU_WIDTH))
+  };
+}
+
+/** Anchor to the trigger's bottom-right corner (menu grows leftward). */
+export function rightAnchor(rect: AnchorRect, innerWidth: number): { top: number; right: number } {
+  return {
+    top: rect.bottom + TRIGGER_GAP,
+    right: Math.max(VIEWPORT_MARGIN, innerWidth - rect.right)
+  };
+}
+
+/**
+ * One-open-menu-at-a-time state for a portaled dropdown. `toggle` closes the
+ * menu when it is already open for `id`, otherwise opens it anchored to the
+ * trigger (left-anchored by default; `'right'` for right-aligned menus like
+ * the workspace chips'). The trigger's click handler must stopPropagation so
+ * the opening click doesn't reach the document-level close listener.
+ */
+export function usePortalMenu(): {
+  menu: MenuAnchor | null;
+  toggle: (trigger: HTMLElement, id: string, side?: 'left' | 'right') => void;
+  close: () => void;
+} {
+  const [menu, setMenu] = useState<MenuAnchor | null>(null);
+
+  // Close the menu on any outside click / Escape / layout shift (the portal is
+  // positioned in viewport coords, so we can't follow the trigger when it
+  // moves). Scroll uses the capture phase: scroll events don't bubble, but
+  // capture on window still sees descendant scrolls (the lists scroll, not
+  // the window).
+  useEffect(() => {
+    if (!menu) return;
+    const close = (): void => setMenu(null);
+    const esc = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setMenu(null);
+    };
+    document.addEventListener('click', close);
+    document.addEventListener('keydown', esc);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('click', close);
+      document.removeEventListener('keydown', esc);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [menu]);
+
+  const toggle = (trigger: HTMLElement, id: string, side: 'left' | 'right' = 'left'): void => {
+    setMenu((prev) => {
+      if (prev?.id === id) return null;
+      const rect = trigger.getBoundingClientRect();
+      return {
+        id,
+        ...(side === 'right' ? rightAnchor(rect, window.innerWidth) : leftAnchor(rect, window.innerWidth))
+      };
+    });
+  };
+
+  return { menu, toggle, close: () => setMenu(null) };
+}


### PR DESCRIPTION
Supersedes #265, which GitHub auto-closed when the stacked base branch (`worktree-session-row-kebab`, #263) was deleted on merge. Same commits, **rebased onto `main`** now that #263 has landed; no content changes. Verified post-rebase: `portalMenu` unit test 6/6, web typecheck clean, no rebase conflicts.

Closes #264.

---

Closes #264. **Stacked on #263** — base is `worktree-session-row-kebab`; retarget to `main` (or let GitHub auto-retarget) once #263 merges.

## Change

The portaled `.ws-chip-menu` mechanics were hand-rolled three times (workspace chips, session tabs, session rows): anchor state, the close-on-outside-click/Escape/scroll/resize effect, and the 188/8/4 viewport-clamp constants. The menu SVG icons were also duplicated per component — the pencil existed three times.

- **`portalMenu.tsx`** — `usePortalMenu()` hook (one open menu at a time, `toggle`/`close`, owns the close listeners) plus pure, unit-tested `leftAnchor`/`rightAnchor` position math with the geometry constants named in one place.
- **`menuIcons.tsx`** — the nine menu glyphs, named by glyph (`IconPencil`, `IconRefresh`, `IconEject`, …) since the same glyph serves different actions per menu. `IconGear` stays in the tab strip (top-strip button, not a menu icon).
- All three components migrated; menu contents stay per-component. Pure refactor — no behavior, IPC, or SPEC change.
- One deliberate visual nit: the session-row **Delete** icon switches from the one-off stroke trash (added in #263) to the shared filled `IconTrash` the chip menu uses.

## Testing

- New `portalMenu.test.ts` covers the anchor math (pass-through, right-edge clamp, narrow-viewport floor, trigger gap, right-anchor mirror).
- `npm run typecheck` clean; `npm run test:unit` 489/489; `npm run build` ✓ (renderer bundle −3 KB).
- Not verified interactively (no display in this container) — the three menus deserve a quick open/close/Escape/scroll spot-check on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
