### PR TITLE
chore: release v0.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release: busy indicators work again — `isBusyTitle` now recognizes claude's quadrant-circle title spinner `◐◑` plus legacy braille, with a once-per-session unknown-glyph diagnostic (#343, fixed in #347).

v0.13.3 was cut/published concurrently with #347's CI run and does not contain the fix, so this follows immediately behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)