### PR TITLE
fix: read terminalRenderer back from config.json (#268)

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -443,3 +443,36 @@ describe('resolveTerminalRenderer', () => {
     expect(await resolveTerminalRenderer(undefined)).toBe('dom');
   });
 });
+
+// #268: the renderer must survive a RESTART, not just an in-process round trip.
+// The original tests set-then-got in one process, where the in-memory cache
+// masked the fact that read() dropped the field on every load from disk.
+describe('terminalRenderer survives a reload from disk', () => {
+  it('is read back from an existing config.json', async () => {
+    await writeFile(configPath(), JSON.stringify({ terminalRenderer: 'canvas' }), 'utf8');
+    _resetConfigCacheForTests();
+    expect(await getTerminalRenderer()).toBe('canvas');
+  });
+
+  it('survives setTerminalRenderer + cache drop (the restart path)', async () => {
+    await setTerminalRenderer('webgl');
+    _resetConfigCacheForTests();
+    expect(await getTerminalRenderer()).toBe('webgl');
+  });
+
+  it('is not erased by writing an unrelated setting', async () => {
+    // write() spreads the parsed config, so a dropped field is destroyed on
+    // the next save of anything else — silent data loss, not just a bad read.
+    await setTerminalRenderer('canvas');
+    _resetConfigCacheForTests();
+    await setHardwareAccelDisabled(true);
+    _resetConfigCacheForTests();
+    expect(await getTerminalRenderer()).toBe('canvas');
+  });
+
+  it('coerces garbage on disk to dom', async () => {
+    await writeFile(configPath(), JSON.stringify({ terminalRenderer: 'opengl' }), 'utf8');
+    _resetConfigCacheForTests();
+    expect(await getTerminalRenderer()).toBe('dom');
+  });
+});

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -158,6 +158,18 @@ async function read(): Promise<AppConfig> {
     cached = {
       fleetRoot: typeof parsed.fleetRoot === 'string' && parsed.fleetRoot ? parsed.fleetRoot : undefined,
       disableHardwareAcceleration: parsed.disableHardwareAcceleration === true,
+      // Read back explicitly: this normalizer is a field-by-field allowlist,
+      // so an omitted key is silently dropped on every load — the value round
+      // -tripped through setTerminalRenderer only because the in-memory cache
+      // held it, and reappeared as 'dom' after a restart. Worse, `write()`
+      // spreads this object, so saving any UNRELATED setting erased it from
+      // disk (#268).
+      terminalRenderer:
+        parsed.terminalRenderer === 'canvas' ||
+        parsed.terminalRenderer === 'webgl' ||
+        parsed.terminalRenderer === 'dom'
+          ? parsed.terminalRenderer
+          : undefined,
       // Persist as-is so an explicit `false` survives a reload; absent ⇒ default
       // on (see getAutoReloadLoadouts).
       autoReloadLoadouts:

--- a/src/main/ptyCapture.test.ts
+++ b/src/main/ptyCapture.test.ts
@@ -47,6 +47,17 @@ describe('ptyCapture (#268 diagnostics)', () => {
     expect(createPtyCapture({ ...base })).toBeNull();
   });
 
+  it('ignores a path that is not absolute on this platform', () => {
+    // A Windows path on POSIX is a legal relative filename with backslashes,
+    // so this would otherwise create `./C:\\Users\\…` wherever the app was
+    // started — which is exactly how capture files ended up inside a git
+    // checkout during the #268 investigation.
+    process.env.CLAUDE_FLEET_CAPTURE_PTY =
+      process.platform === 'win32' ? 'relative\\path' : 'C:\\Users\\Someone\\ptycap';
+    expect(captureDir()).toBeNull();
+    expect(createPtyCapture({ ...base })).toBeNull();
+  });
+
   it('records the spawn geometry in an open event', async () => {
     const cap = createPtyCapture({ ...base, dir })!;
     expect(cap).not.toBeNull();

--- a/src/main/ptyCapture.test.ts
+++ b/src/main/ptyCapture.test.ts
@@ -7,10 +7,16 @@ import { createPtyCapture, captureDir } from './ptyCapture';
 let dir: string;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'ptycap-'));
+  // Clear on the way IN as well as out: "off by default" must assert the
+  // code's default, not the developer's shell. A machine that happens to have
+  // this exported (e.g. mid-investigation) failed this test spuriously.
+  delete process.env.CLAUDE_FLEET_CAPTURE_PTY;
+  delete process.env.CLAUDE_FLEET_CAPTURE_PTY_MAX_MB;
 });
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
   delete process.env.CLAUDE_FLEET_CAPTURE_PTY;
+  delete process.env.CLAUDE_FLEET_CAPTURE_PTY_MAX_MB;
 });
 
 const base = { handleId: 'h1', workspaceId: 'ws1', brokerSessionId: 'bs1', cols: 107, rows: 45 };

--- a/src/main/ptyCapture.ts
+++ b/src/main/ptyCapture.ts
@@ -23,7 +23,7 @@
 // line-oriented and binary-safe.
 
 import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { logError } from './errorLog.js';
 
 /** Per-session cap so a long-running capture can't fill the disk. Override
@@ -52,7 +52,24 @@ export interface PtyCaptureOpts {
 
 export function captureDir(): string | null {
   const d = process.env.CLAUDE_FLEET_CAPTURE_PTY;
-  return d && d.trim() ? d.trim() : null;
+  if (!d || !d.trim()) return null;
+  const dir = d.trim();
+  // Must be absolute FOR THIS PLATFORM. A Windows-style path on POSIX is a
+  // perfectly legal *relative filename* containing backslashes, so mkdir
+  // happily creates `./C:\Users\…` next to the cwd instead of failing —
+  // which is how a stray env var scattered capture files through a git
+  // checkout (and produced a path Windows then refused to check out).
+  if (!isAbsolute(dir)) {
+    logError({
+      source: 'main',
+      type: 'pty-capture-bad-dir',
+      level: 'warn',
+      message: `CLAUDE_FLEET_CAPTURE_PTY must be an absolute path on this platform; ignoring ${JSON.stringify(dir)}`,
+      extra: { dir, platform: process.platform }
+    });
+    return null;
+  }
+  return dir;
 }
 
 function maxBytesFromEnv(): number {


### PR DESCRIPTION
**The canvas test never actually ran.** The app-level renderer setting never survived a restart.

## The bug

`config.ts`'s `read()` rebuilds the parsed config **field by field** and omitted `terminalRenderer`, so it was stripped on every load from disk. Reproduced locally with the owner's exact configuration:

```
CONFIG_ON_DISK  {"terminalRenderer":"canvas"}
config.get()    "dom"
```

Settings was showing `dom` for a `config.json` that plainly said `canvas` — and it was telling the truth about what the app believed.

Worse: `write()` spreads that same stripped object, so saving **any unrelated setting** erased the value from disk. Silent data loss, not just a bad read.

## What this means for #268

The owner set canvas, still saw artifacts, and reasonably concluded canvas doesn't help. It was **never active** — no renderer addon attached, because the resolver kept returning `dom`. Theory eight is untested, not disproven.

The tell was three zeroes in the log where one should have been non-zero: `terminal-renderer-attached: 0`, `unresolved: 0`, `failed: 0` across 17 attaches. Only the `=== 'dom'` early-return is silent.

## Fourth time

This is the **fourth** field-by-field projection in this feature to drop the field — the create path, `fetchAllWorkspaces`' live branch, `workspaceToFormInitial`, and now the config normalizer. Each typechecks fine because the field is optional everywhere.

The existing round-trip tests missed this one because they set and got within a single process, where the in-memory cache held the value. The new tests **drop the cache first** — the restart path that actually failed — and one asserts the value survives an unrelated write.

## Also

Hardens `ptyCapture`'s "off by default" test to clear the env var on the way *in*, not only out. It was asserting the developer's shell rather than the code's default, and failed spuriously on a machine with the capture variable exported (mine, mid-investigation).

## Verification

- ✅ Failing-first: removing the read-back fails 3 of the new tests
- ✅ typecheck, build
- ✅ unit — 911 passed
- ✅ e2e — terminal-renderer green

🤖 Generated with [Claude Code](https://claude.com/claude-code)