### PR TITLE
chore: release v0.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release to get the #268 repaint fix testable — it can't be evaluated from v0.12.2.

## What's new since v0.12.2

**#328 — repaint after a resize and when a hidden pane returns.** The one change in this release, and the first attempt at #268 that's aimed at the right layer.

The owner's clarification relocated the bug: stray glyphs overlap the text and **don't go away as you scroll**. Buffer content scrolls with the content, so anything that stays put is a cell xterm never repainted — the buffer is right, the paint is stale. And it reproduces in **container** workspaces, which never touch ConPTY, so the issue's founding premise ("containers render fine, therefore ConPTY") is false.

xterm's DOM renderer redraws rows via `term.refresh()`, which was called exactly once — after webfonts load. Resizes got none, nor did a hidden pane becoming visible, despite panes being always-mounted and resized while `visibility: hidden`.

## How to test

The discriminating question is narrow: **do stray glyphs still survive scrolling?**

- gone entirely → #268 resolved
- vanish on scroll but still flash right after a resize → much smaller problem, different fix
- unchanged → the repaint isn't reaching those cells, and the next suspect is which element is actually painting them

Worth reproducing the same way it showed up before: start the app with resumed sessions, then resize the window.

## Also in v0.12.2 (already installed, restated for the release notes)

#309 Windows local MCP · #310 WSL interop · #314 WSL transcript ingestion · #325 invariant/watcher logging · #326 settled attach + resize dedupe.

Both #314 and #325 are confirmed working on the owner's machine: sessions now ingest (this conversation appears in the DB), and the new startup sweep immediately flagged the #323 bad manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)