### PR TITLE
chore: release v0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.12.5",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Minor release for the serving-rail feature (#308): always-visible kill button (with an actionable toast on pre-KILLPORT runner images) and port → session chips with click-to-focus.

The runner image republish from #308's merge is what activates the chips — workspaces must be RECREATED on the new image (same recreate also activates #302's summarizer fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)