### PR TITLE
chore: release v0.13.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.12",
+      "version": "0.13.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Version bump for the v0.13.13 release — carries #384 (session_costs rollup + debounced summary invalidation, the #382/#383 recompute-storm fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)