### PR TITLE
[DO NOT MERGE] docs-only probe for #303

### DIFF
--- a/docs/ci-probe.md
+++ b/docs/ci-probe.md
@@ -1,0 +1,4 @@
+# CI probe
+
+Throwaway PR to verify #303: a docs-only change must still report the required
+e2e contexts. This branch is closed without merging.


### PR DESCRIPTION
Throwaway verification PR for #303, based on the #315 branch so it runs the new workflow.

Touches **only** `docs/`, so it reproduces exactly the shape that used to deadlock. Expected: the `e2e run (…)` jobs **skip**, and the required `e2e (playwright)` / `e2e (playwright, windows)` contexts still report **green**.

Will be closed without merging once observed.