### PR TITLE
[DO NOT MERGE] docs-only probe for #318

### DIFF
--- a/docs/ci-probe-unit.md
+++ b/docs/ci-probe-unit.md
@@ -1,0 +1,4 @@
+# CI probe
+
+Throwaway PR verifying #318: a docs-only change must still report the
+`unit (vitest)` required context. Closed without merging.


### PR DESCRIPTION
Throwaway verification for #318, based on the #319 branch so it runs the new workflow.

Touches only `docs/`. Expected: `unit run (vitest)` **skips** while `unit (vitest)` reports **green**, alongside the same behaviour for the e2e contexts.

Closed without merging once observed.