### PR TITLE
chore: release v0.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Version bump for a patch release. Same shape as #307 — `package.json` + `package-lock.json` only.

## What's in v0.12.2 since v0.12.1

**Fixes that can only be verified on a Windows host** (the reason for cutting now):

| | |
|---|---|
| #309 | Windows **local** workspaces never got the fleet MCP at all — the readiness gate checked for a unix socket that Windows never creates, and the bridge was unix-only. Dual-transport now (TCP + per-workspace token). |
| #310 | WSL interop under-detected (missed `WSLInterop-late`, and "registered" vs "enabled"), and the probed result was thrown away rather than gating MCP wiring. |
| #314 | WSL local workspaces ingested **nothing** — the transcript watcher polled an untranslated `workspaceRoot`, so it watched a directory claude never writes to. Zero observability for affected workspaces. |
| #325 | Detection + logging so the #314 class of failure can't run silently again (manifest invariant with a caller stack; the watcher's swallowed mkdir failure now logged). |
| #326 | ConPTY ghosting, partial (#268): attach at a **settled** size instead of a premature `107x45`, and stop pushing resizes that change nothing. |

**Infrastructure** (no runtime effect): #315 required-check deadlock, #317 unit suite in CI, #319 unit suite required, #322 node 22 everywhere.

## Verifying after install

Two of the above are checkable in minutes:

- **#314** — a WSL local workspace should start appearing in the observability and session rails.
- **#326** — before judging the ghosting by eye, check `error.log`: `conpty-settle` `spawned` should stop being `107x45` and match the settled size, and consecutive settles at an identical size should be zero (was 17 of 157).

#268 stays open pending that confirmation; `pty.clear()` (candidate #3) is held in reserve so the effect of #326 can be judged on its own.

## Note

#326 adds up to **500 ms** before a PTY attaches at startup, while pane layout settles. Capped, and only when the fit is still moving — but it's the one behavioural change in this batch worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)