### PR TITLE
chore: release v0.13.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.9",
+      "version": "0.13.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Cuts #362.

## What's in it

**PTY capture is configurable from the UI** — Settings → Behavior → *Capture terminal output*, with a Browse button. Empty turns it off. `CLAUDE_FLEET_CAPTURE_PTY` still overrides it for the e2e suite.

Resolved **per attach** rather than at startup, so a change applies to terminals opened afterwards with no restart — and without quitting the app to dodge the single-instance lock, which is what made the env var painful in practice.

Also hardens the settings modal against an optional config field being absent: reading `capturePty` into state and calling `.trim()` at Save threw when the field was missing, taking every other write in the handler down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)