### PR TITLE
fix: reveal a wsl workspace's private folder from the Windows app

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1476,9 +1476,12 @@ export function registerIpc(opts: RegisterIpcOpts = { jsonlWatcher: null }): voi
   // '' on success, or an error string. Under WSL `shell.openPath` can't reach a
   // GUI file manager (no xdg-open / no Linux file manager), so route through
   // explorer.exe instead. Neither path rejects — callers get a string.
-  ipcMain.handle('fs:openPath', async (_e, path: string) => {
+  // `distro` (wsl-launcher workspaces) marks the path as living inside that
+  // distro, so the Windows app reveals it via \\wsl.localhost\<distro>\… — a
+  // bare Linux path is not resolvable by Explorer (#387).
+  ipcMain.handle('fs:openPath', async (_e, path: string, distro?: string) => {
     if (typeof path !== 'string' || path.length === 0) return 'No path provided';
-    return openHostPath(path);
+    return openHostPath(path, typeof distro === 'string' && distro.length > 0 ? distro : undefined);
   });
 
   // ── Loadout library (#16-followup) ───────────────────────────────────────

--- a/src/main/openHostPath.test.ts
+++ b/src/main/openHostPath.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// openHostPath.ts imports electron for shell.openPath; the pure path
+// translation under test never touches it.
+vi.mock('electron', () => ({ shell: {} }));
+
+const { hostOpenablePath } = await import('./openHostPath.js');
+
+describe('hostOpenablePath (#387)', () => {
+  it('rewrites a wsl workspace root to the UNC share Explorer can resolve', () => {
+    expect(
+      hostOpenablePath('/home/troy/fleet/local-wsl', {
+        platform: 'win32',
+        distro: 'Ubuntu-24.04'
+      })
+    ).toBe('\\\\wsl.localhost\\Ubuntu-24.04\\home\\troy\\fleet\\local-wsl');
+  });
+
+  it('leaves a Windows host path alone even when a distro is named', () => {
+    expect(
+      hostOpenablePath('C:\\Users\\troy\\claude-shared', {
+        platform: 'win32',
+        distro: 'Ubuntu-24.04'
+      })
+    ).toBe('C:\\Users\\troy\\claude-shared');
+  });
+
+  it('leaves a path alone with no distro — the shared folder is a real host path', () => {
+    expect(hostOpenablePath('/home/troy/fleet', { platform: 'win32' })).toBe('/home/troy/fleet');
+  });
+
+  it('never rewrites off Windows — a Linux/macOS app opens its own paths directly', () => {
+    expect(
+      hostOpenablePath('/home/troy/fleet', { platform: 'linux', distro: 'Ubuntu-24.04' })
+    ).toBe('/home/troy/fleet');
+    expect(
+      hostOpenablePath('/Users/troy/fleet', { platform: 'darwin', distro: 'Ubuntu-24.04' })
+    ).toBe('/Users/troy/fleet');
+  });
+});

--- a/src/main/openHostPath.ts
+++ b/src/main/openHostPath.ts
@@ -2,6 +2,7 @@ import { shell } from 'electron';
 import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { isWslEnvironment } from './wsl.js';
+import { linuxPathToUnc } from './localLauncher.js';
 
 /** Detected once at load: are we running under WSL? */
 export const RUNNING_IN_WSL = ((): boolean => {
@@ -30,7 +31,36 @@ function openPathViaExplorer(path: string): Promise<string> {
   });
 }
 
-/** Reveal a host path in the OS file manager (WSL-aware). Never rejects. */
-export function openHostPath(path: string): Promise<string> {
-  return RUNNING_IN_WSL ? openPathViaExplorer(path) : Promise.resolve(shell.openPath(path));
+/**
+ * Host-openable form of a path (pure — exported for tests).
+ *
+ * The Windows app can hold paths that live *inside* a distro: a wsl-launcher
+ * workspace's `workspaceRoot` is a Linux absolute path (`/home/troy/…`), which
+ * `shell.openPath` cannot resolve — it fails with "Failed to open path" (#387).
+ * Explorer reaches those through the `\\wsl.localhost\<distro>\…` share, so
+ * translate when we know which distro the path belongs to.
+ *
+ * Only rewrites a POSIX-absolute path: host paths (`C:\…`, and every path when
+ * the app itself runs on Linux/macOS) pass through untouched, so the shared
+ * folder — a real host path — is never mangled.
+ */
+export function hostOpenablePath(
+  path: string,
+  opts: { platform: NodeJS.Platform; distro?: string }
+): string {
+  if (opts.platform !== 'win32') return path;
+  if (!opts.distro || !path.startsWith('/')) return path;
+  return linuxPathToUnc(opts.distro, path);
+}
+
+/**
+ * Reveal a host path in the OS file manager (WSL-aware). Never rejects.
+ *
+ * `distro` names the WSL distro a Linux path belongs to (wsl-launcher
+ * workspaces); omit it for ordinary host paths.
+ */
+export function openHostPath(path: string, distro?: string): Promise<string> {
+  if (RUNNING_IN_WSL) return openPathViaExplorer(path);
+  const target = hostOpenablePath(path, { platform: process.platform, distro });
+  return Promise.resolve(shell.openPath(target));
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -364,8 +364,11 @@ const api = {
   fs: {
     isDirectory: (path: string): Promise<boolean> => ipcRenderer.invoke('fs:isDirectory', path),
     mkdirp: (path: string): Promise<void> => ipcRenderer.invoke('fs:mkdirp', path),
-    /** Reveal a host path in the OS file manager. Resolves '' on success, else an error string. */
-    openPath: (path: string): Promise<string> => ipcRenderer.invoke('fs:openPath', path)
+    /** Reveal a host path in the OS file manager. Resolves '' on success, else an error string.
+     *  `distro` names the WSL distro a Linux path lives in (wsl-launcher
+     *  workspaces); omit it for ordinary host paths. */
+    openPath: (path: string, distro?: string): Promise<string> =>
+      ipcRenderer.invoke('fs:openPath', path, distro)
   },
   files: {
     /**

--- a/src/renderer/src/components/ObservabilityPane.tsx
+++ b/src/renderer/src/components/ObservabilityPane.tsx
@@ -479,13 +479,19 @@ function WorkspaceBlock({
   const fullPath = workspaceHostPath(workspace);
   const limits = formatResourceLimits(workspace.resources);
 
-  const openPath = async (path: string) => {
-    const err = await window.api.fs.openPath(path);
+  // A wsl-launcher workspace's root is a Linux path inside the distro; the
+  // Windows app can only reveal it through \\wsl.localhost\<distro>\…, so name
+  // the distro when asking main to open it (#387). The shared folder is a real
+  // host path and passes no distro.
+  const distro = workspace.launcher?.mode === 'wsl' ? workspace.launcher.distro : undefined;
+
+  const openPath = async (path: string, inDistro?: string) => {
+    const err = await window.api.fs.openPath(path, inDistro);
     if (err) {
       void window.api.app.logError({
         type: 'openPath',
         message: `Could not open folder: ${err}`,
-        extra: { path }
+        extra: { path, distro: inDistro }
       });
     }
   };
@@ -497,7 +503,7 @@ function WorkspaceBlock({
         <button
           type="button"
           className="obs-ws-row obs-ws-action"
-          onClick={() => openPath(fullPath)}
+          onClick={() => openPath(fullPath, distro)}
           title={`Open ${fullPath} (private — only this container)`}
         >
           <span className="obs-ws-key">private</span>


### PR DESCRIPTION
## The bug

Clicking the **private** row in the observability rail does nothing for a `wsl`-launcher workspace. Every click writes the same line to `error.log`:

```json
{"source":"renderer","type":"openPath",
 "message":"Could not open folder: Failed to open path",
 "extra":{"path":"/home/troy/fleet/local-wsl"}}
```

## Why

A wsl workspace stores `workspaceRoot` as a Linux absolute path *inside the distro*:

```json
{ "workspaceRoot": "/home/troy/fleet/local-wsl",
  "launcher": { "mode": "wsl", "distro": "Ubuntu-24.04" } }
```

`ObservabilityPane` passes that straight to `fs:openPath` → `openHostPath` → `shell.openPath`. The Electron app runs **natively on Windows** here (it only spawns `claude` into the distro), so Explorer gets a bare `/home/...` path it cannot resolve.

The existing WSL branch doesn't help: `RUNNING_IN_WSL` is `false`, because it detects *fleet itself* running inside a distro — a different deployment from "Windows app, WSL workspace".

## The fix

Translate to the UNC share Explorer can reach, reusing the existing `linuxPathToUnc` from `localLauncher.ts`:

```
/home/troy/fleet/local-wsl  →  \\wsl.localhost\Ubuntu-24.04\home\troy\fleet\local-wsl
```

(byte-identical to what `wslpath -w` returns for that path, and `Test-Path` confirms Windows resolves it)

The rewrite in the new pure `hostOpenablePath` is gated on **win32 + POSIX-absolute path + a known distro**, so nothing else changes shape:

- the **shared** folder is a real host path and passes no distro → untouched
- `C:\…` paths → untouched
- the Linux/macOS app, and fleet-inside-WSL → untouched

The distro comes from the workspace's own `launcher`, so only the private row of a wsl workspace opts in.

## Testing

- New `src/main/openHostPath.test.ts` covers the rewrite and all three pass-through cases.
- Full unit suite: **955 passed / 121 files**.
- `typecheck` clean for this change (two pre-existing `@xterm/addon-{webgl,canvas}` resolution errors in `TerminalSession.tsx` reproduce on an unmodified tree — those packages aren't in this clone's `node_modules`).

Not covered by an automated test: the actual Explorer window opening, which needs a Windows host with a wsl workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHQkNi3sJYTgh9TAcDzA64