### PR TITLE
fix(logging): make the #313 failure mode loud instead of silent (#323)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,7 @@ import { ensureBuiltinLoadouts } from './loadouts.js';
 import { JsonlWatcher } from './jsonlWatcher.js';
 import { PeerStatusWatcher } from './peerStatusWatcher.js';
 import { broadcastSessionStatus } from './sessionStatusBroadcast.js';
-import { listWorkspaceManifests } from './workspaces.js';
+import { listWorkspaceManifests, manifestInvariant } from './workspaces.js';
 import { wslLocalProjectsDir, wslLocalSessionsDir } from './localLauncher.js';
 import { encodeClaudeProjectDir, workspaceClaudeSessionsDir, hostLocalSessionsDir } from './paths.js';
 import { installMainProcessHandlers, getLogPath, setErrorSink, logError } from './errorLog.js';
@@ -222,6 +222,21 @@ if (gotSingleInstanceLock) app.whenReady().then(async () => {
     // per-workspace state dir — register those host project dirs so their
     // (and their subagents') token spend is ingested (#plan-usage).
     for (const m of manifests) {
+      // Sweep for states that should be impossible (#323). writeWorkspaceManifest
+      // catches these as they're written, but a manifest already on disk in a bad
+      // state is never re-written, so it would otherwise stay silent forever —
+      // which is exactly what happened for ~6 days in #313.
+      const violation = manifestInvariant(m);
+      if (violation) {
+        logError({
+          source: 'main',
+          type: 'manifest-invariant',
+          level: 'error',
+          message: `${violation} (found at startup)`,
+          workspaceId: m.id,
+          extra: { workspaceRoot: m.workspaceRoot, launcher: m.launcher, kind: m.kind }
+        });
+      }
       if (m.kind === 'local' && m.workspaceRoot) {
         if (m.launcher?.mode === 'wsl') {
           jsonlWatcher.registerPolledLocalDir(

--- a/src/main/jsonlWatcher.ts
+++ b/src/main/jsonlWatcher.ts
@@ -29,6 +29,27 @@ import { ingestLine } from './db.js';
 import { effectiveForClaudeSession } from './mirrorPolicy.js';
 import { perfSpan } from './perf.js';
 
+/**
+ * Fire-and-forget structured log for watcher lifecycle events (#323).
+ *
+ * `errorLog` imports electron, and this module is loaded directly by unit tests
+ * that don't mock it — so the import is lazy and every failure is swallowed.
+ * Logging about the watcher must never be able to break the watcher.
+ */
+function logWatcherEvent(payload: {
+  type: string;
+  message: string;
+  level?: 'error' | 'warn' | 'info';
+  workspaceId?: string;
+  extra?: Record<string, unknown>;
+}): void {
+  void import('./errorLog.js')
+    .then(({ logError }) => logError({ source: 'main', ...payload }))
+    .catch(() => {
+      /* no logger available (unit tests) — nothing useful to do */
+    });
+}
+
 const PROJECTS_SUBDIR = join('projects', '-workspace');
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -183,14 +204,42 @@ export class JsonlWatcher extends EventEmitter {
   }
 
   /** Register a transcript dir that needs POLLING (no inotify — e.g. a
-   *  \\wsl.localhost share for a wsl-launcher workspace, #253). */
+   *  \\wsl.localhost share for a wsl-launcher workspace, #253).
+   *
+   *  Logs the dir it settles on, and no longer swallows a failed mkdir (#323). */
   registerPolledLocalDir(id: string, dir: string): void {
     if (!this.watcher) return; // same started-gate as registerLocalWorkspace
     if (this.hostDirs.has(dir)) return;
     this.hostDirs.set(dir, id);
     this.watchedDirs.add(dir);
     this.polledDirs.add(dir);
-    try { mkdirSync(dir, { recursive: true }); } catch { /* see registerWorkspace */ }
+    // Record WHICH directory this workspace is polled at (#323). A "shows
+    // nothing in either rail" report is otherwise undiagnosable from logs
+    // alone; with this line you compare it against where claude actually
+    // writes, and the answer is immediate — that is how #313 was found.
+    logWatcherEvent({
+      type: 'watcher-polled-dir',
+      level: 'info',
+      message: `polling ${dir}`,
+      workspaceId: id,
+      extra: { dir }
+    });
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch (err) {
+      // Previously swallowed, and that silence is what let #313 run for ~6
+      // days: this mkdir FAILED over the \\wsl.localhost 9P share, so the app
+      // polled a path that never existed and never said so. It also means a
+      // "does the watch dir exist?" health check proves nothing — we create it
+      // ourselves — which makes the failure to create it the signal worth having.
+      logWatcherEvent({
+        type: 'watcher-dir-mkdir-failed',
+        level: 'warn',
+        message: `could not create the directory to poll: ${dir}`,
+        workspaceId: id,
+        extra: { dir, err: String(err) }
+      });
+    }
     void this.ensurePollWatcher().then((w) => {
       // Skip if stopped or unregistered while chokidar was loading.
       if (w && this.polledDirs.has(dir)) w.add(dir);

--- a/src/main/manifestInvariantLog.test.ts
+++ b/src/main/manifestInvariantLog.test.ts
@@ -1,0 +1,110 @@
+// The invariant DETECTOR is unit-tested in workspacesLauncher.test.ts. This
+// covers the half that actually matters in the wild (#323): that a violating
+// write really does land a line in error.log.
+//
+// Worth testing separately because the logger is imported lazily inside
+// writeWorkspaceManifest — errorLog pulls in electron, and this module is
+// loaded by unit tests that don't mock it — so a broken lazy import would
+// silently log nothing, which is precisely the failure mode being fixed.
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const USER_DATA = mkdtempSync(join(tmpdir(), 'cf-invariant-'));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => USER_DATA, getVersion: () => '0.0.0-test' }
+}));
+
+const { writeWorkspaceManifest } = await import('./workspaces.js');
+
+const LOG = join(USER_DATA, 'error.log');
+const WS = '01INVARIANTTESTWS0000000WS';
+
+const base = {
+  id: WS,
+  name: 'invariant-test',
+  labels: [],
+  workspaceSubdir: '',
+  authMode: 'oauth',
+  env: { plain: {}, secretKeys: [] },
+  mirror: { default: 'on', cleanup: 'preserve' },
+  createdAt: 0,
+  lastUsedAt: 0
+} as unknown as Parameters<typeof writeWorkspaceManifest>[0];
+
+const WSL = {
+  mode: 'wsl' as const,
+  distro: 'Ubuntu-24.04',
+  shell: '/bin/zsh',
+  home: '/home/troy',
+  claudePath: '/home/troy/.local/bin/claude'
+};
+
+function logLines(): Array<Record<string, unknown>> {
+  if (!existsSync(LOG)) return [];
+  return readFileSync(LOG, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+/** The lazy import resolves on a later microtask than the write completes. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 50 && logLines().length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('writeWorkspaceManifest — invariant logging (#323)', () => {
+  beforeEach(() => {
+    rmSync(LOG, { force: true });
+    rmSync(join(USER_DATA, 'state'), { recursive: true, force: true });
+  });
+  afterAll(() => rmSync(USER_DATA, { recursive: true, force: true }));
+
+  it('logs a violating write, with the stack that identifies the caller', async () => {
+    await writeWorkspaceManifest({
+      ...base,
+      kind: 'local',
+      launcher: WSL,
+      workspaceRoot: 'C:\\Users\\troyk\\fleet\\01KZKC42R3NZ00F8DRFYZV3XPP'
+    });
+    await settle();
+
+    const entry = logLines().find((e) => e.type === 'manifest-invariant');
+    expect(entry, 'no manifest-invariant entry was written').toBeTruthy();
+    expect(entry!.level).toBe('error');
+    expect(entry!.workspaceId).toBe(WS);
+    expect(String(entry!.message)).toContain('non-Linux workspaceRoot');
+    // The stack is the whole point — #323 is open because we can see the bad
+    // state on disk and can't tell which code path produced it.
+    const extra = entry!.extra as Record<string, unknown>;
+    expect(String(extra.stack)).toContain('manifest-invariant');
+    expect(extra.workspaceRoot).toBe('C:\\Users\\troyk\\fleet\\01KZKC42R3NZ00F8DRFYZV3XPP');
+  });
+
+  it('still writes the manifest — detection must not block the write', async () => {
+    await writeWorkspaceManifest({
+      ...base,
+      kind: 'local',
+      launcher: WSL,
+      workspaceRoot: 'C:\\Users\\troyk\\fleet\\ws'
+    });
+    const manifest = join(USER_DATA, 'state', WS, 'workspace.json');
+    expect(existsSync(manifest)).toBe(true);
+  });
+
+  it('stays silent for a coherent manifest', async () => {
+    await writeWorkspaceManifest({
+      ...base,
+      kind: 'local',
+      launcher: WSL,
+      workspaceRoot: '/home/troy/proj'
+    });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(logLines().filter((e) => e.type === 'manifest-invariant')).toEqual([]);
+  });
+});

--- a/src/main/workspaces.ts
+++ b/src/main/workspaces.ts
@@ -307,7 +307,60 @@ export async function readWorkspaceManifest(id: string): Promise<WorkspaceSpec |
   }
 }
 
+/**
+ * Manifest states that are supposed to be impossible. Returns a description of
+ * the violation, or null when the spec is coherent. Pure — exported for tests
+ * and for the startup sweep in index.ts.
+ *
+ * Today there is exactly one (#323): a `wsl` launcher with a non-Linux
+ * `workspaceRoot`. Both writers run `normalizeAndValidateWslRoot`, which
+ * rejects exactly that — and yet a live install had one. It cost ~6 days of
+ * silent, total observability loss (#313): claude's in-distro cwd is the
+ * `/mnt/<drive>` translation of that root, while the watcher derived its path
+ * from the stored Windows string, and nothing anywhere said a word.
+ */
+export function manifestInvariant(spec: WorkspaceSpec): string | null {
+  if (
+    spec.kind === 'local' &&
+    spec.launcher?.mode === 'wsl' &&
+    spec.workspaceRoot &&
+    !spec.workspaceRoot.startsWith('/')
+  ) {
+    return `wsl launcher with a non-Linux workspaceRoot: ${spec.workspaceRoot}`;
+  }
+  return null;
+}
+
 export async function writeWorkspaceManifest(spec: WorkspaceSpec): Promise<void> {
+  // Every manifest write funnels through here — create, edit,
+  // touchWorkspaceUsed, migration — which makes it the one place a violation
+  // can't slip past, whichever caller produced it. The stack is the point:
+  // #323 is open precisely because the bad state is visible on disk and we
+  // cannot tell which code path wrote it.
+  const violation = manifestInvariant(spec);
+  if (violation) {
+    try {
+      // Lazily imported: errorLog pulls in electron, and this module is loaded
+      // by unit tests that don't mock it. The happy path never reaches here.
+      const { logError } = await import('./errorLog.js');
+      logError({
+        source: 'main',
+        type: 'manifest-invariant',
+        level: 'error',
+        message: violation,
+        workspaceId: spec.id,
+        extra: {
+          workspaceRoot: spec.workspaceRoot,
+          launcher: spec.launcher,
+          kind: spec.kind,
+          // Who wrote it — the evidence #323 is missing.
+          stack: new Error('manifest-invariant').stack
+        }
+      });
+    } catch {
+      /* logging must never break a manifest write */
+    }
+  }
   // Ensure the state dir exists. Real backends mkdir it during create, but the
   // mock backend doesn't, and edit/migration paths shouldn't assume it's there.
   const manifestPath = workspaceManifestPath(spec.id);

--- a/src/main/workspacesLauncher.test.ts
+++ b/src/main/workspacesLauncher.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeLauncher } from './workspaces.js';
+import { sanitizeLauncher, manifestInvariant } from './workspaces.js';
 
 describe('sanitizeLauncher', () => {
   it('passes a well-formed wsl launcher on win32', () => {
@@ -64,5 +64,77 @@ describe('sanitizeLauncher', () => {
     expect(sanitizeLauncher({ mode: 'native' }, 'linux')).toEqual({ mode: 'native' });
     expect(sanitizeLauncher('zsh', 'linux')).toBeUndefined();
     expect(sanitizeLauncher(undefined, 'linux')).toBeUndefined();
+  });
+});
+
+// #323: a wsl launcher with a Windows workspaceRoot is a state both manifest
+// writers claim to reject — and a live install had one anyway, costing ~6 days
+// of silent, total observability loss (#313) with nothing logged. Until the
+// writer hole is found, this is the detector that makes it loud.
+describe('manifestInvariant — #323', () => {
+  const base = {
+    id: '01TEST000000000000000000WS',
+    name: 'ws',
+    labels: [],
+    workspaceSubdir: '',
+    authMode: 'oauth',
+    env: { plain: {}, secretKeys: [] },
+    mirror: { default: 'on', cleanup: 'preserve' },
+    createdAt: 0,
+    lastUsedAt: 0
+  } as unknown as Parameters<typeof manifestInvariant>[0];
+
+  const wsl = {
+    mode: 'wsl' as const,
+    distro: 'Ubuntu-24.04',
+    shell: '/bin/zsh',
+    home: '/home/troy',
+    claudePath: '/home/troy/.local/bin/claude'
+  };
+
+  it('flags the exact live case that produced #313', () => {
+    const v = manifestInvariant({
+      ...base,
+      kind: 'local',
+      launcher: wsl,
+      workspaceRoot: 'C:\\Users\\troyk\\fleet\\01KZKC42R3NZ00F8DRFYZV3XPP'
+    });
+    expect(v).toContain('non-Linux workspaceRoot');
+    expect(v).toContain('C:\\Users\\troyk\\fleet');
+  });
+
+  it('accepts a wsl workspace with a Linux root (the correct shape)', () => {
+    expect(
+      manifestInvariant({ ...base, kind: 'local', launcher: wsl, workspaceRoot: '/home/troy/proj' })
+    ).toBeNull();
+  });
+
+  // A Windows root is normal and correct for these — the invariant is
+  // specifically about wsl, where wsl.exe rewrites the cwd underneath us.
+  it('does not flag a native local workspace with a Windows root', () => {
+    expect(
+      manifestInvariant({
+        ...base,
+        kind: 'local',
+        launcher: { mode: 'native' },
+        workspaceRoot: 'C:\\Users\\troyk\\fleet\\ws'
+      })
+    ).toBeNull();
+  });
+
+  it('does not flag a local workspace with no launcher at all', () => {
+    expect(
+      manifestInvariant({ ...base, kind: 'local', workspaceRoot: 'C:\\Users\\troyk\\fleet\\ws' })
+    ).toBeNull();
+  });
+
+  it('does not flag a container workspace (its root is always derived)', () => {
+    expect(
+      manifestInvariant({
+        ...base,
+        kind: 'container',
+        workspaceRoot: 'C:\\Users\\troyk\\fleet\\ws'
+      })
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Addresses the logging half of #323.

#313 cost ~6 days of **total** observability loss on a live workspace and produced no log line anywhere. The translation bug itself is fixed (#314), but the silence is what made it expensive to find — and the writer hole that created the bad manifest is still open. These are the signals that would have caught it on day one.

## What's added

1. **`manifestInvariant()`** — a pure detector for manifest states that are supposed to be impossible. Today there's exactly one: a `wsl` launcher with a non-Linux `workspaceRoot`, which both writers claim to reject via `normalizeAndValidateWslRoot`, and which a live install had anyway.

2. **Called from `writeWorkspaceManifest`** — the single funnel every write passes through (create, edit, `touchWorkspaceUsed`, migration), so no caller can slip past it. Logs **with a captured stack**, which is the evidence #323 is missing: the bad state is visible on disk, but not which code path wrote it. Never blocks the write, never throws.

3. **A startup sweep** in `index.ts`, because a manifest already on disk in a bad state is never re-written and would otherwise stay silent forever — exactly what happened here.

4. **`registerPolledLocalDir` stops swallowing its mkdir failure.** This was the single biggest missing signal:

   ```js
   try { mkdirSync(dir, { recursive: true }); } catch { /* … */ }
   ```

   That mkdir genuinely **failed** over the `\\wsl.localhost` 9P share, so the app polled a path that never existed and never said so. It also means a *"does the watch dir exist?"* health check proves nothing — the watcher creates the dir itself — which is what makes the *failure to create it* the signal worth having.

5. **The dir being polled is logged at info.** A "this workspace shows nothing in either rail" report is otherwise undiagnosable from logs alone; with that line you compare it against where claude actually writes, and the answer is immediate. That is literally how #313 was found.

## Deliberately not added

A *"watch dir is empty"* heuristic. A legitimately new workspace is empty too, so it would be noise. The invariant in (1)–(3) is false-positive-free.

## Implementation note

Both new call sites import `errorLog` **lazily** — it pulls in `electron`, and both `workspaces.ts` and `jsonlWatcher.ts` are loaded directly by unit tests that don't mock it. The happy path never reaches the import.

## Tests

- The detector: the exact live case verbatim, plus the native / no-launcher / container cases that must **not** flag.
- Separately, that a violating write **really lands a line in error.log** with the stack. That needs its own test precisely because the import is lazy — a broken logger would otherwise fail silently, which is the failure mode being fixed.

Mutation-verified: always-null detector → 1 failure; dropping the wsl-only condition → 2 failures (it starts flagging native workspaces); breaking the lazy import → 1 failure.

Unit **108 files / 795 passed / 1 skipped**, e2e **111 passed / 2 skipped**, typecheck clean.

## Related

- #323 stays open — this is the detection half; the writer hole that produces the bad manifest is still unexplained.
- #324 (control.test.ts load flake) filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)