### PR TITLE
fix(broker): KillTree must SIGKILL reparented survivors (follow-up to #363)

### DIFF
--- a/broker/internal/portscan/portscan.go
+++ b/broker/internal/portscan/portscan.go
@@ -204,15 +204,27 @@ func KillTree(port uint16, roots map[int]string, grace time.Duration) error {
 		return fmt.Errorf("no resolvable owner for port %d", port)
 	}
 	root := subtreeRoot(owner, roots, procPpid)
-	signalTree(root, syscall.SIGTERM)
+
+	// Snapshot the subtree once, then track liveness per pid — never by
+	// re-walking from root. A common dev-server shape is a light parent
+	// (npm/sh) over the socket-owning child; SIGTERM fells the parent first
+	// and the child, if it traps SIGTERM (graceful shutdown / "reload"),
+	// reparents to init while still holding the port. A tree re-walk from
+	// root loses that reparented child and would report a false success with
+	// the port still up. The captured set keeps every pid addressable so the
+	// SIGKILL escalation still reaches it. The owner is always in the set (it
+	// is root or a descendant of root).
+	targets := descendants(root)
+	signalPids(targets, syscall.SIGTERM)
 	deadline := time.Now().Add(grace)
 	for time.Now().Before(deadline) {
-		if len(descendants(root)) == 0 {
+		if !anyAlive(targets) {
 			return nil
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	signalTree(root, syscall.SIGKILL)
+	// Escalate to survivors, folding in any late forks still linked to root.
+	signalPids(mergePids(targets, descendants(root)), syscall.SIGKILL)
 	return nil
 }
 
@@ -255,7 +267,7 @@ func descendants(root int) []int {
 		}
 	}
 	// A root with no /proc entry and no children is already gone.
-	if _, alive := procPpid(root); !alive && len(children[root]) == 0 {
+	if _, exists := procPpid(root); !exists && len(children[root]) == 0 {
 		return nil
 	}
 	out := []int{}
@@ -274,14 +286,52 @@ func descendants(root int) []int {
 	return out
 }
 
-// signalTree sends sig to root and all its current descendants. Errors
-// (already-gone processes) are ignored: the caller polls liveness.
-func signalTree(root int, sig syscall.Signal) {
-	for _, pid := range descendants(root) {
-		if proc, err := os.FindProcess(pid); err == nil {
-			_ = proc.Signal(sig)
+// signalPids sends sig to each pid, skipping pid<=1 (init / process-group
+// sentinels). Errors on already-gone pids are ignored: the caller polls
+// liveness. Unlike a tree walk this hits reparented survivors too, because
+// the pids were captured while the subtree was intact.
+func signalPids(pids []int, sig syscall.Signal) {
+	for _, pid := range pids {
+		if pid > 1 {
+			_ = syscall.Kill(pid, sig)
 		}
 	}
+}
+
+// alive reports whether pid still names a process. Signal 0 is delivered to
+// no one but performs the kernel's existence/permission check: nil or EPERM
+// means the pid exists (EPERM = exists but not ours — can't happen for our
+// own children, kept for safety), ESRCH means it is gone. A zombie still
+// "exists" until reaped, which is fine — the escalation SIGKILL is a no-op on
+// it and the real survivor in the set is what we care about.
+func alive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// anyAlive reports whether any pid in the captured set is still running.
+func anyAlive(pids []int) bool {
+	for _, pid := range pids {
+		if alive(pid) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergePids returns the union of two pid slices, preserving first-seen order.
+func mergePids(a, b []int) []int {
+	seen := make(map[int]bool, len(a)+len(b))
+	out := make([]int, 0, len(a)+len(b))
+	for _, group := range [][]int{a, b} {
+		for _, pid := range group {
+			if !seen[pid] {
+				seen[pid] = true
+				out = append(out, pid)
+			}
+		}
+	}
+	return out
 }
 
 // KillOwner terminates the process listening on port. The PID is resolved

--- a/broker/internal/portscan/portscan_test.go
+++ b/broker/internal/portscan/portscan_test.go
@@ -199,6 +199,89 @@ time.sleep(300)`)
 	}
 }
 
+// The realistic dev-server shape: an intermediate parent (npm/sh) that dies
+// promptly on SIGTERM and is reaped by its own parent, and the socket-owning
+// child that traps SIGTERM (a graceful-shutdown / "reload" handler). When the
+// intermediate is reaped mid-kill the child reparents to init and leaves the
+// intermediate's process tree. A liveness/escalation check that re-walks the
+// tree from the resolved root loses that child and reports a false success
+// with the port still held. KillTree must track the captured pid set instead,
+// so the SIGKILL escalation still reaches the reparented child.
+//
+// The test reaps the intermediate itself (a goroutine `Wait`) to stand in for
+// the shell that reaps `npm`, which is what forces the child to reparent.
+func TestKillTree_KillsSigtermIgnoringChildThatReparents(t *testing.T) {
+	if _, err := os.Stat("/proc/net/tcp"); err != nil {
+		t.Skip("no /proc on this host")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	// Child ignores SIGTERM and holds the port open. Only SIGKILL frees it.
+	pyPath := writeTempScript(t, `import socket,sys,signal,time
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+p=int(sys.argv[1])
+s=socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1",p)); s.listen()
+time.sleep(300)`)
+
+	probe, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := uint16(probe.Addr().(*net.TCPAddr).Port)
+	_ = probe.Close()
+
+	// Intermediate backgrounds the listener child, then becomes `sleep` (dies
+	// on SIGTERM). It is a direct child of this test process.
+	inter := exec.Command("sh", "-c",
+		fmt.Sprintf("python3 %s %d & exec sleep 300", pyPath, port))
+	if err := inter.Start(); err != nil {
+		t.Fatalf("start intermediate: %v", err)
+	}
+	// Reap the intermediate the instant it dies, so the SIGTERM'd child
+	// reparents to init during the kill — as a shell reaps npm in the real
+	// process tree. Without this the intermediate would linger as a zombie and
+	// the child would never reparent (the bug wouldn't reproduce).
+	go func() { _, _ = inter.Process.Wait() }()
+
+	if !waitPortListening(port, 5*time.Second) {
+		t.Fatalf("port %d never came up", port)
+	}
+	// Best-effort cleanup: find and kill the (reparented) listener if the test
+	// bails before KillTree does its job.
+	defer func() {
+		for _, d := range mustListen(t) {
+			if d.Port == port && d.Pid > 1 {
+				_ = syscall.Kill(d.Pid, syscall.SIGKILL)
+			}
+		}
+	}()
+
+	// This test process stands in for the session's PTY root; the intermediate
+	// is the command launched under it.
+	roots := map[int]string{os.Getpid(): "sess-test"}
+	if err := KillTree(port, roots, 2*time.Second); err != nil {
+		t.Fatalf("KillTree: %v", err)
+	}
+	// The child ignores SIGTERM, so only a SIGKILL that actually reaches the
+	// reparented pid frees the port. Allow a moment for SIGKILL to land.
+	if !waitPortGone(port, 3*time.Second) {
+		t.Fatalf("port %d still listening — reparented SIGTERM-ignoring child survived KillTree", port)
+	}
+}
+
+// mustListen returns the current listening set or fails the test.
+func mustListen(t *testing.T) []Detail {
+	t.Helper()
+	d, err := Listening()
+	if err != nil {
+		t.Fatalf("Listening: %v", err)
+	}
+	return d
+}
+
 // writeTempScript writes body to a temp file and returns its path.
 func writeTempScript(t *testing.T, body string) string {
 	t.Helper()
@@ -224,6 +307,32 @@ func waitPortListening(port uint16, within time.Duration) bool {
 				if d.Port == port {
 					return true
 				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// waitPortGone polls Listening() until port is absent or the deadline passes.
+// Returns whether it became gone. Unlike asserting on a single scan, this
+// tolerates the brief window where a just-SIGKILL'd listener is still listed.
+func waitPortGone(port uint16, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for {
+		details, err := Listening()
+		if err == nil {
+			listed := false
+			for _, d := range details {
+				if d.Port == port {
+					listed = true
+					break
+				}
+			}
+			if !listed {
+				return true
 			}
 		}
 		if time.Now().After(deadline) {


### PR DESCRIPTION
## Why the ✕ still didn't work

After #363 shipped (v0.13.12) the kill button **still left dev servers running** — and the tell was important: **no error toast**. The renderer toasts on any `{ok:false}`, so no toast means the broker returned **`ok:true`**. `KillTree` thought it succeeded while the port stayed up. That rules out the respawn theory #363 targeted and points at a bug *inside* `KillTree`.

## Root cause

`KillTree` tracked liveness and sent the escalation SIGKILL through `descendants(root)` — **re-walking the process tree** from the resolved root each time. In the common shape:

```
shell (session PTY root) → npm/sh → node  ← owns the socket
```

SIGTERM fells the light parent (`npm`) first. The socket-owning child traps SIGTERM (graceful-shutdown / "reload" — Next.js, many servers do this), and once `npm` is **reaped by the session shell**, the child **reparents to init** and leaves `npm`'s subtree. Now:

- the grace loop's `descendants(root)` comes back empty → `KillTree` returns **success** early, and
- the escalation `signalPids(descendants(root), SIGKILL)` signals a set that **no longer contains the survivor**.

The listener lives on, the port stays up, the row never clears. `ok:true`, no toast — exactly the report.

## Fix

**Snapshot the subtree pid set once**, then:
- track liveness **per pid** via `signal 0` (`alive`/`anyAlive`), and
- escalate SIGKILL to that **captured set** (folding in any late forks still linked to root).

Reparenting can no longer hide a survivor. The owner is always in the captured set (it's root or a descendant), so a SIGTERM-ignoring server is guaranteed to get SIGKILL'd. Replaces the tree-walking `signalTree` with `signalPids`/`anyAlive`/`alive`/`mergePids`.

## Test (TDD, and it actually discriminates this time)

`TestKillTree_KillsSigtermIgnoringChildThatReparents` reaps the intermediate parent via a goroutine `Wait` — standing in for the shell reaping `npm` — so the SIGTERM-ignoring child genuinely **reparents mid-kill**, then asserts the port **becomes gone**.

Verified it discriminates the bug:
- **Old #363 code → FAIL** (reparented child survives, port still listening)
- **New code → PASS**

(My first attempt at this test was bogus — it failed identically on old and new code because the harness never reaped the intermediate, so the child never reparented, plus a transient-death race in the assertion. Both fixed.)

Full broker suite + `go vet` + build green; ran the package 3× for flakiness. The #363 respawn test still passes.

## Spec

No change — SPEC.md §5 already describes "SIGTERM the subtree, then SIGKILL survivors after grace." This makes that actually hold for reparented survivors.

## Activation

Broker-only, in-container → needs a runner-image republish + workspace **recreate** to take effect (same as #363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)