### PR TITLE
chore: release v0.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release cutting #352 — the root-cause fix for #268's stray characters.

## What's in it

Reattach replay no longer begins inside an escape sequence. Both backends replay a ring of recent PTY output on reattach, and neither respected escape-sequence boundaries — so once the ring evicted, replay could start mid-sequence and the terminal rendered the tail as ordinary text. A dropped ESC turns `ESC[6n` (cursor-position query) into a literal `[6n` printed into the transcript, permanently.

Fixed in `localSessions.ts` and the broker's `ring.go`, with failing-first tests on both sides.

## Note for verification

Existing corrupted scrollback is **not** repaired — nothing rewrites history. Judge this on newly written output. The real test: run long enough to fill the ring (256 KiB), switch workspaces, then scroll back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)