### PR TITLE
chore: release v0.13.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release: the stall sentinel.
- #345 MCP-controlled worker-thread co-stall detector (perf_sentinel_set / perf_status.sentinel) + meta.cpu on stall rows — the starvation-vs-main-loop-block discriminator
- #342 local-command caveat kept out of session titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)