### PR TITLE
chore: release v0.12.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release so the #330 scrollback-reflow fix (#331) can be verified on Windows.

Contains one change since v0.12.3: **#331** — terminal scrollback is no longer reflowed on resize (`windowsPty` in the shared terminal options), eliminating the stray-fragment corruption (`Re`, `Th`, `So.`) over the transcript. Verification on the packaged build: start with resumed sessions, resize the window, then **scroll up**.

After merge: dispatch the `release` workflow with tag `v0.12.4` to cut the draft release with installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)