### PR TITLE
chore: release v0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Version bump for the v0.12.0 release. Since v0.11.0:

* feat(version): embed the git build sha in the app version everywhere it surfaces (#299)
* fix: stale busy indicator — level-trigger the flag, scan before trim (#283) (#284)
* fix(perf): stall fixes round 1 — resolver cache, wall-clock stamps, suspend filtering (#297)
* fix(local): stop the fleet-folder migration clobbering local workspaceRoot (#294)
* fix(log): log pty detach/close at info, not error (#293)

Tag `v0.12.0` after merge to cut the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)