### PR TITLE
chore: release v0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump 0.10.0 → 0.11.0 for the release. Once merged, tag `v0.11.0` triggers the draft-release build (installers for macOS/Windows/Linux, unsigned).

Included since 0.10.0:
- **#285** — local transcript indexer ingests nothing (scrub `CLAUDE_CODE_CHILD_SESSION` marker) — #288
- **#287** — tab-close orphans the claude process (reap via `pty:closeSessionByBroker`) — #289
- **#286** — authoritative busy/idle/waiting reconciler from claude peer-status files — #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)