### PR TITLE
fix(conpty): attach at the settled size, and stop resizing to the same size (#268)

### DIFF
--- a/src/main/local.ts
+++ b/src/main/local.ts
@@ -208,6 +208,9 @@ const defaultSpawn: SpawnPty = ({ file, args, cwd, cols, rows, env }) => {
   // ConPTY to re-emit a clean frame — the programmatic equivalent of the
   // manual window resize that heals the corruption. POSIX PTYs (macOS/Linux,
   // and the container backend's Linux PTY) don't need this, so Windows-only.
+  // Last size pushed to the pty, seeded from the spawn size (#268).
+  let lastCols = cols;
+  let lastRows = rows;
   const settler =
     process.platform === 'win32'
       ? createConptySettler({
@@ -239,7 +242,20 @@ const defaultSpawn: SpawnPty = ({ file, args, cwd, cols, rows, env }) => {
       return p.pid;
     },
     write: (d) => p.write(d),
+    // Change-aware (#268). A resize to the size the pty already has is not
+    // free on Windows: it arms the ConPTY settler, whose job is to jitter the
+    // winsize so ConPTY re-emits a full frame — so a no-op resize cost three
+    // ConPTY resizes and a redraw of whatever stale content sat in its buffer.
+    // Measured on a live install, 11% of settles were triggered with nothing
+    // having changed. The renderer guards this too; this is the authoritative
+    // one, covering every caller.
+    //
+    // Note the settler's own jitter calls `safeResize` DIRECTLY, not through
+    // here, so a genuine size change still gets its intended re-emit.
     resize: (c, r) => {
+      if (c === lastCols && r === lastRows) return;
+      lastCols = c;
+      lastRows = r;
       safeResize(c, r);
       settler?.schedule();
     },

--- a/src/renderer/src/components/TerminalSession.tsx
+++ b/src/renderer/src/components/TerminalSession.tsx
@@ -287,12 +287,48 @@ export function TerminalSession({
       }
     };
 
+    // Fit repeatedly until the size stops changing, so the PTY is spawned at
+    // the size the pane will actually BE (#268).
+    //
+    // One pre-attach fit isn't enough. At app startup every warm workspace's
+    // pane mounts and attaches at once, before layout has settled, and they all
+    // fit to the same too-small size — measured on a live install, 69% of
+    // sessions spawned at 107x45 while the panes they belonged to settled at
+    // 128x52 / 132x52 / 194x51 / 228x72. A `--resume` session then replays its
+    // entire prior conversation into ConPTY's buffer at that wrong width, and
+    // every later resize makes ConPTY re-emit that stale-width content. That is
+    // the ghosting, and it is why it's worst at startup on resumed sessions.
+    //
+    // Two consecutive frames agreeing is the signal. Capped, so a pane whose
+    // size never settles (an animation, a drag in progress) still attaches
+    // promptly — attaching late is worse than attaching slightly wrong.
+    const SETTLED_FIT_MAX_MS = 500;
+    const nextFrame = (): Promise<void> =>
+      new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    const fitUntilStable = async (): Promise<void> => {
+      safeFit();
+      const deadline = Date.now() + SETTLED_FIT_MAX_MS;
+      let prev = `${term.cols}x${term.rows}`;
+      while (!disposed && Date.now() < deadline) {
+        await nextFrame();
+        if (disposed) return;
+        safeFit();
+        const cur = `${term.cols}x${term.rows}`;
+        if (cur === prev) return; // two frames agree — the pane has settled
+        prev = cur;
+      }
+    };
+
     const linkProviderDisposable = term.registerLinkProvider(multilineLinkProvider(term));
 
     // ptyHandleId is the internal handle returned by main's pty:attach —
     // used to address input/resize/detach. Distinct from the prop
     // `sessionId`, which is the broker's persistent session key.
     let ptyHandleId: string | null = null;
+    // Size last pushed to the pty; seeded from the attach so a redundant
+    // first resize is suppressed too (#268).
+    let lastSentCols = -1;
+    let lastSentRows = -1;
     let unsubData: (() => void) | null = null;
     let unsubEnd: (() => void) | null = null;
     let staleBusyTimer: ReturnType<typeof setInterval> | null = null;
@@ -397,7 +433,9 @@ export function TerminalSession({
     // attach runs synchronously with the default term.cols.
     const initialFitRaf = requestAnimationFrame(async () => {
       if (disposed) return;
-      safeFit();
+      // Settled size, not just "one frame after open" (#268).
+      await fitUntilStable();
+      if (disposed) return;
 
       // Don't attach into a frozen broker. While paused, set up the xterm
       // (so the under-overlay terminal is sized and ready) but skip the
@@ -428,6 +466,8 @@ export function TerminalSession({
         }
         ptyHandleId = sid;
         ptyHandleRef.current = sid;
+        lastSentCols = term.cols;
+        lastSentRows = term.rows;
         // Busy/idle (#283): read the title from xterm's own OSC parser —
         // onTitleChange fires once per complete title no matter how the PTY
         // stream was chunked, which is the framing dependence that used to
@@ -554,11 +594,24 @@ export function TerminalSession({
     const ro = new ResizeObserver(() => {
       safeFit();
       if (ptyHandleId) {
-        try {
-          window.api.pty.resize(ptyHandleId, term.cols, term.rows);
-        } catch {
-          // pty:resize is best-effort — failing to resize doesn't
-          // justify killing the terminal.
+        // Only push a size the pty doesn't already have (#268). The observer
+        // fires on any host layout change — a scrollbar appearing as claude's
+        // output grows, rails mounting, the context bar updating — and most of
+        // those leave cols/rows untouched. Forwarding them anyway was not free:
+        // on Windows every resize also arms the ConPTY settler, whose whole job
+        // is to jitter the winsize and force ConPTY to re-emit a frame. So a
+        // no-op resize cost three ConPTY resizes and a full redraw of whatever
+        // was in its buffer. 11% of settles on a live install were triggered
+        // this way, with nothing having changed.
+        if (term.cols !== lastSentCols || term.rows !== lastSentRows) {
+          lastSentCols = term.cols;
+          lastSentRows = term.rows;
+          try {
+            window.api.pty.resize(ptyHandleId, term.cols, term.rows);
+          } catch {
+            // pty:resize is best-effort — failing to resize doesn't
+            // justify killing the terminal.
+          }
         }
         // A real post-attach size change while still armed ⇒ debounce a
         // single Ctrl+L once resizes settle, then disarm. Fires at most


### PR DESCRIPTION
Two changes for #268, aimed squarely at the case the owner reports as worst: ghosting right after launch, on a **resumed** session, on a machine where the window gets resized often. Full measurements are in the issue ([analysis](https://github.com/ImIOImI/claude-fleet/issues/268#issuecomment-5308944952), [startup case](https://github.com/ImIOImI/claude-fleet/issues/268#issuecomment-5308983249)).

## 1. Attach at a settled size

The pre-attach fit ran exactly one frame after `term.open`, before pane layout had finished. On a live install that put **69% of sessions at a spawn size of 107x45**, while the panes they belonged to settled at 128x52 / 132x52 / 194x51 / 228x72 — `107x45` was the real pane size only 8 times out of 176.

At startup every warm workspace's pane mounts and attaches at once, so they all take that same too-small fit:

```
app-start 22:36:41
  +4.1s  attach 107x45   ← 7 sessions
  +4.4s  settle 107x45
  +66.2s settle 163x45  (spawned 107x45)
```

A `--resume` session then replays its **entire prior conversation** into ConPTY's buffer at that wrong width, and every later resize makes ConPTY re-emit that stale-width content. That's the ghosting, and it's why it's worst at startup on resumed sessions specifically.

`fitUntilStable()` fits until two consecutive frames agree, capped at 500 ms — attaching late is worse than attaching slightly wrong.

## 2. Stop pushing resizes that change nothing

The `ResizeObserver` fires on any host layout change — a scrollbar appearing as claude's output grows, rails mounting, the context bar updating — and most leave cols/rows untouched. Forwarding them anyway wasn't free: on Windows every resize arms the ConPTY settler, whose entire job is to jitter the winsize and force ConPTY to re-emit a frame.

So **a no-op resize cost three ConPTY resizes and a redraw of whatever stale content was in the buffer**. 11% of settles on a live install were triggered this way with nothing having changed.

Guarded in the renderer (avoids the IPC) and in `local.ts`'s `resize` (authoritative, covers every caller). The settler's own jitter calls `safeResize` **directly** rather than through the guarded path, so a genuine size change still gets its intended re-emit.

## How to tell whether it worked

This one doesn't need a native-Windows repro to evaluate — both effects are visible in `error.log`:

- `conpty-settle` `spawned` should stop being `107x45` and start matching the settled size
- consecutive settles at an **identical** size should drop to zero

The ghosting itself still needs a human to confirm.

## Deliberately not included

`pty.clear()` (candidate #3) is held back so the effect of these two can be judged on its own. It remains the best-supported next step if ghosting persists — its documented purpose is exactly *"synchronize state with the backend to avoid conpty possibly reprinting the screen"* — and it is still unused anywhere in the codebase.

## Verification

Unit **108 files / 795 passed / 1 skipped**; e2e **111 passed / 2 skipped**, including the `always-mount` guard that pins attach cols aren't xterm's 80x24 default (the closest existing regression test to this change); typecheck clean.

One unrelated note: a unit run hit the #324 load flake, this time on `mcpServer.test.ts` rather than `control.test.ts`. Two clean re-runs after; I've updated #324 since it shows the flake isn't file-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)