### PR TITLE
chore: release v0.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.7",
+      "version": "0.13.8",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Cuts #357. Small release whose main purpose is to make the #268 renderer test **verifiable**.

## What's in it

- **`terminal-renderer-attached`** (info) is logged when canvas/webgl actually attaches; the previously silent resolve failure logs `terminal-renderer-unresolved`. Only failures were logged before, so an empty log couldn't distinguish "canvas attached" from "this code never ran" — which is exactly why the last canvas test was inconclusive.
- The **per-workspace renderer now survives a round trip** to the edit form. Two field-by-field projections dropped it, so the form showed *"Default"* for a workspace that had an override, and saving an unrelated edit silently wiped it.
- Renderer-side `logError` gains an optional `level`, so diagnostics read as lifecycle records rather than errors.

## Why now

Replaying a captured PTY stream from an affected session reproduces the whole conversation **with no artifacts at all** — the bytes are clean, and xterm's buffer and DOM both match. The corruption is introduced at paint time, below everything xterm knows about.

The remaining unknown is which renderer is actually live when that happens. This release answers that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)