### PR TITLE
chore: release v0.13.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Cuts #360 — the fix that makes the terminal-renderer setting actually load.

## Why this matters for #268

`config.ts`'s `read()` rebuilt the parsed config field by field and omitted `terminalRenderer`, so the app-level setting was stripped on every load from disk. Settings displayed `dom` for a `config.json` that said `canvas`, and saving any unrelated setting erased the value.

**So canvas was never running.** The setting was chosen, artifacts persisted, and the reasonable conclusion — that canvas doesn't help — came from a test that never actually ran. This release gives theory eight its first real trial; v0.13.8's `terminal-renderer-attached` line will now report which renderer is live.

## Also

Guards `CLAUDE_FLEET_CAPTURE_PTY` against a path that isn't absolute for the running platform. On POSIX a Windows-style path is a legal relative filename with backslashes, so it silently created a directory next to the cwd instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)