### PR TITLE
[DO NOT MERGE] final docs-only probe — #318 ruleset verification

### DIFF
--- a/docs/ci-probe-final.md
+++ b/docs/ci-probe-final.md
@@ -1,0 +1,4 @@
+# CI probe
+
+Final verification for #318: with `unit (vitest)` now required, a docs-only PR
+must still reach a mergeable state. Closed without merging.


### PR DESCRIPTION
Docs-only PR against `main`, opened **after** `unit (vitest)` was added to the `pass ci` ruleset.

This is the case #303 was about, now with a third required context. Expected: all three required contexts report green via their aggregators, and `mergeStateStatus` reaches `CLEAN` rather than `BLOCKED`.

Closed without merging.