### PR TITLE
Fix session-tab drag reorder no-op (#177 flag never wired for session tabs)

### DIFF
--- a/src/renderer/src/components/TerminalPane.tsx
+++ b/src/renderer/src/components/TerminalPane.tsx
@@ -21,6 +21,7 @@ import { TerminalSession } from './TerminalSession';
 import { ToastView } from './Toast';
 import { makeToast } from '../toasts';
 import { readyToRefresh } from './refreshQueue';
+import { reorderDragHandlers } from '../dropIngestion';
 import { useBlinkSync } from '../blinkSync';
 import { usePortalMenu } from './portalMenu';
 import { IconAuto, IconEject, IconPencil, IconRefresh } from './menuIcons';
@@ -719,19 +720,12 @@ export function TerminalPane({
               onClick={() => setActiveId(s.id)}
               // Don't drag while editing the name (the input owns the pointer).
               draggable={renamingId !== s.id}
-              onDragStart={(e) => {
-                setDragSessionId(s.id);
-                e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragOver={(e) => {
-                if (dragSessionId && dragSessionId !== s.id) e.preventDefault();
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                if (dragSessionId && dragSessionId !== s.id) reorderSessions(dragSessionId, s.id);
-                setDragSessionId(null);
-              }}
-              onDragEnd={() => setDragSessionId(null)}
+              {...reorderDragHandlers({
+                id: s.id,
+                dragId: dragSessionId,
+                setDragId: setDragSessionId,
+                onReorder: reorderSessions
+              })}
             >
               <SessionTabDot ended={ended} busy={busyIds.has(s.id)} waiting={tabWaiting} />
               {renamingId === s.id ? (

--- a/src/renderer/src/components/WorkspaceTabStrip.tsx
+++ b/src/renderer/src/components/WorkspaceTabStrip.tsx
@@ -4,7 +4,7 @@ import type { WorkspaceObservabilitySummary } from '../../../preload';
 import { colorFor, type WorkspaceState, type WorkspaceSummary } from '../App';
 import { isManager, isReachable, ManagerGlyph, WifiGlyph } from './committee';
 import { useBlinkSync } from '../blinkSync';
-import { setInternalDragActive } from '../dropIngestion';
+import { reorderDragHandlers } from '../dropIngestion';
 import { dotClass } from './chipState';
 import { usePortalMenu } from './portalMenu';
 import { IconCopy, IconEject, IconPause, IconPencil, IconPlay, IconStop, IconTrash } from './menuIcons';
@@ -171,29 +171,12 @@ export function WorkspaceTabStrip({
           }`}
           style={{ ['--hue' as never]: colorFor(w) }}
           draggable
-          onDragStart={(e) => {
-            setDragId(w.id);
-            e.dataTransfer.effectAllowed = 'move';
-            // Tell the window-level file-ingestion handlers to stay out of this
-            // internal drag — otherwise its dragover forces dropEffect='copy'
-            // over our 'move' and cancels the reorder drop (#177).
-            setInternalDragActive(true);
-          }}
-          onDragOver={(e) => {
-            if (dragId && dragId !== w.id) e.preventDefault(); // allow drop
-          }}
-          onDrop={(e) => {
-            e.preventDefault();
-            if (dragId && dragId !== w.id) onReorderWorkspace(dragId, w.id);
-            setDragId(null);
-            setInternalDragActive(false);
-          }}
-          onDragEnd={() => {
-            setDragId(null);
-            // dragend always fires (drop or cancel), so this is the guaranteed
-            // clear; the onDrop clear above just frees it a beat earlier.
-            setInternalDragActive(false);
-          }}
+          {...reorderDragHandlers({
+            id: w.id,
+            dragId,
+            setDragId,
+            onReorder: onReorderWorkspace
+          })}
         >
           <button
             className="ws-chip"

--- a/src/renderer/src/dropIngestion.test.ts
+++ b/src/renderer/src/dropIngestion.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { isExternalDrag, shouldClaimDragOver } from './dropIngestion';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isExternalDrag,
+  isInternalDragActive,
+  reorderDragHandlers,
+  setInternalDragActive,
+  shouldClaimDragOver
+} from './dropIngestion';
 
 describe('isExternalDrag', () => {
   // #147: an internal workspace-chip reorder drag carries effectAllowed='move'
@@ -44,5 +50,94 @@ describe('shouldClaimDragOver', () => {
 
   it('claims dragover for ordinary (external) drags so the copy cursor shows', () => {
     expect(shouldClaimDragOver(false)).toBe(true);
+  });
+});
+
+describe('reorderDragHandlers', () => {
+  // Session-tab reorder regression: TerminalPane wired its own drag handlers
+  // without setInternalDragActive, so the window-level dragover still forced
+  // dropEffect='copy' over the tab's 'move' and the drop never fired (the same
+  // mechanism as #177, which was only fixed for workspace chips). The shared
+  // factory exists so every internal reorder drag gets the flag wiring; these
+  // tests pin that contract.
+  interface FakeEvent {
+    preventDefault(): void;
+    dataTransfer: { effectAllowed: string };
+    defaultPrevented: boolean;
+  }
+  function fakeEvent(): FakeEvent {
+    const e = {
+      defaultPrevented: false,
+      preventDefault(): void {
+        e.defaultPrevented = true;
+      },
+      dataTransfer: { effectAllowed: 'uninitialized' }
+    };
+    return e;
+  }
+
+  let dragId: string | null = null;
+  let reorders: Array<[string, string]> = [];
+  const opts = (id: string): Parameters<typeof reorderDragHandlers>[0] => ({
+    id,
+    dragId,
+    setDragId: (v) => {
+      dragId = v;
+    },
+    onReorder: (draggedId, targetId) => {
+      reorders.push([draggedId, targetId]);
+    }
+  });
+
+  beforeEach(() => {
+    dragId = null;
+    reorders = [];
+    setInternalDragActive(false);
+  });
+
+  it('dragstart marks the drag internal so window dragover stays out (#177)', () => {
+    const e = fakeEvent();
+    reorderDragHandlers(opts('a')).onDragStart(e);
+    expect(isInternalDragActive()).toBe(true);
+    expect(shouldClaimDragOver(isInternalDragActive())).toBe(false);
+    expect(e.dataTransfer.effectAllowed).toBe('move');
+    expect(dragId).toBe('a');
+  });
+
+  it('dragover accepts the drop only over a different chip', () => {
+    dragId = 'a';
+    const over = fakeEvent();
+    reorderDragHandlers(opts('b')).onDragOver(over);
+    expect(over.defaultPrevented).toBe(true);
+
+    const self = fakeEvent();
+    reorderDragHandlers(opts('a')).onDragOver(self);
+    expect(self.defaultPrevented).toBe(false);
+  });
+
+  it('drop reorders dragged-before-target and clears the drag state', () => {
+    dragId = 'a';
+    setInternalDragActive(true);
+    reorderDragHandlers(opts('b')).onDrop(fakeEvent());
+    expect(reorders).toEqual([['a', 'b']]);
+    expect(dragId).toBeNull();
+    expect(isInternalDragActive()).toBe(false);
+  });
+
+  it('drop on the dragged chip itself is a no-op reorder but still clears state', () => {
+    dragId = 'a';
+    setInternalDragActive(true);
+    reorderDragHandlers(opts('a')).onDrop(fakeEvent());
+    expect(reorders).toEqual([]);
+    expect(dragId).toBeNull();
+    expect(isInternalDragActive()).toBe(false);
+  });
+
+  it('dragend clears the flag even for a cancelled drag (no drop)', () => {
+    dragId = 'a';
+    setInternalDragActive(true);
+    reorderDragHandlers(opts('a')).onDragEnd();
+    expect(dragId).toBeNull();
+    expect(isInternalDragActive()).toBe(false);
   });
 });

--- a/src/renderer/src/dropIngestion.ts
+++ b/src/renderer/src/dropIngestion.ts
@@ -55,6 +55,64 @@ export function setInternalDragActive(active: boolean): void {
   internalDragActive = active;
 }
 
+/** Read the internal-drag flag (for tests). */
+export function isInternalDragActive(): boolean {
+  return internalDragActive;
+}
+
+// The event surface the reorder handlers need — React.DragEvent satisfies it,
+// and tests can pass a plain object.
+interface ReorderDragEvent {
+  preventDefault(): void;
+  dataTransfer: { effectAllowed: string };
+}
+
+interface ReorderDragOpts {
+  /** This chip's id. */
+  id: string;
+  /** The id currently being dragged (the strip's drag state), or null. */
+  dragId: string | null;
+  setDragId: (id: string | null) => void;
+  /** Move `draggedId` before `targetId` in the strip's order. */
+  onReorder: (draggedId: string, targetId: string) => void;
+}
+
+/** Drag-reorder handlers for a chip/tab in a strip (workspace chips, session
+ *  tabs). Centralized so every internal reorder drag sets the internal-drag
+ *  flag — a strip that wires dragstart by hand and forgets the flag gets its
+ *  drop silently cancelled by the window-level ingestion dragover (#177:
+ *  forced dropEffect='copy' is incompatible with the drag's
+ *  effectAllowed='move', so Chromium resolves the operation to none). */
+export function reorderDragHandlers({ id, dragId, setDragId, onReorder }: ReorderDragOpts): {
+  onDragStart: (e: ReorderDragEvent) => void;
+  onDragOver: (e: ReorderDragEvent) => void;
+  onDrop: (e: ReorderDragEvent) => void;
+  onDragEnd: () => void;
+} {
+  return {
+    onDragStart(e) {
+      setDragId(id);
+      e.dataTransfer.effectAllowed = 'move';
+      setInternalDragActive(true);
+    },
+    onDragOver(e) {
+      if (dragId && dragId !== id) e.preventDefault(); // allow drop
+    },
+    onDrop(e) {
+      e.preventDefault();
+      if (dragId && dragId !== id) onReorder(dragId, id);
+      setDragId(null);
+      setInternalDragActive(false);
+    },
+    onDragEnd() {
+      setDragId(null);
+      // dragend always fires (drop or cancel), so this is the guaranteed
+      // clear; the onDrop clear above just frees it a beat earlier.
+      setInternalDragActive(false);
+    }
+  };
+}
+
 /** Whether the window-level ingestion should claim a `dragover` —
  *  `preventDefault()` + `dropEffect='copy'`. It must NOT claim an internal
  *  chip drag (#177): that drag carries `effectAllowed='move'`, and forcing


### PR DESCRIPTION
## Problem

Session tabs in the terminal pane can't be drag-reordered — the drop silently never fires (Troy's report: "session chips are not able to be reordered").

## Root cause

Same mechanism as #177: the window-level file-ingestion `dragover` claims every drag with `dropEffect='copy'` unless `internalDragActive` is set. The tab's drag carries `effectAllowed='move'`, and `'copy'` is incompatible with `'move'`, so Chromium resolves the drag operation to `none` and the tab's `drop` never fires.

The #177 fix wired `setInternalDragActive` into the **workspace chips** (WorkspaceTabStrip) but the **session tabs** in TerminalPane have their own hand-rolled drag handlers that never set the flag.

## Fix

Rather than copy the three flag calls into TerminalPane (leaving the same trap for the next strip), extract the chip/tab drag-reorder handlers into a shared `reorderDragHandlers()` factory in `dropIngestion.ts` — the module that owns the internal-drag flag — and use it for both workspace chips and session tabs. Behavior of the workspace chips is unchanged; session tabs gain the flag wiring they were missing.

## Tests

- New unit tests pin the factory contract: flag raised on dragstart (so `shouldClaimDragOver` yields), cleared on drop **and** dragend (cancelled drags), reorder fires only across distinct chips.
- `npm run test:unit` (636 passed), `npm run typecheck`, `npm run build` all green in-container.
- No UI verification here (no display in this workspace) — Troy, please eyeball: drag a session tab across another; also sanity-check workspace-chip reorder and a file drop onto the window still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)