### PR TITLE
chore: release v0.13.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-fleet",
-      "version": "0.13.13",
+      "version": "0.13.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-fleet",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
Version bump for **v0.13.14**.

Picks up #387 — clicking the **private** row in the observability rail now opens the folder for `wsl`-launcher workspaces from the Windows app (it previously failed with `Failed to open path`, because a distro-local Linux path was handed straight to `shell.openPath`).

Bumps `package.json` + `package-lock.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHQkNi3sJYTgh9TAcDzA64