### PR TITLE
chore: release v0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.10.0 draft release. Since v0.9.0:

- feat: local-workspace launcher — run claude in WSL (distro + login shell) or via custom command (#257)
- feat(form): Model picker row replaces the Endpoint auth radio (#256) (#262)
- feat(ui): settings modal design-language alignment + Feather gear icon (#271)
- Collapse session-row actions into a portaled ⋮ menu (#263), shared usePortalMenu hook (#270)
- fix: settle ConPTY after spawn so local Windows workspaces stop overlapping (#269)
- fix: gate dev-server preview toast behind an HTTP probe (broken-link toasts) (#272)

After merge, `release.yml` will be dispatched with `tag=v0.10.0` to build the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)