### PR TITLE
chore: release v0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Patch release: perf round from the 2026-08-14/15 dogfood analysis.
- #301 listAllWorkspaces 1s-TTL cache
- #304 docker.ping child span + sync-dispatch discriminator
- #306 event-invalidated caches for the synchronous observability reads
(plus everything else on main since v0.12.0: #302 summarizer prompt fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)