### PR TITLE
ci: give the unit suite an aggregator so it can be required (#318)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -62,14 +62,12 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
   # Unit suite (vitest). Until #311, `vitest` appeared nowhere in this workflow:
-  # ~790 tests ran on developer machines only and protected nothing on main. It
-  # sits alongside the e2e jobs on the same `changes` gate.
-  #
-  # NOTE: this job is NOT in the `pass ci` ruleset. If you make it required, give
-  # it the aggregator treatment the e2e contexts get below — a gated job that is
-  # required but skipped by the gate reproduces the #303 deadlock exactly.
-  unit:
-    name: unit (vitest)
+  # ~790 tests ran on developer machines only and protected nothing on main.
+  # Required via the `unit (vitest)` aggregator at the bottom (#318) — this job
+  # is gated, so it can't carry the required name itself without reproducing the
+  # #303 deadlock on docs-only PRs.
+  unit-run:
+    name: unit run (vitest)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -379,6 +377,27 @@ jobs:
   #
   # `changes` is checked explicitly: if IT fails, the run job is skipped, and
   # treating that skip as success would silently green a broken pipeline.
+  unit:
+    name: unit (vitest)
+    needs: [changes, unit-run]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror the unit run outcome
+        shell: bash
+        run: |
+          gate='${{ needs.changes.result }}'
+          run='${{ needs.unit-run.result }}'
+          echo "changes=$gate  unit run=$run"
+          if [ "$gate" != "success" ]; then
+            echo "::error::the changes gate concluded '$gate'"; exit 1
+          fi
+          case "$run" in
+            success) echo "unit suite passed"; exit 0 ;;
+            skipped) echo "no code paths changed — unit suite not required for this PR"; exit 0 ;;
+            *) echo "::error::unit run concluded '$run'"; exit 1 ;;
+          esac
+
   e2e:
     name: e2e (playwright)
     needs: [changes, e2e-linux]


### PR DESCRIPTION
Part 1 of #318 — the workflow half. The ruleset change follows once this is on `main`.

## Why an aggregator rather than just requiring the job

`unit (vitest)` is gated on `changes` like the e2e run jobs. A required check that a gate skips is precisely the #303 deadlock: on a docker/docs-only PR it never reports, the context stays Pending, and `mergeStateStatus` sits at `BLOCKED` forever. Adding it to the ruleset as-is would reintroduce the bug #303 just fixed, for the same class of PR.

So it gets the #315 treatment:

| job | name | runs |
|---|---|---|
| `unit-run` | `unit run (vitest)` | only when code changed |
| `unit` | **`unit (vitest)`** | always — mirrors `unit-run` |

The aggregator passes on `success`, passes on `skipped` (nothing to test), fails on anything else, and fails if the `changes` gate itself failed — so a broken gate can't be laundered into a green via a skipped run.

## Sequencing

The ruleset update is **not** in this PR on purpose. The aggregator must exist on `main` before `unit (vitest)` becomes required, or every docs-only PR blocks the moment it's added. I'll add it to `pass ci` after this merges and confirm the contexts.

## Verification

- This PR touches the workflow → `code=true`, so the aggregator mirrors a real run here.
- A throwaway docs-only probe PR will confirm `unit run (vitest)` skips while `unit (vitest)` reports green — the case that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)