### PR TITLE
ci: move the whole workflow to node 22, and declare it in package.json

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -74,19 +74,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Node 22, NOT the 20 the other jobs use. vitest loads better-sqlite3 in
-      # process, and better-sqlite3@13 declares `engines: { node: '>=22' }` —
-      # under node 20 its native binding fails to load and takes the whole
-      # vitest worker with it ("Worker exited unexpectedly", which is how this
-      # first showed up: exactly the 17 db/watcher/perf/transcript specs that
-      # open the DB died, the other 90 files passed).
-      #
-      # 22 also lines up with the Node that Electron 43 bundles, i.e. the one
-      # these modules actually run under in the app. The build/e2e jobs stay on
-      # 20 because there node is only the toolchain — the natives are loaded by
-      # Electron's own runtime, not by the runner's node. (npm does warn
-      # EBADENGINE for @electron/rebuild, @electron/get and extract-zip on 20;
-      # worth revisiting the whole workflow's node version separately.)
+      # Node 22 everywhere now (#318 follow-up). This job is why: vitest loads
+      # better-sqlite3 in process, and better-sqlite3@13 declares
+      # `engines: { node: '>=22' }` — under node 20 its native binding failed to
+      # load and took the whole vitest worker with it ("Worker exited
+      # unexpectedly": exactly the 17 db/watcher/perf/transcript specs that open
+      # the DB, while the other 90 files passed).
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -137,7 +130,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # keytar's prebuilt binary dynamically links libsecret at runtime;
@@ -207,7 +200,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # libsecret for keytar (links it at runtime); build-essential/python3 are
@@ -273,7 +266,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # Same Windows install dance as the build job: skip node-ABI native builds,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       # keytar's prebuilt binary dynamically links libsecret at runtime;

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Drag OS files, pasted images, web content, or text fragments onto the window and
 
 ## Getting started
 
-**Prerequisites:** Node 20+ and a reachable Docker daemon (Docker Desktop with WSL2 integration, or native `dockerd`).
+**Prerequisites:** Node 22+ and a reachable Docker daemon (Docker Desktop with WSL2 integration, or native `dockerd`).
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "claude-fleet",
   "version": "0.12.1",
+  "engines": {
+    "node": ">=22"
+  },
   "description": "Desktop app for managing a fleet of Claude Code container instances",
   "main": "out/main/index.cjs",
   "author": "Troy Knapp",


### PR DESCRIPTION
Follow-up to #317/#318.

#317 had to put the unit job on node 22 by itself, because `better-sqlite3@13` declares `engines: { node: ">=22" }` and its native binding aborts the vitest worker under node 20. The rest of the pipeline stayed on 20, where npm was warning `EBADENGINE` for `@electron/rebuild`, `@electron/get` and `extract-zip` — all of which want `>=22.12`.

## Changes

| file | change |
|---|---|
| `.github/workflows/build-app.yml` | 3 remaining `node-version: 20` → `22` (build, both e2e run jobs) |
| `.github/workflows/release.yml` | `node-version: 20` → `22` |
| `package.json` | **adds** `"engines": { "node": ">=22" }` |
| `README.md` | "Node 20+" → "Node 22+" |

Node 22 is also what Electron 43 bundles — the runtime these modules actually load under in the app — and matches the runner image's `node:22-bookworm-slim` base, so the whole project is on one major now.

## The two non-workflow changes are the point

The workflow bump alone would leave the same trap set for the next person:

- **`package.json` had no `engines` field at all**, so node 20 produced a native crash (`Worker exited unexpectedly`, 17 db/watcher/perf specs dying while 90 files passed) instead of an install-time warning. That cost two CI round-trips to diagnose in #317. npm now says it up front.
- **The README said "Node 20+"**, which has been wrong since better-sqlite3 13 landed. A contributor following it hits exactly that crash.

## Verification

Ran the unit job's own recipe locally (`npm ci --ignore-scripts`): install exits 0 with **zero** EBADENGINE warnings, typecheck clean, and the suite is 107 files / 787 passed / 1 skipped.

One thing to flag honestly: on the first post-install run I saw `control.test.ts` fail to load once under load. It passes in isolation (25 tests) and passed 2/2 on full re-runs, and it passes in CI — so it looks like a local resource flake rather than anything from this change, but it's worth knowing it can happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)