### PR TITLE
chore: release v0.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release cutting #349 (the #268 width-divergence instrumentation).

## What's in it

- `pty:resize` reports its outcome instead of silently no-op'ing on an unknown handle
- Renderer advances its delivered-size latch **only** on a confirmed resize, with bounded retry — a dropped resize is no longer remembered as delivered and then suppressed forever by the #326 dedupe
- New diagnostics in `error.log`: `width-divergence`, `pty-resize-dropped`, `pty-resize-abandoned`
- `PtyHandle.getSize?` exposes the size the pty actually holds (node-pty only)

## Note

This is **instrumentation-first**. It fixes a real defect in the resize path, but whether that defect is what produces the reported leading-column artifacts is not yet established — the new log lines are what will answer it. See #349 for the full reasoning and what it explicitly does not claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)