### PR TITLE
chore: release v0.13.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.6",
+      "version": "0.13.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Patch release cutting #351 and #355 — both diagnostics for #268's terminal artifacts. **Neither changes default behaviour.**

## What's in it

**Per-workspace terminal renderer (#355)** — workspace override → app default → `dom`. Set a local workspace to `canvas` (workspace edit form) or set a fleet-wide default in Settings → Behavior. `canvas`/`webgl` paint the grid as one element, which the DOM renderer's scroll/paint invalidation problem cannot survive. Scoped per workspace because the artifacts are reported on **local** workspaces, and the DOM renderer is otherwise preferable for its per-glyph font fallback.

**PTY capture + replay (#351)** — `CLAUDE_FLEET_CAPTURE_PTY=<dir>` records the exact bytes and resize timeline a terminal received; `node scripts/replay-pty-capture.mjs <file>` reproduces it offline. Inert when unset.

## Status of #268

Still **unconfirmed**. The renderer switch is theory eight; the capture exists so that if it fails we read bytes instead of inventing theory nine. Verify by setting a local workspace to `canvas`, opening a new terminal there, and scrolling — existing tabs keep their renderer, so you can compare side by side in one window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)