### PR TITLE
chore: release v0.13.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
**Root-cause fix for #268.** Cuts #373.

`convertEol` was `true`, making a bare LF behave as CRLF. Claude's Ink renderer positions absolutely and relies on LF meaning *"down one row, same column"* — the injected carriage return moved each write to column 0 and stranded the previous frame's leading characters in the first columns. Those are the reported `Th` / `Co` / `Tw` fragments.

The damage happened in the **parser**, before anything was painted, which is why it survived the scrollback-reflow fix, disabling hardware acceleration, and the canvas renderer — and why xterm's buffer and the rendered DOM always agreed with each other.

Found by replaying a recorded session through the app's own terminal options, using the capture harness shipped in v0.13.7. Measured: orphan fragments **10 → 0** on an affected capture, unchanged on a clean one, indentation identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)