### PR TITLE
chore: release v0.13.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.11",
+      "version": "0.13.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Release **v0.13.12** — hopefully the final 0.13 cut before model-compatibility work begins.

Bundles three merged fixes:
- **#372** (closes #371) — session tab dot uses the peer-reconciled busy set, not the raw glyph.
- **#363** — broker kills the whole command subtree behind a serving port (supervised dev servers no longer respawn).
- **#354** — bump pinned `@anthropic-ai/claude-code` in the runner image 2.1.177 → 2.1.238; SPEC §4 pin updated.

Version bump only (`package.json` + `package-lock.json`). After merge, dispatch `release.yml` with tag `v0.13.12` to build the draft installers.

### ⚠️ Host verification required before publishing the draft
- **#354 pin bump** was NOT verified against a built image here (no Docker daemon in-workspace). Per SPEC §4 pin policy, confirm the #65 managed-settings PTY gate still navigates over the broker PTY before publishing.
- **#363 + #354** both change `docker/` / `broker/`, so merging to main auto-triggers a runner-image republish (`publish-runner.yml`). Existing workspaces need a **container recreate** to pick up the new image and the kill-tree fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)