### PR TITLE
chore: release v0.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release: claude-update decisions survive Saved-tab resume / edit-save (#339, PR #340). Supersedes the unpublished v0.13.1 draft (its toast decisions didn't stick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)