### PR TITLE
chore: release v0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release: newer-claude cue for wsl-launcher workspaces (#337), fixing workspaces stranded on a stale pinned `claudePath` (#336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)