### PR TITLE
chore: release v0.12.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release: stall-attribution instrumentation.
- #333 GC pause rows (kind='gc') + ingest-broadcast span — names the unattributed 84% of surviving big stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)