### PR TITLE
Fix modals closing when a text-selection drag releases over the backdrop

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -176,6 +176,7 @@ A running chip also surfaces a **waiting indicator** — a violet (`--wait`) sta
 - **Bottom row** (`BottomBar`): static hint bar with key bindings and degraded-vault notice when applicable.
 
 Modals owned by `App`:
+- All modals render inside the shared `ModalBackdrop` component, which dismisses only when a left-button press **starts and ends on the backdrop element itself** (tracked via mousedown/mouseup targets, pure logic in `backdropDismiss.ts`) — a plain `onClick={onClose}` backdrop would also close on a text-selection drag that releases over the backdrop, because the browser fires `click` on the common ancestor of the down/up targets. Passing `onClose={undefined}` disables backdrop dismissal (used while a modal is `busy`).
 - `WorkspaceModal` — tabbed shell with Saved + New tabs (underlined-tab style). Body of each tab uses `WorkspaceForm` — the field-level form component owns state, validation, and footer; New tab renders it in `mode='create'`, expanded Saved-tab rows render it in `mode='edit'`. Saved-row expanded footer is `Delete · Cancel · Clone · Resume`; New-tab footer is `Cancel · Create & start`.
 - `EditWorkspaceModal` — single-purpose modal for editing a *live* workspace. Opened from the chip ⋮ menu Edit entry. Wraps `WorkspaceForm` in `mode='edit'`. On Save, calls `workspace:writeManifest` + diffs pre/post specs; container-level changes flip the restart-to-apply banner in the workspace's TerminalPane.
 - `CloseWorkspaceModal` — Stop / Pause / Stop & remove (keeps state dir).

--- a/src/renderer/src/components/AdvancedImageSearchModal.tsx
+++ b/src/renderer/src/components/AdvancedImageSearchModal.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { WorkspaceSummary } from '../App';
+import { ModalBackdrop } from './ModalBackdrop';
 
 export interface ImageEntry {
   ref: string;
@@ -148,7 +149,7 @@ export function AdvancedImageSearchModal({
     );
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
         <div className="modal-tabs" role="tablist">
           <div className="modal-tab active" aria-current="page">
@@ -306,7 +307,7 @@ export function AdvancedImageSearchModal({
           )}
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }
 

--- a/src/renderer/src/components/CloseWorkspaceModal.tsx
+++ b/src/renderer/src/components/CloseWorkspaceModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { WorkspaceSummary } from '../App';
+import { ModalBackdrop } from './ModalBackdrop';
 
 interface Props {
   workspace: WorkspaceSummary;
@@ -99,7 +100,7 @@ export function CloseWorkspaceModal({ workspace, onClose, onClosed }: Props) {
   };
 
   return (
-    <div className="modal-backdrop" onClick={busy ? undefined : onClose}>
+    <ModalBackdrop onClose={busy ? undefined : onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h2>Close workspace</h2>
         <p className="modal-eyebrow">
@@ -163,6 +164,6 @@ export function CloseWorkspaceModal({ workspace, onClose, onClosed }: Props) {
           </button>
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }

--- a/src/renderer/src/components/DeleteWorkspaceModal.tsx
+++ b/src/renderer/src/components/DeleteWorkspaceModal.tsx
@@ -5,6 +5,7 @@
 
 import { useState } from 'react';
 import type { WorkspaceSummary } from '../App';
+import { ModalBackdrop } from './ModalBackdrop';
 
 interface Props {
   workspace: WorkspaceSummary;
@@ -61,7 +62,7 @@ export function DeleteWorkspaceModal({ workspace, onClose, onDeleted }: Props) {
   };
 
   return (
-    <div className="modal-backdrop" onClick={busy ? undefined : onClose}>
+    <ModalBackdrop onClose={busy ? undefined : onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h2>Delete workspace</h2>
         <p className="modal-eyebrow">{workspace.name}</p>
@@ -83,6 +84,6 @@ export function DeleteWorkspaceModal({ workspace, onClose, onDeleted }: Props) {
           </button>
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }

--- a/src/renderer/src/components/EditWorkspaceModal.tsx
+++ b/src/renderer/src/components/EditWorkspaceModal.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react';
 import { WorkspaceForm, type WorkspaceFormSubmit } from './WorkspaceForm';
 import { DeleteWorkspaceModal } from './DeleteWorkspaceModal';
 import { workspaceToFormInitial } from './formInitial';
+import { ModalBackdrop } from './ModalBackdrop';
 import type { WorkspaceSummary } from '../App';
 
 interface Props {
@@ -80,7 +81,7 @@ export function EditWorkspaceModal({
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
         <div className="modal-tabs" role="tablist">
           <div className="modal-tab active" aria-current="page">
@@ -102,7 +103,7 @@ export function EditWorkspaceModal({
           />
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }
 

--- a/src/renderer/src/components/LoadoutBrowserModal.tsx
+++ b/src/renderer/src/components/LoadoutBrowserModal.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { WorkspaceSummary } from '../App';
+import { ModalBackdrop } from './ModalBackdrop';
 
 type Entry = Awaited<ReturnType<typeof window.api.loadouts.catalog>>[number];
 
@@ -87,7 +88,7 @@ export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: P
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal loadout-browser" onClick={(ev) => ev.stopPropagation()}>
         <div className="lb-head">
           <span className="eyebrow">Loadouts · browse</span>
@@ -191,6 +192,6 @@ export default function LoadoutBrowserModal({ workspace, onClose, onChanged }: P
           </ul>
         </div>
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }

--- a/src/renderer/src/components/LoadoutReviewModal.tsx
+++ b/src/renderer/src/components/LoadoutReviewModal.tsx
@@ -4,6 +4,7 @@
 // loadout's source folder via the WSL-aware fs:openPath.
 
 import { useEffect, useState } from 'react';
+import { ModalBackdrop } from './ModalBackdrop';
 
 interface LoadoutDetail {
   id: string;
@@ -104,7 +105,7 @@ export function LoadoutReviewModal({
   const toolDeps = detail ? depList(detail.dependencies?.tools) : [];
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal loadout-review" onClick={(e) => e.stopPropagation()}>
         <div className="lr-head">
           <span className="eyebrow">Loadout · review</span>
@@ -255,6 +256,6 @@ export function LoadoutReviewModal({
           </>
         )}
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }

--- a/src/renderer/src/components/ModalBackdrop.tsx
+++ b/src/renderer/src/components/ModalBackdrop.tsx
@@ -1,0 +1,28 @@
+// Shared modal backdrop. Every modal renders inside this instead of a raw
+// <div className="modal-backdrop" onClick={onClose}> so that dismissal only
+// happens when the press starts and ends on the backdrop — see
+// backdropDismiss.ts for why onClick alone closes on text-selection drags.
+
+import { useRef, type ReactNode } from 'react';
+import { createBackdropDismiss } from './backdropDismiss';
+
+interface Props {
+  /** Omit (undefined) to disable backdrop dismissal, e.g. while busy. */
+  onClose?: () => void;
+  children: ReactNode;
+}
+
+export function ModalBackdrop({ onClose, children }: Props) {
+  const dismiss = useRef(createBackdropDismiss());
+  return (
+    <div
+      className="modal-backdrop"
+      onMouseDown={(e) => dismiss.current.mouseDown(e.target === e.currentTarget, e.button)}
+      onMouseUp={(e) => {
+        if (dismiss.current.mouseUp(e.target === e.currentTarget)) onClose?.();
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/src/components/SettingsModal.tsx
+++ b/src/renderer/src/components/SettingsModal.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from 'react';
 import type { PerfStatusPayload, UsageBudgetPreset, UiPrefs } from '../../../preload';
+import { ModalBackdrop } from './ModalBackdrop';
 
 /** Compact token formatter for preset labels (e.g. 19_000_000 → "19M"). */
 function fmtTokens(n: number): string {
@@ -308,7 +309,7 @@ export function SettingsModal({ onClose, onSaved, initialTab }: Props) {
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
         <div className="modal-tabs" role="tablist">
           <div
@@ -779,7 +780,7 @@ export function SettingsModal({ onClose, onSaved, initialTab }: Props) {
           </div>
         )}
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }
 

--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -19,6 +19,7 @@ import type { WorkspaceObservabilitySummary } from '../../../preload';
 import type { MirrorSetting, CleanupSetting } from '../App';
 import { TerminalSession } from './TerminalSession';
 import { ToastView } from './Toast';
+import { ModalBackdrop } from './ModalBackdrop';
 import { makeToast } from '../toasts';
 import { readyToRefresh } from './refreshQueue';
 import { useBlinkSync } from '../blinkSync';
@@ -934,7 +935,7 @@ export function TerminalPane({
         )}
       </div>
       {closeTarget && (
-        <div className="modal-backdrop" onClick={() => setCloseTarget(null)}>
+        <ModalBackdrop onClose={() => setCloseTarget(null)}>
           <div className="modal mirror-close-modal" onClick={(e) => e.stopPropagation()}>
             <h3>Close {closeTarget.name}</h3>
             <p className="form-hint">
@@ -961,7 +962,7 @@ export function TerminalPane({
               </button>
             </div>
           </div>
-        </div>
+        </ModalBackdrop>
       )}
     </div>
   );

--- a/src/renderer/src/components/WorkspaceModal.tsx
+++ b/src/renderer/src/components/WorkspaceModal.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ulid } from 'ulid';
 import { colorFor, type WorkspaceSummary } from '../App';
+import { ModalBackdrop } from './ModalBackdrop';
 import {
   WorkspaceForm,
   type WorkspaceFormSubmit
@@ -191,7 +192,7 @@ export function WorkspaceModal({
   };
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
+    <ModalBackdrop onClose={onClose}>
       <div className="modal modal-tabbed" onClick={(e) => e.stopPropagation()}>
         <div className="modal-tabs" role="tablist">
           <button
@@ -396,7 +397,7 @@ export function WorkspaceModal({
           </div>
         )}
       </div>
-    </div>
+    </ModalBackdrop>
   );
 }
 

--- a/src/renderer/src/components/backdropDismiss.test.ts
+++ b/src/renderer/src/components/backdropDismiss.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { createBackdropDismiss } from './backdropDismiss';
+
+describe('createBackdropDismiss', () => {
+  it('closes on a plain left-click that starts and ends on the backdrop', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 0);
+    expect(d.mouseUp(true)).toBe(true);
+  });
+
+  it('does not close when the press started inside the panel (text-selection drag out)', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(false, 0);
+    expect(d.mouseUp(true)).toBe(false);
+  });
+
+  it('does not close when the press started on the backdrop but released over the panel', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 0);
+    expect(d.mouseUp(false)).toBe(false);
+  });
+
+  it('does not close on non-left buttons', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 2);
+    expect(d.mouseUp(true)).toBe(false);
+  });
+
+  it('disarms after each release — a stray mouseup without a new press never closes', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 0);
+    expect(d.mouseUp(true)).toBe(true);
+    expect(d.mouseUp(true)).toBe(false);
+  });
+
+  it('disarms even when the release did not close (drag released over panel, then stray up)', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 0);
+    expect(d.mouseUp(false)).toBe(false);
+    expect(d.mouseUp(true)).toBe(false);
+  });
+
+  it('recovers after a release outside the window (no mouseup seen): next full click closes', () => {
+    const d = createBackdropDismiss();
+    d.mouseDown(true, 0);
+    // release happened off-window — no mouseUp delivered
+    d.mouseDown(true, 0);
+    expect(d.mouseUp(true)).toBe(true);
+  });
+});

--- a/src/renderer/src/components/backdropDismiss.ts
+++ b/src/renderer/src/components/backdropDismiss.ts
@@ -1,0 +1,29 @@
+// Decides when a backdrop press should dismiss a modal. A naive
+// onClick={onClose} on the backdrop closes on any click whose common
+// ancestor is the backdrop — including a text-selection drag that starts
+// inside the panel and releases over the backdrop (the browser fires the
+// click on the nearest common ancestor of mousedown and mouseup targets).
+// Instead, require a left-button press that both starts AND ends on the
+// backdrop element itself. Kept as a pure state machine so it's unit
+// testable (vitest here has no DOM environment).
+
+export interface BackdropDismiss {
+  /** Call from the backdrop's mousedown. `onBackdrop` = event target is the backdrop itself. */
+  mouseDown(onBackdrop: boolean, button: number): void;
+  /** Call from the backdrop's mouseup. Returns true when the modal should close. */
+  mouseUp(onBackdrop: boolean): boolean;
+}
+
+export function createBackdropDismiss(): BackdropDismiss {
+  let armed = false;
+  return {
+    mouseDown(onBackdrop, button) {
+      armed = onBackdrop && button === 0;
+    },
+    mouseUp(onBackdrop) {
+      const close = armed && onBackdrop;
+      armed = false;
+      return close;
+    }
+  };
+}


### PR DESCRIPTION
## Problem

Modals dismissed on mouse *release*: highlighting text inside a modal and letting go of the button outside the panel (or off the window edge, over the full-viewport backdrop) closed the modal and threw away form state.

**Root cause:** every backdrop was `<div className="modal-backdrop" onClick={onClose}>`. The DOM fires `click` on the **nearest common ancestor** of the mousedown and mouseup targets — so a drag that starts in the panel and releases over the backdrop makes the backdrop itself the click target, and the panel's `stopPropagation` never runs.

## Fix

- New shared `ModalBackdrop` component: closes only when a **left-button press starts AND ends on the backdrop element itself** (`mousedown`/`mouseup` target checks). Selection drags in either direction, non-left buttons, and off-window releases never dismiss; a plain backdrop click behaves exactly as before.
- Decision logic lives in a pure `backdropDismiss.ts` state machine with 7 unit tests (vitest has no DOM env, so the component stays a thin wrapper).
- All nine backdrop call sites swapped (`WorkspaceModal`, `EditWorkspaceModal`, `CloseWorkspaceModal`, `DeleteWorkspaceModal`, `SettingsModal`, `AdvancedImageSearchModal`, `LoadoutBrowserModal`, `LoadoutReviewModal`, `TerminalPane` mirror-close). The `busy ? undefined : onClose` guards carry over unchanged.
- One-line SPEC note under *Modals owned by App* recording the convention.

## Verification

Gated with `typecheck` + `test:unit` (618 passed, incl. 7 new) + `build` — **no UI verification in this container** (no display); please eyeball on the host: open any modal, select text dragging out of the panel, release → modal should stay open; a plain click on the dimmed area should still close it. No Playwright specs click the backdrop, so e2e is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)