### PR TITLE
fix(log): log pty detach/close at info, not error

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1645,6 +1645,11 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     handleBrokerSessionId.delete(sessionId);
     logError({
       source: 'main',
+      // Lifecycle diagnostics, not failures — logged at info to match pty-attach
+      // (a missing level defaults to 'error' in the DB sink). The unknown-handle
+      // branch is a normal no-op after tab-close reaps the handle first (#287),
+      // so error-level here buried real errors under routine tab churn.
+      level: 'info',
       type: 'pty-detach',
       message: present
         ? `pty:detach OK (live=${ptySessions.size})`
@@ -1664,6 +1669,8 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
     handleBrokerSessionId.delete(ptyHandleId);
     logError({
       source: 'main',
+      // Successful reap is a lifecycle event, not a failure — info, like pty-attach.
+      level: 'info',
       type: 'pty-close',
       message: `${via} OK (live=${ptySessions.size})`,
       extra: { ptyHandleId, live: ptySessions.size }


### PR DESCRIPTION
## Problem

Surfaced while verifying v0.11.0 against the live app. `pty:attach` logs at `info`, but `pty:detach` and `pty:closeSession`/`pty:closeSessionByBroker` omit `level`, and the DB sink defaults a missing level to **`error`**. So routine PTY lifecycle events land in the **error** log.

\#287's tab-close reap made this constant: every tab-close now writes
```
pty:closeSessionByBroker OK        (level: error)
pty:detach for unknown handle      (level: error)  ← benign no-op: the child's unmount detach hits the already-reaped handle
```
— two error-level lines per close, burying genuine errors under normal tab churn (seen live: three closes in a row, each pair error-level).

## Fix

Set `level: 'info'` on both the `pty-detach` and `pty-close` lifecycle logs, matching `pty-attach`. The messages/types/extra are unchanged, so anything grepping for them still works — they're just no longer classified as errors. `pty-attach-failed` (a real failure) stays at its level.

## Scope / risk

Diagnostics only — no behavior change, no IPC/data-model/user-flow change, so no `docs/SPEC.md` update per the spec-maintenance rule. No test asserts these levels; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)